### PR TITLE
feat: add core package

### DIFF
--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@workspace/config-eslint/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@workspace/core",
+  "version": "0.0.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "lint": "eslint \"./**/*.{ts,mjs}\""
+  },
+  "devDependencies": {
+    "@workspace/config-eslint": "workspace:*",
+    "@workspace/config-typescript": "workspace:*",
+    "@types/node": "^24.6.0",
+    "eslint": "^9.36.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/core/src/try-catch.ts
+++ b/packages/core/src/try-catch.ts
@@ -1,0 +1,20 @@
+export type Success<T> = {
+  data: T
+  error: null
+}
+
+export type Failure<E> = {
+  data: null
+  error: E
+}
+
+export type Result<T, E = Error> = Success<T> | Failure<E>
+
+export async function tryCatch<T, E = Error>(promise: Promise<T>): Promise<Result<T, E>> {
+  try {
+    const data = await promise
+    return { data, error: null }
+  } catch (error) {
+    return { data: null, error: error as E }
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@workspace/config-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,24 @@ importers:
         specifier: latest
         version: 5.9.3
 
+  packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.6.0
+      '@workspace/config-eslint':
+        specifier: workspace:*
+        version: link:../config-eslint
+      '@workspace/config-typescript':
+        specifier: workspace:*
+        version: link:../config-typescript
+      eslint:
+        specifier: ^9.36.0
+        version: 9.36.0(jiti@2.5.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+
   packages/features:
     dependencies:
       '@radix-ui/react-slot':


### PR DESCRIPTION
The PR adds the `core` package for exporting helper functions and auxiliary files that are too small to go into their own package, for example this [tryCatch](https://gist.github.com/t3dotgg/a486c4ae66d32bf17c09c73609dacc5b) function.