### PR TITLE
chore: add turbo generators

### DIFF
--- a/packages/config-typescript/package.json
+++ b/packages/config-typescript/package.json
@@ -2,8 +2,5 @@
   "name": "@workspace/config-typescript",
   "version": "0.0.0",
   "private": true,
-  "license": "PROPRIETARY",
-  "publishConfig": {
-    "access": "public"
-  }
+  "license": "MIT"
 }

--- a/turbo/generators/README.md
+++ b/turbo/generators/README.md
@@ -1,0 +1,37 @@
+# Generators
+
+This repo uses [turbo gen](https://turborepo.com/docs/guides/generating-code) to
+generate new packages.
+
+## Usage
+
+You can run the generator in interactive mode:
+
+```shell
+pnpm turbo gen
+```
+
+### Generating a package
+
+Or you can run pass the parameters and automate the generation:
+
+```shell
+pnpm turbo gen pkg --args base i18n
+#              ^          ^    ^
+#              |          |    |
+#              |          |    + - - the name of the package
+#              |          |
+#              |          + - - the type of package you want to generate
+#              |
+#              + - - the generator you want to invoke
+```
+
+## Adding a new generator
+
+Take these steps to add a new generator:
+
+- copy `turbo/generators/generator-pkg.ts` to
+  `turbo/generators/generator-<name>.ts`
+- add template files in `turbo/generators/templates/<name>`
+- update references from `pkg` to `<name>`
+- update `turbo/generators/config.ts` and register the new generator

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -1,0 +1,6 @@
+import { PlopTypes } from "@turbo/gen";
+import { generatorPkg } from "./generator-pkg";
+
+export default function generator(plop: PlopTypes.NodePlopAPI): void {
+  plop.setGenerator("pkg", generatorPkg);
+}

--- a/turbo/generators/generator-pkg.ts
+++ b/turbo/generators/generator-pkg.ts
@@ -1,0 +1,34 @@
+import { PlopTypes } from '@turbo/gen'
+import { validateName } from './helpers'
+
+const TARGET_DIR = 'packages'
+const TEMPLATE_ROOT = 'templates/pkg'
+
+export const generatorPkg: PlopTypes.PlopGeneratorConfig = {
+  description: `Generate a package in the ${TARGET_DIR} directory`,
+  prompts: [
+    {
+      type: 'list',
+      name: 'type',
+      message: 'What type of package should be created?',
+      choices: ['base', 'react-ui'],
+    },
+    {
+      type: 'input',
+      name: 'name',
+      default: ({ type }) => type,
+      message: 'What is the name of the package?',
+      validate: (input: string) => {
+        return validateName(input)
+      },
+    },
+  ],
+  actions: [
+    {
+      type: 'addMany',
+      destination: `{{turbo.paths.root}}/${TARGET_DIR}/{{ dashCase name }}`,
+      base: `./${TEMPLATE_ROOT}/{{type}}`,
+      templateFiles: `./${TEMPLATE_ROOT}/{{type}}/**/*`,
+    },
+  ],
+}

--- a/turbo/generators/helpers.ts
+++ b/turbo/generators/helpers.ts
@@ -1,0 +1,12 @@
+export function validateName(name: string) {
+  if (name.includes(".")) {
+    return "name cannot include an extension";
+  }
+  if (name.includes(" ")) {
+    return "name cannot include spaces";
+  }
+  if (!name) {
+    return "name is required";
+  }
+  return true;
+}

--- a/turbo/generators/package.json
+++ b/turbo/generators/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/turbo/generators/templates/pkg/base/eslint.config.mjs.hbs
+++ b/turbo/generators/templates/pkg/base/eslint.config.mjs.hbs
@@ -1,0 +1,4 @@
+import { config } from "@workspace/config-eslint/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/turbo/generators/templates/pkg/base/package.json.hbs
+++ b/turbo/generators/templates/pkg/base/package.json.hbs
@@ -1,0 +1,21 @@
+{
+  "name": "@workspace/{{name}}",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "lint": "eslint \"**/{src}/**/*.{ts,mjs}\""
+  },
+  "devDependencies": {
+    "@workspace/config-eslint": "workspace:*",
+    "@workspace/config-typescript": "workspace:*",
+    "@types/node": "^24.6.0",
+    "eslint": "^9.36.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/turbo/generators/templates/pkg/base/src/index.ts.hbs
+++ b/turbo/generators/templates/pkg/base/src/index.ts.hbs
@@ -1,0 +1,1 @@
+export const name = '{{name}}'

--- a/turbo/generators/templates/pkg/base/tsconfig.json.hbs
+++ b/turbo/generators/templates/pkg/base/tsconfig.json.hbs
@@ -1,0 +1,8 @@
+{
+  "extends": "@workspace/config-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/turbo/generators/templates/pkg/react-ui/eslint.config.mjs.hbs
+++ b/turbo/generators/templates/pkg/react-ui/eslint.config.mjs.hbs
@@ -1,0 +1,4 @@
+import { config } from "@workspace/config-eslint/react-internal";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/turbo/generators/templates/pkg/react-ui/package.json.hbs
+++ b/turbo/generators/templates/pkg/react-ui/package.json.hbs
@@ -1,0 +1,26 @@
+{
+  "name": "@workspace/{{name}}",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "exports": {
+    "./*": "./src/*.tsx"
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0"
+  },
+  "devDependencies": {
+    "@workspace/config-eslint": "workspace:*",
+    "@workspace/config-typescript": "workspace:*",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.1.16",
+    "@types/react-dom": "^19.1.9",
+    "eslint": "^9.36.0",
+    "typescript": "^5.9.2"
+  },
+  "dependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  }
+}

--- a/turbo/generators/templates/pkg/react-ui/src/hello.tsx.hbs
+++ b/turbo/generators/templates/pkg/react-ui/src/hello.tsx.hbs
@@ -1,0 +1,3 @@
+export function Hello({ name = '{{name}}', className }: { name?: string; className?: string }) {
+  return <div className={className}>Hello {name}</div>
+}

--- a/turbo/generators/templates/pkg/react-ui/tsconfig.json.hbs
+++ b/turbo/generators/templates/pkg/react-ui/tsconfig.json.hbs
@@ -1,0 +1,8 @@
+{
+  "extends": "@workspace/config-typescript/react-library.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Problem

We need a way to quickly scaffold out new packages in the `packages/` directory in a consistent way.


### Summary of Changes

Use [turbo gen](https://turborepo.com/docs/guides/generating-code) to create new packages.

You can run the generator in interactive mode:

```shell
pnpm turbo gen
```

Or you can run pass the parameters and automate the generation:

```shell
pnpm turbo gen pkg --args basic my-feature
#              ^          ^     ^                           
#              |          |     |
#              |          |     + - - the name of the package
#              |          |    
#              |          + - - the type of package you want to generate                           
#              |             
#              + - - the generator you want to invoke                           
```

