### PR TITLE
fix: ensure config-vitest package is private

### DIFF
--- a/packages/config-vitest/package.json
+++ b/packages/config-vitest/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@workspace/config-vitest",
   "version": "0.0.0",
+  "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The config-vitest package should not be published to public registries as it's for internal use only