### PR TITLE
chore: make linting stricter

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint \"./**/*.{ts,mjs}\""
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "hono": "^4.9.10"

--- a/apps/extension/entrypoints/content/index.ts
+++ b/apps/extension/entrypoints/content/index.ts
@@ -1,10 +1,10 @@
 import { setup } from '@workspace/wallet-standard'
 
 export default defineContentScript({
-  runAt: 'document_start',
-  world: 'MAIN',
-  matches: ['<all_urls>'],
   main() {
     setup()
   },
+  matches: ['<all_urls>'],
+  runAt: 'document_start',
+  world: 'MAIN',
 })

--- a/apps/extension/entrypoints/popup/main.tsx
+++ b/apps/extension/entrypoints/popup/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+
 import { App } from './app'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -10,7 +10,8 @@
     "compile": "tsc --noEmit",
     "postinstall": "wxt prepare",
     "check-types": "tsc --noEmit",
-    "lint": "eslint \"./**/*.{ts,mjs}\""
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "dependencies": {
     "@workspace/wallet-standard": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,7 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import '@workspace/ui/globals.css'
 import { CoreFeature } from '@workspace/features/core/core-feature.tsx'
+import { StrictMode } from 'react'
+import '@workspace/ui/globals.css'
+import { createRoot } from 'react-dom/client'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 // https://vite.dev/config/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check-types": "turbo run check-types",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
+    "lint:fix": "turbo run lint:fix",
     "prepare": "lefthook install",
     "test": "vitest run",
     "test:watch": "vitest --watch",

--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -3,6 +3,7 @@ import eslintConfigPrettier from 'eslint-config-prettier'
 import onlyWarn from 'eslint-plugin-only-warn'
 import turboPlugin from 'eslint-plugin-turbo'
 import tseslint from 'typescript-eslint'
+import perfectionist from 'eslint-plugin-perfectionist'
 
 /**
  * A shared ESLint configuration for the repository.
@@ -12,7 +13,14 @@ import tseslint from 'typescript-eslint'
 export const config = [
   js.configs.recommended,
   eslintConfigPrettier,
+  perfectionist.configs['recommended-alphabetical'],
   ...tseslint.configs.recommended,
+  {
+    rules: {
+      '@typescript-eslint/consistent-type-definitions': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+    },
+  },
   {
     plugins: {
       turbo: turboPlugin,

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -17,6 +17,7 @@
     "eslint": "catalog:",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-only-warn": "^1.1.0",
+    "eslint-plugin-perfectionist": "^4.15.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^6.1.1",
     "eslint-plugin-turbo": "^2.5.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint \"./**/*.{ts,mjs}\""
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/packages/core/src/try-catch.ts
+++ b/packages/core/src/try-catch.ts
@@ -1,14 +1,14 @@
-export type Success<T> = {
-  data: T
-  error: null
-}
-
-export type Failure<E> = {
+export interface Failure<E> {
   data: null
   error: E
 }
 
-export type Result<T, E = Error> = Success<T> | Failure<E>
+export type Result<T, E = Error> = Failure<E> | Success<T>
+
+export interface Success<T> {
+  data: T
+  error: null
+}
 
 export async function tryCatch<T, E = Error>(promise: Promise<T>): Promise<Result<T, E>> {
   try {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint \"**/*.{ts,mjs}\"",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },

--- a/packages/db/src/create-db.ts
+++ b/packages/db/src/create-db.ts
@@ -1,4 +1,6 @@
-import { Db, DbConfig } from './db'
+import type { DbConfig } from './db';
+
+import { Db } from './db'
 
 export function createDb(config: DbConfig) {
   return new Db(config)

--- a/packages/db/src/db-account-create.ts
+++ b/packages/db/src/db-account-create.ts
@@ -1,16 +1,17 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import type { Db } from './db'
-import { Account } from './entity/account'
 
-export type DbAccountCreateInput = Omit<Account, 'id' | 'createdAt' | 'updatedAt'>
+import type { Db } from './db'
+import type { Account } from './entity/account'
+
+export type DbAccountCreateInput = Omit<Account, 'createdAt' | 'id' | 'updatedAt'>
 
 export async function dbAccountCreate(db: Db, input: DbAccountCreateInput): Promise<string> {
   const now = new Date()
   const { data, error } = await tryCatch(
     db.accounts.add({
       ...input,
-      id: crypto.randomUUID(),
       createdAt: now,
+      id: crypto.randomUUID(),
       updatedAt: now,
     }),
   )

--- a/packages/db/src/db-account-delete.ts
+++ b/packages/db/src/db-account-delete.ts
@@ -1,4 +1,5 @@
 import { tryCatch } from '@workspace/core/try-catch'
+
 import type { Db } from './db'
 
 export async function dbAccountDelete(db: Db, id: string): Promise<void> {

--- a/packages/db/src/db-account-find-many.ts
+++ b/packages/db/src/db-account-find-many.ts
@@ -1,6 +1,7 @@
 import { tryCatch } from '@workspace/core/try-catch'
+
 import type { Db } from './db'
-import { Account } from './entity/account'
+import type { Account } from './entity/account'
 
 export type DbAccountFindManyInput = Partial<Pick<Account, 'id' | 'name'>>
 

--- a/packages/db/src/db-account-find-unique.ts
+++ b/packages/db/src/db-account-find-unique.ts
@@ -1,6 +1,7 @@
 import { tryCatch } from '@workspace/core/try-catch'
+
 import type { Db } from './db'
-import { Account } from './entity/account'
+import type { Account } from './entity/account'
 
 export async function dbAccountFindUnique(db: Db, id: string): Promise<Account | undefined> {
   const { data, error } = await tryCatch(db.accounts.get(id))

--- a/packages/db/src/db-account-update.ts
+++ b/packages/db/src/db-account-update.ts
@@ -1,8 +1,10 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import { type Db } from './db'
-import { Account } from './entity/account'
 
-export type DbAccountUpdateInput = Partial<Omit<Account, 'id' | 'createdAt' | 'updatedAt'>>
+import type { Account } from './entity/account'
+
+import { type Db } from './db'
+
+export type DbAccountUpdateInput = Partial<Omit<Account, 'createdAt' | 'id' | 'updatedAt'>>
 
 export async function dbAccountUpdate(db: Db, id: string, input: DbAccountUpdateInput): Promise<number> {
   const { data, error } = await tryCatch(

--- a/packages/db/src/db-cluster-create.ts
+++ b/packages/db/src/db-cluster-create.ts
@@ -1,16 +1,18 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import { type Db } from './db'
-import { Cluster } from './entity/cluster'
 
-export type DbClusterCreateInput = Omit<Cluster, 'id' | 'createdAt' | 'updatedAt'>
+import type { Cluster } from './entity/cluster'
+
+import { type Db } from './db'
+
+export type DbClusterCreateInput = Omit<Cluster, 'createdAt' | 'id' | 'updatedAt'>
 
 export async function dbClusterCreate(db: Db, input: DbClusterCreateInput): Promise<string> {
   const now = new Date()
   const { data, error } = await tryCatch(
     db.clusters.add({
       ...input,
-      id: crypto.randomUUID(),
       createdAt: now,
+      id: crypto.randomUUID(),
       updatedAt: now,
     }),
   )

--- a/packages/db/src/db-cluster-delete.ts
+++ b/packages/db/src/db-cluster-delete.ts
@@ -1,4 +1,5 @@
 import { tryCatch } from '@workspace/core/try-catch'
+
 import type { Db } from './db'
 
 export async function dbClusterDelete(db: Db, id: string): Promise<void> {

--- a/packages/db/src/db-cluster-find-many.ts
+++ b/packages/db/src/db-cluster-find-many.ts
@@ -1,6 +1,7 @@
 import { tryCatch } from '@workspace/core/try-catch'
+
 import type { Db } from './db'
-import { Cluster } from './entity/cluster'
+import type { Cluster } from './entity/cluster'
 
 export type DbClusterFindManyInput = Partial<Pick<Cluster, 'endpoint' | 'id' | 'name' | 'type'>>
 

--- a/packages/db/src/db-cluster-find-unique.ts
+++ b/packages/db/src/db-cluster-find-unique.ts
@@ -1,6 +1,7 @@
 import { tryCatch } from '@workspace/core/try-catch'
+
 import type { Db } from './db'
-import { Cluster } from './entity/cluster'
+import type { Cluster } from './entity/cluster'
 
 export async function dbClusterFindUnique(db: Db, id: string): Promise<Cluster | undefined> {
   const { data, error } = await tryCatch(db.clusters.get(id))

--- a/packages/db/src/db-cluster-update.ts
+++ b/packages/db/src/db-cluster-update.ts
@@ -1,8 +1,9 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import type { Db } from './db'
-import { Cluster } from './entity/cluster'
 
-export type DbClusterUpdateInput = Partial<Omit<Cluster, 'id' | 'createdAt' | 'updatedAt'>>
+import type { Db } from './db'
+import type { Cluster } from './entity/cluster'
+
+export type DbClusterUpdateInput = Partial<Omit<Cluster, 'createdAt' | 'id' | 'updatedAt'>>
 
 export async function dbClusterUpdate(db: Db, id: string, input: DbClusterUpdateInput): Promise<number> {
   const { data, error } = await tryCatch(

--- a/packages/db/src/db-wallet-create.ts
+++ b/packages/db/src/db-wallet-create.ts
@@ -1,16 +1,17 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import type { Db } from './db'
-import { Wallet } from './entity/wallet'
 
-export type DbWalletCreateInput = Omit<Wallet, 'id' | 'createdAt' | 'updatedAt'>
+import type { Db } from './db'
+import type { Wallet } from './entity/wallet'
+
+export type DbWalletCreateInput = Omit<Wallet, 'createdAt' | 'id' | 'updatedAt'>
 
 export async function dbWalletCreate(db: Db, input: DbWalletCreateInput): Promise<string> {
   const now = new Date()
   const { data, error } = await tryCatch(
     db.wallets.add({
       ...input,
-      id: crypto.randomUUID(),
       createdAt: now,
+      id: crypto.randomUUID(),
       updatedAt: now,
     }),
   )

--- a/packages/db/src/db-wallet-delete.ts
+++ b/packages/db/src/db-wallet-delete.ts
@@ -1,4 +1,5 @@
 import { tryCatch } from '@workspace/core/try-catch'
+
 import type { Db } from './db'
 
 export async function dbWalletDelete(db: Db, id: string): Promise<void> {

--- a/packages/db/src/db-wallet-find-many.ts
+++ b/packages/db/src/db-wallet-find-many.ts
@@ -1,9 +1,10 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import type { Db } from './db'
-import { Wallet } from './entity/wallet'
 
-export type DbWalletFindManyInput = Pick<Wallet, 'accountId'> &
-  Partial<Pick<Wallet, 'id' | 'name' | 'publicKey' | 'type'>>
+import type { Db } from './db'
+import type { Wallet } from './entity/wallet'
+
+export type DbWalletFindManyInput = Partial<Pick<Wallet, 'id' | 'name' | 'publicKey' | 'type'>> &
+  Pick<Wallet, 'accountId'>
 
 export async function dbWalletFindMany(db: Db, input: DbWalletFindManyInput): Promise<Wallet[]> {
   const { data, error } = await tryCatch(db.wallets.where('accountId').equals(input.accountId).toArray())

--- a/packages/db/src/db-wallet-find-unique.ts
+++ b/packages/db/src/db-wallet-find-unique.ts
@@ -1,8 +1,9 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import type { Db } from './db'
-import { Wallet } from './entity/wallet'
 
-export async function dbWalletFindUnique(db: Db, id: string): Promise<Wallet | undefined> {
+import type { Db } from './db'
+import type { Wallet } from './entity/wallet'
+
+export async function dbWalletFindUnique(db: Db, id: string): Promise<undefined | Wallet> {
   const { data, error } = await tryCatch(db.wallets.get(id))
   if (error) {
     console.log(error)

--- a/packages/db/src/db-wallet-update.ts
+++ b/packages/db/src/db-wallet-update.ts
@@ -1,8 +1,9 @@
 import { tryCatch } from '@workspace/core/try-catch'
-import type { Db } from './db'
-import { Wallet } from './entity/wallet'
 
-export type DbWalletUpdateInput = Partial<Omit<Wallet, 'id' | 'createdAt' | 'updatedAt'>>
+import type { Db } from './db'
+import type { Wallet } from './entity/wallet'
+
+export type DbWalletUpdateInput = Partial<Omit<Wallet, 'createdAt' | 'id' | 'updatedAt'>>
 
 export async function dbWalletUpdate(db: Db, id: string, input: DbWalletUpdateInput): Promise<number> {
   const { data, error } = await tryCatch(

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,7 +1,8 @@
 import Dexie, { type Table } from 'dexie'
-import { Account } from './entity/account'
-import { Cluster } from './entity/cluster'
-import { Wallet } from './entity/wallet'
+
+import type { Account } from './entity/account'
+import type { Cluster } from './entity/cluster'
+import type { Wallet } from './entity/wallet'
 
 export interface DbConfig {
   name: string

--- a/packages/db/src/entity/account.ts
+++ b/packages/db/src/entity/account.ts
@@ -1,8 +1,8 @@
 export interface Account {
-  id: string
   createdAt: Date
-  updatedAt: Date
+  id: string
+  mnemonic: string
   name: string
   secret: string
-  mnemonic: string
+  updatedAt: Date
 }

--- a/packages/db/src/entity/cluster.ts
+++ b/packages/db/src/entity/cluster.ts
@@ -1,10 +1,10 @@
-import { ClusterType } from './cluster-type'
+import type { ClusterType } from './cluster-type'
 
 export interface Cluster {
-  id: string
   createdAt: Date
-  updatedAt: Date
-  name: string
   endpoint: string
+  id: string
+  name: string
   type: ClusterType
+  updatedAt: Date
 }

--- a/packages/db/src/entity/wallet.ts
+++ b/packages/db/src/entity/wallet.ts
@@ -1,12 +1,12 @@
-import { WalletType } from './wallet-type'
+import type { WalletType } from './wallet-type'
 
 export interface Wallet {
-  id: string
-  createdAt: Date
-  updatedAt: Date
   accountId: string
+  createdAt: Date
+  id: string
   name: string
   publicKey: string
   secretKey?: string
   type: WalletType
+  updatedAt: Date
 }

--- a/packages/db/test/db-account-create.test.ts
+++ b/packages/db/test/db-account-create.test.ts
@@ -1,8 +1,12 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbAccountCreate, DbAccountCreateInput } from '../src/db-account-create'
+
+import type { DbAccountCreateInput } from '../src/db-account-create';
+
+import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindMany } from '../src/db-account-find-many'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -15,7 +19,7 @@ describe('db-account-create', () => {
     it('should create an account', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbAccountCreateInput = { name: randomName('account'), secret: 'bar', mnemonic: 'baz' }
+      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
 
       // ACT
       await dbAccountCreate(db, input)
@@ -38,7 +42,7 @@ describe('db-account-create', () => {
     it('should throw an error when creating an account fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbAccountCreateInput = { name: 'test', secret: 'bar', mnemonic: 'baz' }
+      const input: DbAccountCreateInput = { mnemonic: 'baz', name: 'test', secret: 'bar' }
       vi.spyOn(db.accounts, 'add').mockImplementationOnce(
         () => Promise.reject(new Error('Test error')) as PromiseExtended<string>,
       )

--- a/packages/db/test/db-account-delete.test.ts
+++ b/packages/db/test/db-account-delete.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbAccountCreate, DbAccountCreateInput } from '../src/db-account-create'
+
+import type { DbAccountCreateInput } from '../src/db-account-create';
+
+import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountDelete } from '../src/db-account-delete'
 import { dbAccountFindUnique } from '../src/db-account-find-unique'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -16,7 +20,7 @@ describe('db-account-delete', () => {
     it('should delete an account', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbAccountCreateInput = { name: randomName('account'), secret: 'bar', mnemonic: 'baz' }
+      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
       const id = await dbAccountCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-account-find-many.test.ts
+++ b/packages/db/test/db-account-find-many.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest } from './test-helpers'
-import { dbAccountCreate, DbAccountCreateInput } from '../src/db-account-create'
+
+import type { DbAccountCreateInput } from '../src/db-account-create';
+import type { Account } from '../src/entity/account'
+
+import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindMany } from '../src/db-account-find-many'
-import { Account } from '../src/entity/account'
+import { createDbTest } from './test-helpers'
 
 const db = createDbTest()
 
@@ -16,9 +20,9 @@ describe('db-account-find-many', () => {
     it('should find many accounts by a partial name', async () => {
       // ARRANGE
       expect.assertions(2)
-      const account1: DbAccountCreateInput = { name: 'Test Account Alpha', secret: 's', mnemonic: 'm' }
-      const account2: DbAccountCreateInput = { name: 'Test Account Beta', secret: 's', mnemonic: 'm' }
-      const account3: DbAccountCreateInput = { name: 'Another One', secret: 's', mnemonic: 'm' }
+      const account1: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Alpha', secret: 's' }
+      const account2: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Beta', secret: 's' }
+      const account3: DbAccountCreateInput = { mnemonic: 'm', name: 'Another One', secret: 's' }
       await dbAccountCreate(db, account1)
       await dbAccountCreate(db, account2)
       await dbAccountCreate(db, account3)
@@ -34,8 +38,8 @@ describe('db-account-find-many', () => {
     it('should find many accounts by id', async () => {
       // ARRANGE
       expect.assertions(2)
-      const account1: DbAccountCreateInput = { name: 'Test Account Alpha', secret: 's', mnemonic: 'm' }
-      const account2: DbAccountCreateInput = { name: 'Test Account Beta', secret: 's', mnemonic: 'm' }
+      const account1: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Alpha', secret: 's' }
+      const account2: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Beta', secret: 's' }
       const id1 = await dbAccountCreate(db, account1)
       await dbAccountCreate(db, account2)
 

--- a/packages/db/test/db-account-find-unique.test.ts
+++ b/packages/db/test/db-account-find-unique.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbAccountCreate, DbAccountCreateInput } from '../src/db-account-create'
+
+import type { DbAccountCreateInput } from '../src/db-account-create';
+import type { Account } from '../src/entity/account'
+
+import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindUnique } from '../src/db-account-find-unique'
-import { Account } from '../src/entity/account'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -16,7 +20,7 @@ describe('db-account-find-unique', () => {
     it('should find a unique account', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbAccountCreateInput = { name: randomName('account'), secret: 'bar', mnemonic: 'baz' }
+      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
       const id = await dbAccountCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-account-update.test.ts
+++ b/packages/db/test/db-account-update.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbAccountCreate, DbAccountCreateInput } from '../src/db-account-create'
+
+import type { DbAccountCreateInput } from '../src/db-account-create';
+
+import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindUnique } from '../src/db-account-find-unique'
 import { dbAccountUpdate } from '../src/db-account-update'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -16,7 +20,7 @@ describe('db-account-update', () => {
     it('should update an account', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbAccountCreateInput = { name: randomName('account'), secret: 'bar', mnemonic: 'baz' }
+      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
       const id = await dbAccountCreate(db, input)
       const newName = randomName('newName')
 

--- a/packages/db/test/db-cluster-create.test.ts
+++ b/packages/db/test/db-cluster-create.test.ts
@@ -1,8 +1,12 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbClusterCreate, DbClusterCreateInput } from '../src/db-cluster-create'
+
+import type { DbClusterCreateInput } from '../src/db-cluster-create';
+
+import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindMany } from '../src/db-cluster-find-many'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -16,8 +20,8 @@ describe('db-cluster-create', () => {
       // ARRANGE
       expect.assertions(1)
       const input: DbClusterCreateInput = {
-        name: randomName('cluster'),
         endpoint: 'http://localhost:8899',
+        name: randomName('cluster'),
         type: 'solana:devnet',
       }
 
@@ -43,8 +47,8 @@ describe('db-cluster-create', () => {
       // ARRANGE
       expect.assertions(1)
       const input: DbClusterCreateInput = {
-        name: 'test',
         endpoint: 'http://localhost:8899',
+        name: 'test',
         type: 'solana:devnet',
       }
       vi.spyOn(db.clusters, 'add').mockImplementationOnce(

--- a/packages/db/test/db-cluster-delete.test.ts
+++ b/packages/db/test/db-cluster-delete.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbClusterCreate, DbClusterCreateInput } from '../src/db-cluster-create'
-import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
+
+import type { DbClusterCreateInput } from '../src/db-cluster-create';
+
+import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterDelete } from '../src/db-cluster-delete'
+import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -17,8 +21,8 @@ describe('db-cluster', () => {
       // ARRANGE
       expect.assertions(1)
       const input: DbClusterCreateInput = {
-        name: randomName('cluster'),
         endpoint: 'http://localhost:8899',
+        name: randomName('cluster'),
         type: 'solana:devnet',
       }
       const id = await dbClusterCreate(db, input)

--- a/packages/db/test/db-cluster-find-many.test.ts
+++ b/packages/db/test/db-cluster-find-many.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest } from './test-helpers'
-import { dbClusterCreate, DbClusterCreateInput } from '../src/db-cluster-create'
+
+import type { DbClusterCreateInput } from '../src/db-cluster-create';
+import type { Cluster } from '../src/entity/cluster'
+
+import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindMany } from '../src/db-cluster-find-many'
-import { Cluster } from '../src/entity/cluster'
+import { createDbTest } from './test-helpers'
 
 const db = createDbTest()
 
@@ -16,9 +20,9 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial name', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { name: 'Test Cluster Alpha', endpoint: 'ep1', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { name: 'Test Cluster Beta', endpoint: 'ep2', type: 'solana:devnet' }
-      const cluster3: DbClusterCreateInput = { name: 'Another One', endpoint: 'ep3', type: 'solana:devnet' }
+      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
+      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:devnet' }
+      const cluster3: DbClusterCreateInput = { endpoint: 'ep3', name: 'Another One', type: 'solana:devnet' }
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
@@ -34,8 +38,8 @@ describe('db-cluster', () => {
     it('should find many clusters by id', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { name: 'Test Cluster Alpha', endpoint: 'ep1', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { name: 'Test Cluster Beta', endpoint: 'ep2', type: 'solana:mainnet' }
+      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
+      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:mainnet' }
       const id1 = await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
 
@@ -50,9 +54,9 @@ describe('db-cluster', () => {
     it('should find many clusters by type', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { name: 'Test Cluster Alpha', endpoint: 'ep1', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { name: 'Test Cluster Beta', endpoint: 'ep2', type: 'solana:mainnet' }
-      const cluster3: DbClusterCreateInput = { name: 'Another One', endpoint: 'ep3', type: 'solana:devnet' }
+      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
+      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:mainnet' }
+      const cluster3: DbClusterCreateInput = { endpoint: 'ep3', name: 'Another One', type: 'solana:devnet' }
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
@@ -69,18 +73,18 @@ describe('db-cluster', () => {
       // ARRANGE
       expect.assertions(2)
       const cluster1: DbClusterCreateInput = {
-        name: 'Test Cluster Alpha',
         endpoint: 'http://test.com',
+        name: 'Test Cluster Alpha',
         type: 'solana:devnet',
       }
       const cluster2: DbClusterCreateInput = {
-        name: 'Test Cluster Beta',
         endpoint: 'http://test.com',
+        name: 'Test Cluster Beta',
         type: 'solana:devnet',
       }
       const cluster3: DbClusterCreateInput = {
-        name: 'Another One',
         endpoint: 'http://another.com',
+        name: 'Another One',
         type: 'solana:devnet',
       }
       await dbClusterCreate(db, cluster1)
@@ -98,9 +102,9 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial name and type', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { name: 'Test Cluster Alpha', endpoint: 'ep1', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { name: 'Test Cluster Beta', endpoint: 'ep2', type: 'solana:mainnet' }
-      const cluster3: DbClusterCreateInput = { name: 'Another One', endpoint: 'ep3', type: 'solana:devnet' }
+      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
+      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:mainnet' }
+      const cluster3: DbClusterCreateInput = { endpoint: 'ep3', name: 'Another One', type: 'solana:devnet' }
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)

--- a/packages/db/test/db-cluster-find-unique.test.ts
+++ b/packages/db/test/db-cluster-find-unique.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbClusterCreate, DbClusterCreateInput } from '../src/db-cluster-create'
+
+import type { DbClusterCreateInput } from '../src/db-cluster-create';
+import type { Cluster } from '../src/entity/cluster'
+
+import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
-import { Cluster } from '../src/entity/cluster'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -17,8 +21,8 @@ describe('db-cluster', () => {
       // ARRANGE
       expect.assertions(2)
       const input: DbClusterCreateInput = {
-        name: randomName('cluster'),
         endpoint: 'http://localhost:8899',
+        name: randomName('cluster'),
         type: 'solana:devnet',
       }
       const id = await dbClusterCreate(db, input)

--- a/packages/db/test/db-cluster-update.test.ts
+++ b/packages/db/test/db-cluster-update.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbClusterCreate, DbClusterCreateInput } from '../src/db-cluster-create'
-import { dbClusterUpdate } from '../src/db-cluster-update'
+
+import type { DbClusterCreateInput } from '../src/db-cluster-create';
+
+import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
+import { dbClusterUpdate } from '../src/db-cluster-update'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -17,8 +21,8 @@ describe('db-cluster', () => {
       // ARRANGE
       expect.assertions(2)
       const input: DbClusterCreateInput = {
-        name: randomName('cluster'),
         endpoint: 'http://localhost:8899',
+        name: randomName('cluster'),
         type: 'solana:devnet',
       }
       const id = await dbClusterCreate(db, input)

--- a/packages/db/test/db-wallet-create.test.ts
+++ b/packages/db/test/db-wallet-create.test.ts
@@ -1,8 +1,12 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbWalletCreate, DbWalletCreateInput } from '../src/db-wallet-create'
+
+import type { DbWalletCreateInput } from '../src/db-wallet-create';
+
+import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindMany } from '../src/db-wallet-find-many'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 

--- a/packages/db/test/db-wallet-delete.test.ts
+++ b/packages/db/test/db-wallet-delete.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbWalletCreate, DbWalletCreateInput } from '../src/db-wallet-create'
+
+import type { DbWalletCreateInput } from '../src/db-wallet-create';
+
+import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletDelete } from '../src/db-wallet-delete'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 

--- a/packages/db/test/db-wallet-find-many.test.ts
+++ b/packages/db/test/db-wallet-find-many.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbWalletCreate, DbWalletCreateInput } from '../src/db-wallet-create'
+
+import type { DbWalletCreateInput } from '../src/db-wallet-create';
+
+import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindMany } from '../src/db-wallet-find-many'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 

--- a/packages/db/test/db-wallet-find-unique.test.ts
+++ b/packages/db/test/db-wallet-find-unique.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbWalletCreate, DbWalletCreateInput } from '../src/db-wallet-create'
+
+import type { DbWalletCreateInput } from '../src/db-wallet-create';
+import type { Wallet } from '../src/entity/wallet'
+
+import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
-import { Wallet } from '../src/entity/wallet'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 
@@ -47,7 +51,7 @@ describe('db-wallet-find-unique', () => {
       expect.assertions(1)
       const id = 'test-id'
       vi.spyOn(db.wallets, 'get').mockImplementationOnce(
-        () => Promise.reject(new Error('Test error')) as PromiseExtended<Wallet | undefined>,
+        () => Promise.reject(new Error('Test error')) as PromiseExtended<undefined | Wallet>,
       )
 
       // ACT & ASSERT

--- a/packages/db/test/db-wallet-update.test.ts
+++ b/packages/db/test/db-wallet-update.test.ts
@@ -1,9 +1,13 @@
 import type { PromiseExtended } from 'dexie'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createDbTest, randomName } from './test-helpers'
-import { dbWalletCreate, DbWalletCreateInput } from '../src/db-wallet-create'
+
+import type { DbWalletCreateInput } from '../src/db-wallet-create';
+
+import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
 import { dbWalletUpdate } from '../src/db-wallet-update'
+import { createDbTest, randomName } from './test-helpers'
 
 const db = createDbTest()
 

--- a/packages/db/test/db.test.ts
+++ b/packages/db/test/db.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { createDbTest } from './test-helpers'
 
 const db = createDbTest()

--- a/packages/db/test/test-helpers.ts
+++ b/packages/db/test/test-helpers.ts
@@ -1,11 +1,13 @@
 import 'fake-indexeddb/auto'
-import { Db } from '../src/db'
-import { createDb } from '../src/create-db'
 
-export function randomName(prefix: string): string {
-  return `${prefix}-${Math.random().toString(36).substring(2, 9)}`
-}
+import type { Db } from '../src/db'
+
+import { createDb } from '../src/create-db'
 
 export function createDbTest(): Db {
   return createDb({ name: 'test' })
+}
+
+export function randomName(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).substring(2, 9)}`
 }

--- a/packages/db/vitest.config.mts
+++ b/packages/db/vitest.config.mts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config'
 import { sharedConfig } from '@workspace/config-vitest'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   ...sharedConfig,

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "lint": "eslint . --max-warnings 0",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },

--- a/packages/features/src/core/core-feature.tsx
+++ b/packages/features/src/core/core-feature.tsx
@@ -1,4 +1,5 @@
 import { HashRouter } from 'react-router'
+
 import { CoreRoutes } from './core-routes.js'
 import { CoreProviders } from './data-access/core-providers.js'
 

--- a/packages/features/src/core/core-routes.tsx
+++ b/packages/features/src/core/core-routes.tsx
@@ -1,5 +1,6 @@
 import { lazy } from 'react'
 import { Navigate, useRoutes } from 'react-router'
+
 import { CoreLayout } from './ui/core-layout.js'
 
 const DevRoutes = lazy(() => import('../dev/dev-routes.js'))
@@ -15,13 +16,13 @@ const links = [
 export function CoreRoutes() {
   return useRoutes([
     {
-      element: <CoreLayout links={links} />,
       children: [
-        { index: true, element: <Navigate replace to="/portfolio" /> },
-        { path: 'portfolio/*', element: <PortfolioRoutes /> },
-        { path: 'dev/*', element: <DevRoutes /> },
-        { path: 'settings/*', element: <SettingsRoutes /> },
+        { element: <Navigate replace to="/portfolio" />, index: true },
+        { element: <PortfolioRoutes />, path: 'portfolio/*' },
+        { element: <DevRoutes />, path: 'dev/*' },
+        { element: <SettingsRoutes />, path: 'settings/*' },
       ],
+      element: <CoreLayout links={links} />,
     },
   ])
 }

--- a/packages/features/src/core/data-access/core-providers.tsx
+++ b/packages/features/src/core/data-access/core-providers.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
 import { SettingsProvider } from '../../settings/data-access/settings-provider.js'
 
 const queryClient = new QueryClient()

--- a/packages/features/src/core/ui/core-layout.tsx
+++ b/packages/features/src/core/ui/core-layout.tsx
@@ -6,7 +6,7 @@ export function CoreLayout({ links }: { links: { label: string; to: string }[] }
       <header className="bg-secondary/50 px-4 py-2">
         <div className="flex items-center gap-2">
           {links.map((link) => (
-            <NavLink key={link.to} className={({ isActive }) => (isActive ? 'font-bold' : '')} to={link.to}>
+            <NavLink className={({ isActive }) => (isActive ? 'font-bold' : '')} key={link.to} to={link.to}>
               {link.label}
             </NavLink>
           ))}

--- a/packages/features/src/portfolio/portfolio-routes.tsx
+++ b/packages/features/src/portfolio/portfolio-routes.tsx
@@ -1,10 +1,11 @@
 import { useRoutes } from 'react-router'
-import { PortfolioFeatureIndex } from './portfolio-feature-index.js'
+
 import { CoreNotFound } from '../core/ui/core-not-found.js'
+import { PortfolioFeatureIndex } from './portfolio-feature-index.js'
 
 export default function PortfolioRoutes() {
   return useRoutes([
-    { index: true, element: <PortfolioFeatureIndex /> },
-    { path: '*', element: <CoreNotFound /> },
+    { element: <PortfolioFeatureIndex />, index: true },
+    { element: <CoreNotFound />, path: '*' },
   ])
 }

--- a/packages/features/src/settings/data-access/settings-group.ts
+++ b/packages/features/src/settings/data-access/settings-group.ts
@@ -1,9 +1,8 @@
-import type { ForwardRefExoticComponent } from 'react'
-import * as react from 'react'
 import type { LucideProps } from 'lucide-react'
-import type { SettingsItem } from './settings-item.js'
+import type { ForwardRefExoticComponent } from 'react'
+import type * as react from 'react'
 
-export type SettingsIcon = ForwardRefExoticComponent<Omit<LucideProps, 'ref'> & react.RefAttributes<SVGSVGElement>>
+import type { SettingsItem } from './settings-item.js'
 
 export interface SettingsGroup {
   description: string
@@ -12,3 +11,5 @@ export interface SettingsGroup {
   items: SettingsItem[]
   name: string
 }
+
+export type SettingsIcon = ForwardRefExoticComponent<Omit<LucideProps, 'ref'> & react.RefAttributes<SVGSVGElement>>

--- a/packages/features/src/settings/data-access/settings-item.ts
+++ b/packages/features/src/settings/data-access/settings-item.ts
@@ -1,8 +1,8 @@
-import { SettingsType } from './settings-type.js'
+import type { SettingsType } from './settings-type.js'
 
 export interface SettingsItem {
+  description: string
   id: string
   name: string
-  description: string
   type: SettingsType
 }

--- a/packages/features/src/settings/data-access/settings-provider.tsx
+++ b/packages/features/src/settings/data-access/settings-provider.tsx
@@ -1,6 +1,8 @@
-import { createContext, type ReactNode, useContext } from 'react'
 import { LucideLock, LucidePaintBucket, LucideSettings } from 'lucide-react'
+import { createContext, type ReactNode, useContext } from 'react'
+
 import type { SettingsGroup } from './settings-group.js'
+
 import { SettingsType } from './settings-type.js'
 
 export const defaultItems: SettingsGroup[] = [

--- a/packages/features/src/settings/data-access/settings-schema.ts
+++ b/packages/features/src/settings/data-access/settings-schema.ts
@@ -1,13 +1,13 @@
 import { Schema } from 'effect'
 
 export const SettingsSchema = Schema.Struct({
+  age: Schema.NumberFromString,
   autoLockEnabled: Schema.BooleanFromString,
   autoLockSeconds: Schema.NumberFromString,
   // TODO: Make this an enum of USD/EUR/etc
   currency: Schema.String,
   // TODO: Make this an enum of EN/ES
   language: Schema.String,
-  age: Schema.NumberFromString,
 })
 
 export type Settings = Schema.Schema.Type<typeof SettingsSchema>

--- a/packages/features/src/settings/data-access/use-settings-detail.tsx
+++ b/packages/features/src/settings/data-access/use-settings-detail.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+
 import { useSettings } from './settings-provider.js'
 
 export function useSettingsDetail({ groupId }: { groupId: string }) {

--- a/packages/features/src/settings/settings-feature-detail.tsx
+++ b/packages/features/src/settings/settings-feature-detail.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router'
+
 import { useSettingsDetail } from './data-access/use-settings-detail.js'
 import { SettingsUiDetailGrid } from './ui/settings-ui-detail-grid.js'
-
 import { SettingsUiGroupCard } from './ui/settings-ui-group-card.js'
 
 export function SettingsFeatureDetail() {

--- a/packages/features/src/settings/settings-feature-index.tsx
+++ b/packages/features/src/settings/settings-feature-index.tsx
@@ -1,5 +1,5 @@
-import { SettingsUiGroupList } from './ui/settings-ui-group-list.js'
 import { useSettings } from './data-access/settings-provider.js'
+import { SettingsUiGroupList } from './ui/settings-ui-group-list.js'
 
 export function SettingsFeatureIndex() {
   const { groups } = useSettings()

--- a/packages/features/src/settings/settings-routes.tsx
+++ b/packages/features/src/settings/settings-routes.tsx
@@ -1,10 +1,11 @@
 import { useRoutes } from 'react-router'
-import { SettingsFeatureIndex } from './settings-feature-index.js'
+
 import { SettingsFeatureDetail } from './settings-feature-detail.js'
+import { SettingsFeatureIndex } from './settings-feature-index.js'
 
 export default function SettingsRoutes() {
   return useRoutes([
-    { index: true, element: <SettingsFeatureIndex /> },
-    { path: ':groupId', element: <SettingsFeatureDetail /> },
+    { element: <SettingsFeatureIndex />, index: true },
+    { element: <SettingsFeatureDetail />, path: ':groupId' },
   ])
 }

--- a/packages/features/src/settings/ui/settings-ui-detail-grid.tsx
+++ b/packages/features/src/settings/ui/settings-ui-detail-grid.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+
 import { useSettings } from '../data-access/settings-provider.js'
 import { SettingsUiGroupList } from './settings-ui-group-list.js'
 

--- a/packages/features/src/settings/ui/settings-ui-group-card.tsx
+++ b/packages/features/src/settings/ui/settings-ui-group-card.tsx
@@ -1,5 +1,7 @@
-import type { SettingsGroup } from '../data-access/settings-group.js'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@workspace/ui/components/card.js'
+
+import type { SettingsGroup } from '../data-access/settings-group.js'
+
 import { SettingsUiItems } from './settings-ui-items.js'
 
 export function SettingsUiGroupCard({ group }: { group: SettingsGroup }) {

--- a/packages/features/src/settings/ui/settings-ui-group-header.tsx
+++ b/packages/features/src/settings/ui/settings-ui-group-header.tsx
@@ -1,4 +1,5 @@
 import type { SettingsGroup } from '../data-access/settings-group.js'
+
 import { SettingsUiGroupHeaderIcon } from './settings-ui-group-header-icon.js'
 import { SettingsUiGroupHeaderTitle } from './settings-ui-group-header-title.js'
 

--- a/packages/features/src/settings/ui/settings-ui-group-item.tsx
+++ b/packages/features/src/settings/ui/settings-ui-group-item.tsx
@@ -1,22 +1,24 @@
-import type { SettingsGroup } from '../data-access/settings-group.js'
-import { SettingsUiGroupHeader } from './settings-ui-group-header.js'
 import { cn } from '@workspace/ui/lib/utils.js'
 import { LucideChevronRight } from 'lucide-react'
 import { NavLink } from 'react-router'
+
+import type { SettingsGroup } from '../data-access/settings-group.js'
+
 import { useSettings } from '../data-access/settings-provider.js'
+import { SettingsUiGroupHeader } from './settings-ui-group-header.js'
 
 export function SettingsUiGroupItem({ group }: { group: SettingsGroup }) {
   const { basePath } = useSettings()
   return (
     <div>
       <NavLink
-        to={`${basePath}/${group.id}`}
         className={({ isActive }) =>
           cn(`p-4 flex justify-between rounded-xl border border-primary/10`, {
             'font-bold text-white': isActive,
             'text-muted-foreground': !isActive,
           })
         }
+        to={`${basePath}/${group.id}`}
       >
         <SettingsUiGroupHeader group={group} />
         <LucideChevronRight />

--- a/packages/features/src/settings/ui/settings-ui-group-list.tsx
+++ b/packages/features/src/settings/ui/settings-ui-group-list.tsx
@@ -1,4 +1,5 @@
 import type { SettingsGroup } from '../data-access/settings-group.js'
+
 import { SettingsUiGroupItem } from './settings-ui-group-item.js'
 
 export function SettingsUiGroupList({ groups }: { groups: SettingsGroup[] }) {
@@ -7,7 +8,7 @@ export function SettingsUiGroupList({ groups }: { groups: SettingsGroup[] }) {
       {groups
         .filter((group) => group.items.length)
         .map((group) => (
-          <SettingsUiGroupItem key={group.id} group={group} />
+          <SettingsUiGroupItem group={group} key={group.id} />
         ))}
     </div>
   )

--- a/packages/features/src/settings/ui/settings-ui-input.tsx
+++ b/packages/features/src/settings/ui/settings-ui-input.tsx
@@ -1,24 +1,23 @@
-import type { SettingsItem } from '../data-access/settings-item.js'
-import { SettingsType } from '../data-access/settings-type.js'
-import { Switch } from '@workspace/ui/components/switch.js'
 import type { ReactNode } from 'react'
-import { Label } from '@workspace/ui/components/label.js'
-import { Input } from '@workspace/ui/components/input.js'
 
-export function SettingsUiInputWrapper({ children }: { children: ReactNode }) {
-  return <div className="flex items-center justify-between gap-4">{children}</div>
-}
+import { Input } from '@workspace/ui/components/input.js'
+import { Label } from '@workspace/ui/components/label.js'
+import { Switch } from '@workspace/ui/components/switch.js'
+
+import type { SettingsItem } from '../data-access/settings-item.js'
+
+import { SettingsType } from '../data-access/settings-type.js'
 
 export function SettingsUiInput({ item }: { item: SettingsItem }) {
   switch (item.type) {
     case SettingsType.Boolean:
       return (
         <SettingsUiInputWrapper>
-          <Label htmlFor={item.id} className="flex flex-col items-start">
+          <Label className="flex flex-col items-start" htmlFor={item.id}>
             <span>{item.name}</span>
             <span className="text-muted-foreground leading-snug font-normal">{item.description}</span>
           </Label>
-          <Switch id={item.id} defaultChecked aria-label={item.name} />
+          <Switch aria-label={item.name} defaultChecked id={item.id} />
         </SettingsUiInputWrapper>
       )
     case SettingsType.Number:
@@ -26,7 +25,7 @@ export function SettingsUiInput({ item }: { item: SettingsItem }) {
         <SettingsUiInputWrapper>
           <div className="grid w-full max-w-sm items-center gap-3">
             <Label htmlFor={item.id}>{item.name}</Label>
-            <Input type="number" id={item.id} placeholder={item.name} />
+            <Input id={item.id} placeholder={item.name} type="number" />
           </div>
           <input type="number" />
         </SettingsUiInputWrapper>
@@ -34,12 +33,16 @@ export function SettingsUiInput({ item }: { item: SettingsItem }) {
     case SettingsType.String:
       return (
         <SettingsUiInputWrapper>
-          <Label htmlFor={item.id} className="flex flex-col items-start">
+          <Label className="flex flex-col items-start" htmlFor={item.id}>
             <span>{item.name}</span>
             <span className="text-muted-foreground leading-snug font-normal">{item.description}</span>
           </Label>
-          <Input type="text" id={item.id} placeholder={item.name} />
+          <Input id={item.id} placeholder={item.name} type="text" />
         </SettingsUiInputWrapper>
       )
   }
+}
+
+export function SettingsUiInputWrapper({ children }: { children: ReactNode }) {
+  return <div className="flex items-center justify-between gap-4">{children}</div>
 }

--- a/packages/features/src/settings/ui/settings-ui-item.tsx
+++ b/packages/features/src/settings/ui/settings-ui-item.tsx
@@ -1,4 +1,5 @@
 import type { SettingsItem } from '../data-access/settings-item.js'
+
 import { SettingsUiInput } from './settings-ui-input.js'
 
 export function SettingsUiItem({ item }: { item: SettingsItem }) {

--- a/packages/features/src/settings/ui/settings-ui-items.tsx
+++ b/packages/features/src/settings/ui/settings-ui-items.tsx
@@ -1,11 +1,12 @@
-import { SettingsUiItem } from './settings-ui-item.js'
 import type { SettingsGroup } from '../data-access/settings-group.js'
+
+import { SettingsUiItem } from './settings-ui-item.js'
 
 export function SettingsUiItems({ group }: { group: SettingsGroup }) {
   return (
     <div className="py-4 flex flex-col gap-4">
       {group.items.map((item) => (
-        <SettingsUiItem key={item.id} item={item} />
+        <SettingsUiItem item={item} key={item.id} />
       ))}
     </div>
   )

--- a/packages/features/vitest.config.mts
+++ b/packages/features/vitest.config.mts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config'
 import { sharedConfig } from '@workspace/config-vitest'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   ...sharedConfig,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,8 @@
     "access": "public"
   },
   "scripts": {
-    "lint": "eslint . --max-warnings 0",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -1,34 +1,45 @@
 'use client'
 
-import * as React from 'react'
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
-import { ChevronDownIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { ChevronDownIcon } from 'lucide-react'
+import * as React from 'react'
 
 function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
   return <AccordionPrimitive.Root data-slot="accordion" {...props} />
 }
 
+function AccordionContent({ children, className, ...props }: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      data-slot="accordion-content"
+      {...props}
+    >
+      <div className={cn('pt-0 pb-4', className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  )
+}
+
 function AccordionItem({ className, ...props }: React.ComponentProps<typeof AccordionPrimitive.Item>) {
   return (
     <AccordionPrimitive.Item
-      data-slot="accordion-item"
       className={cn('border-b last:border-b-0', className)}
+      data-slot="accordion-item"
       {...props}
     />
   )
 }
 
-function AccordionTrigger({ className, children, ...props }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+function AccordionTrigger({ children, className, ...props }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
   return (
     <AccordionPrimitive.Header className="flex">
       <AccordionPrimitive.Trigger
-        data-slot="accordion-trigger"
         className={cn(
           'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
           className,
         )}
+        data-slot="accordion-trigger"
         {...props}
       >
         {children}
@@ -38,16 +49,4 @@ function AccordionTrigger({ className, children, ...props }: React.ComponentProp
   )
 }
 
-function AccordionContent({ className, children, ...props }: React.ComponentProps<typeof AccordionPrimitive.Content>) {
-  return (
-    <AccordionPrimitive.Content
-      data-slot="accordion-content"
-      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
-      {...props}
-    >
-      <div className={cn('pt-0 pb-4', className)}>{children}</div>
-    </AccordionPrimitive.Content>
-  )
-}
-
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger }

--- a/packages/ui/src/components/alert.tsx
+++ b/packages/ui/src/components/alert.tsx
@@ -1,11 +1,13 @@
-import * as React from 'react'
-import { cva, type VariantProps } from 'class-variance-authority'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 const alertVariants = cva(
   'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
   {
+    defaultVariants: {
+      variant: 'default',
+    },
     variants: {
       variant: {
         default: 'bg-card text-card-foreground',
@@ -13,37 +15,34 @@ const alertVariants = cva(
           'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
       },
     },
-    defaultVariants: {
-      variant: 'default',
-    },
   },
 )
 
 function Alert({ className, variant, ...props }: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
-  return <div data-slot="alert" role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
-}
-
-function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="alert-title"
-      className={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
-      {...props}
-    />
-  )
+  return <div className={cn(alertVariants({ variant }), className)} data-slot="alert" role="alert" {...props} />
 }
 
 function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="alert-description"
       className={cn(
         'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
         className,
       )}
+      data-slot="alert-description"
       {...props}
     />
   )
 }
 
-export { Alert, AlertTitle, AlertDescription }
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
+      data-slot="alert-title"
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertDescription, AlertTitle }

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,15 +1,24 @@
 'use client'
 
-import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Avatar({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Root>) {
   return (
     <AvatarPrimitive.Root
-      data-slot="avatar"
       className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-full', className)}
+      data-slot="avatar"
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      className={cn('bg-muted flex size-full items-center justify-center rounded-full', className)}
+      data-slot="avatar-fallback"
       {...props}
     />
   )
@@ -17,18 +26,8 @@ function Avatar({ className, ...props }: React.ComponentProps<typeof AvatarPrimi
 
 function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
   return (
-    <AvatarPrimitive.Image data-slot="avatar-image" className={cn('aspect-square size-full', className)} {...props} />
+    <AvatarPrimitive.Image className={cn('aspect-square size-full', className)} data-slot="avatar-image" {...props} />
   )
 }
 
-function AvatarFallback({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
-  return (
-    <AvatarPrimitive.Fallback
-      data-slot="avatar-fallback"
-      className={cn('bg-muted flex size-full items-center justify-center rounded-full', className)}
-      {...props}
-    />
-  )
-}
-
-export { Avatar, AvatarImage, AvatarFallback }
+export { Avatar, AvatarFallback, AvatarImage }

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -1,36 +1,35 @@
-import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 const badgeVariants = cva(
   'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
   {
+    defaultVariants: {
+      variant: 'default',
+    },
     variants: {
       variant: {
         default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
-        secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
         destructive:
           'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
       },
-    },
-    defaultVariants: {
-      variant: 'default',
     },
   },
 )
 
 function Badge({
+  asChild = false,
   className,
   variant,
-  asChild = false,
   ...props
-}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+}: { asChild?: boolean } & React.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
   const Comp = asChild ? Slot : 'span'
 
-  return <Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+  return <Comp className={cn(badgeVariants({ variant }), className)} data-slot="badge" {...props} />
 }
 
 export { Badge, badgeVariants }

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,50 +1,49 @@
-import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
     variants: {
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        icon: 'size-9',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+      },
       variant: {
         default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
         destructive:
           'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline',
       },
-      size: {
-        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        icon: 'size-9',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
     },
   },
 )
 
 function Button({
-  className,
-  variant,
-  size,
   asChild = false,
+  className,
+  size,
+  variant,
   ...props
-}: React.ComponentProps<'button'> &
-  VariantProps<typeof buttonVariants> & {
+}: {
     asChild?: boolean
-  }) {
+  } &
+  React.ComponentProps<'button'> & VariantProps<typeof buttonVariants>) {
   const Comp = asChild ? Slot : 'button'
 
-  return <Comp data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />
+  return <Comp className={cn(buttonVariants({ className, size, variant }))} data-slot="button" {...props} />
 }
 
 export { Button, buttonVariants }

--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -1,68 +1,47 @@
 'use client'
 
-import * as React from 'react'
-import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
-import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker'
+import type { DayButton} from 'react-day-picker';
 
-import { cn } from '@workspace/ui/lib/utils'
 import { Button, buttonVariants } from '@workspace/ui/components/button'
+import { cn } from '@workspace/ui/lib/utils'
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+import * as React from 'react'
+import { DayPicker, getDefaultClassNames } from 'react-day-picker'
 
 function Calendar({
+  buttonVariant = 'ghost',
+  captionLayout = 'label',
   className,
   classNames,
-  showOutsideDays = true,
-  captionLayout = 'label',
-  buttonVariant = 'ghost',
-  formatters,
   components,
+  formatters,
+  showOutsideDays = true,
   ...props
-}: React.ComponentProps<typeof DayPicker> & {
+}: {
   buttonVariant?: React.ComponentProps<typeof Button>['variant']
-}) {
+} & React.ComponentProps<typeof DayPicker>) {
   const defaultClassNames = getDefaultClassNames()
 
   return (
     <DayPicker
-      showOutsideDays={showOutsideDays}
+      captionLayout={captionLayout}
       className={cn(
         'bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className,
       )}
-      captionLayout={captionLayout}
-      formatters={{
-        formatMonthDropdown: (date) => date.toLocaleString('default', { month: 'short' }),
-        ...formatters,
-      }}
       classNames={{
-        root: cn('w-fit', defaultClassNames.root),
-        months: cn('flex gap-4 flex-col md:flex-row relative', defaultClassNames.months),
-        month: cn('flex flex-col w-full gap-4', defaultClassNames.month),
-        nav: cn('flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between', defaultClassNames.nav),
-        button_previous: cn(
-          buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
-          defaultClassNames.button_previous,
-        ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
           'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
           defaultClassNames.button_next,
         ),
-        month_caption: cn(
-          'flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)',
-          defaultClassNames.month_caption,
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
+          defaultClassNames.button_previous,
         ),
-        dropdowns: cn(
-          'w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5',
-          defaultClassNames.dropdowns,
-        ),
-        dropdown_root: cn(
-          'relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md',
-          defaultClassNames.dropdown_root,
-        ),
-        dropdown: cn('absolute bg-popover inset-0 opacity-0', defaultClassNames.dropdown),
         caption_label: cn(
           'select-none font-medium',
           captionLayout === 'label'
@@ -70,35 +49,49 @@ function Calendar({
             : 'rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5',
           defaultClassNames.caption_label,
         ),
-        table: 'w-full border-collapse',
-        weekdays: cn('flex', defaultClassNames.weekdays),
-        weekday: cn(
-          'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',
-          defaultClassNames.weekday,
-        ),
-        week: cn('flex w-full mt-2', defaultClassNames.week),
-        week_number_header: cn('select-none w-(--cell-size)', defaultClassNames.week_number_header),
-        week_number: cn('text-[0.8rem] select-none text-muted-foreground', defaultClassNames.week_number),
         day: cn(
           'relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none',
           defaultClassNames.day,
         ),
-        range_start: cn('rounded-l-md bg-accent', defaultClassNames.range_start),
-        range_middle: cn('rounded-none', defaultClassNames.range_middle),
+        disabled: cn('text-muted-foreground opacity-50', defaultClassNames.disabled),
+        dropdown: cn('absolute bg-popover inset-0 opacity-0', defaultClassNames.dropdown),
+        dropdown_root: cn(
+          'relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md',
+          defaultClassNames.dropdown_root,
+        ),
+        dropdowns: cn(
+          'w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5',
+          defaultClassNames.dropdowns,
+        ),
+        hidden: cn('invisible', defaultClassNames.hidden),
+        month: cn('flex flex-col w-full gap-4', defaultClassNames.month),
+        month_caption: cn(
+          'flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)',
+          defaultClassNames.month_caption,
+        ),
+        months: cn('flex gap-4 flex-col md:flex-row relative', defaultClassNames.months),
+        nav: cn('flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between', defaultClassNames.nav),
+        outside: cn('text-muted-foreground aria-selected:text-muted-foreground', defaultClassNames.outside),
         range_end: cn('rounded-r-md bg-accent', defaultClassNames.range_end),
+        range_middle: cn('rounded-none', defaultClassNames.range_middle),
+        range_start: cn('rounded-l-md bg-accent', defaultClassNames.range_start),
+        root: cn('w-fit', defaultClassNames.root),
+        table: 'w-full border-collapse',
         today: cn(
           'bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none',
           defaultClassNames.today,
         ),
-        outside: cn('text-muted-foreground aria-selected:text-muted-foreground', defaultClassNames.outside),
-        disabled: cn('text-muted-foreground opacity-50', defaultClassNames.disabled),
-        hidden: cn('invisible', defaultClassNames.hidden),
+        week: cn('flex w-full mt-2', defaultClassNames.week),
+        week_number: cn('text-[0.8rem] select-none text-muted-foreground', defaultClassNames.week_number),
+        week_number_header: cn('select-none w-(--cell-size)', defaultClassNames.week_number_header),
+        weekday: cn(
+          'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',
+          defaultClassNames.weekday,
+        ),
+        weekdays: cn('flex', defaultClassNames.weekdays),
         ...classNames,
       }}
       components={{
-        Root: ({ className, rootRef, ...props }) => {
-          return <div data-slot="calendar" ref={rootRef} className={cn(className)} {...props} />
-        },
         Chevron: ({ className, orientation, ...props }) => {
           if (orientation === 'left') {
             return <ChevronLeftIcon className={cn('size-4', className)} {...props} />
@@ -111,6 +104,9 @@ function Calendar({
           return <ChevronDownIcon className={cn('size-4', className)} {...props} />
         },
         DayButton: CalendarDayButton,
+        Root: ({ className, rootRef, ...props }) => {
+          return <div className={cn(className)} data-slot="calendar" ref={rootRef} {...props} />
+        },
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>
@@ -120,6 +116,11 @@ function Calendar({
         },
         ...components,
       }}
+      formatters={{
+        formatMonthDropdown: (date) => date.toLocaleString('default', { month: 'short' }),
+        ...formatters,
+      }}
+      showOutsideDays={showOutsideDays}
       {...props}
     />
   )
@@ -135,21 +136,21 @@ function CalendarDayButton({ className, day, modifiers, ...props }: React.Compon
 
   return (
     <Button
-      ref={ref}
-      variant="ghost"
-      size="icon"
-      data-day={day.date.toLocaleDateString()}
-      data-selected-single={
-        modifiers.selected && !modifiers.range_start && !modifiers.range_end && !modifiers.range_middle
-      }
-      data-range-start={modifiers.range_start}
-      data-range-end={modifiers.range_end}
-      data-range-middle={modifiers.range_middle}
       className={cn(
         'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70',
         defaultClassNames.day,
         className,
       )}
+      data-day={day.date.toLocaleDateString()}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      data-range-start={modifiers.range_start}
+      data-selected-single={
+        modifiers.selected && !modifiers.range_start && !modifiers.range_end && !modifiers.range_middle
+      }
+      ref={ref}
+      size="icon"
+      variant="ghost"
       {...props}
     />
   )

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -1,54 +1,53 @@
-import * as React from 'react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card"
       className={cn('bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm', className)}
+      data-slot="card"
       {...props}
     />
   )
-}
-
-function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="card-header"
-      className={cn(
-        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
-}
-
-function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="card-action"
       className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      data-slot="card-action"
       {...props}
     />
   )
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
+  return <div className={cn('px-6', className)} data-slot="card-content" {...props} />
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div className={cn('text-muted-foreground text-sm', className)} data-slot="card-description" {...props} />
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
+  return <div className={cn('flex items-center px-6 [.border-t]:pt-6', className)} data-slot="card-footer" {...props} />
 }
 
-export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      data-slot="card-header"
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div className={cn('leading-none font-semibold', className)} data-slot="card-title" {...props} />
+}
+
+export { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }

--- a/packages/ui/src/components/chart.tsx
+++ b/packages/ui/src/components/chart.tsx
@@ -1,25 +1,55 @@
 'use client'
 
+import { cn } from '@workspace/ui/lib/utils'
 import * as React from 'react'
 import * as RechartsPrimitive from 'recharts'
 
-import { cn } from '@workspace/ui/lib/utils'
-
 // Format: { THEME_NAME: CSS_SELECTOR }
-const THEMES = { light: '', dark: '.dark' } as const
+const THEMES = { dark: '.dark', light: '' } as const
 
 export type ChartConfig = {
-  [k in string]: {
-    label?: React.ReactNode
+  [k in string]: ({ color?: never; theme: Record<keyof typeof THEMES, string> } | { color?: string; theme?: never }) & {
     icon?: React.ComponentType
-  } & ({ color?: string; theme?: never } | { color?: never; theme: Record<keyof typeof THEMES, string> })
+    label?: React.ReactNode
+  }
 }
 
-type ChartContextProps = {
+interface ChartContextProps {
   config: ChartConfig
 }
 
 const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function ChartContainer({
+  children,
+  className,
+  config,
+  id,
+  ...props
+}: {
+  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>['children']
+  config: ChartConfig
+} & React.ComponentProps<'div'>) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className,
+        )}
+        data-chart={chartId}
+        data-slot="chart"
+        {...props}
+      >
+        <ChartStyle config={config} id={chartId} />
+        <RechartsPrimitive.ResponsiveContainer>{children}</RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+}
 
 function useChart() {
   const context = React.useContext(ChartContext)
@@ -31,38 +61,7 @@ function useChart() {
   return context
 }
 
-function ChartContainer({
-  id,
-  className,
-  children,
-  config,
-  ...props
-}: React.ComponentProps<'div'> & {
-  config: ChartConfig
-  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>['children']
-}) {
-  const uniqueId = React.useId()
-  const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`
-
-  return (
-    <ChartContext.Provider value={{ config }}>
-      <div
-        data-slot="chart"
-        data-chart={chartId}
-        className={cn(
-          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
-          className,
-        )}
-        {...props}
-      >
-        <ChartStyle id={chartId} config={config} />
-        <RechartsPrimitive.ResponsiveContainer>{children}</RechartsPrimitive.ResponsiveContainer>
-      </div>
-    </ChartContext.Provider>
-  )
-}
-
-const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+const ChartStyle = ({ config, id }: { config: ChartConfig; id: string; }) => {
   const colorConfig = Object.entries(config).filter(([, config]) => config.theme || config.color)
 
   if (!colorConfig.length) {
@@ -95,26 +94,26 @@ const ChartTooltip = RechartsPrimitive.Tooltip
 
 function ChartTooltipContent({
   active,
-  payload,
   className,
-  indicator = 'dot',
-  hideLabel = false,
-  hideIndicator = false,
-  label,
-  labelFormatter,
-  labelClassName,
-  formatter,
   color,
-  nameKey,
+  formatter,
+  hideIndicator = false,
+  hideLabel = false,
+  indicator = 'dot',
+  label,
+  labelClassName,
+  labelFormatter,
   labelKey,
-}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-  React.ComponentProps<'div'> & {
-    hideLabel?: boolean
+  nameKey,
+  payload,
+}: {
     hideIndicator?: boolean
-    indicator?: 'line' | 'dot' | 'dashed'
-    nameKey?: string
+    hideLabel?: boolean
+    indicator?: 'dashed' | 'dot' | 'line'
     labelKey?: string
-  }) {
+    nameKey?: string
+  } &
+  React.ComponentProps<'div'> & React.ComponentProps<typeof RechartsPrimitive.Tooltip>) {
   const { config } = useChart()
 
   const tooltipLabel = React.useMemo(() => {
@@ -163,11 +162,11 @@ function ChartTooltipContent({
 
             return (
               <div
-                key={item.dataKey}
                 className={cn(
                   '[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5',
                   indicator === 'dot' && 'items-center',
                 )}
+                key={item.dataKey}
               >
                 {formatter && item?.value !== undefined && item.name ? (
                   formatter(item.value, item.name, item, index, item.payload)
@@ -180,9 +179,9 @@ function ChartTooltipContent({
                         <div
                           className={cn('shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)', {
                             'h-2.5 w-2.5': indicator === 'dot',
-                            'w-1': indicator === 'line',
-                            'w-0 border-[1.5px] border-dashed bg-transparent': indicator === 'dashed',
                             'my-0.5': nestLabel && indicator === 'dashed',
+                            'w-0 border-[1.5px] border-dashed bg-transparent': indicator === 'dashed',
+                            'w-1': indicator === 'line',
                           })}
                           style={
                             {
@@ -224,14 +223,14 @@ const ChartLegend = RechartsPrimitive.Legend
 function ChartLegendContent({
   className,
   hideIcon = false,
+  nameKey,
   payload,
   verticalAlign = 'bottom',
-  nameKey,
-}: React.ComponentProps<'div'> &
-  Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
+}: {
     hideIcon?: boolean
     nameKey?: string
-  }) {
+  } &
+  Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & React.ComponentProps<'div'>) {
   const { config } = useChart()
 
   if (!payload?.length) {
@@ -248,8 +247,8 @@ function ChartLegendContent({
 
           return (
             <div
-              key={item.value}
               className={cn('[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3')}
+              key={item.value}
             >
               {itemConfig?.icon && !hideIcon ? (
                 <itemConfig.icon />
@@ -295,4 +294,4 @@ function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key:
   return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config]
 }
 
-export { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent, ChartStyle }
+export { ChartContainer, ChartLegend, ChartLegendContent, ChartStyle, ChartTooltip, ChartTooltipContent }

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,24 +1,23 @@
 'use client'
 
-import * as React from 'react'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { CheckIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { CheckIcon } from 'lucide-react'
+import * as React from 'react'
 
 function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (
     <CheckboxPrimitive.Root
-      data-slot="checkbox"
       className={cn(
         'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
+      data-slot="checkbox"
       {...props}
     >
       <CheckboxPrimitive.Indicator
-        data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current transition-none"
+        data-slot="checkbox-indicator"
       >
         <CheckIcon className="size-3.5" />
       </CheckboxPrimitive.Indicator>

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -1,38 +1,37 @@
 'use client'
 
-import * as React from 'react'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@workspace/ui/components/dialog'
+import { cn } from '@workspace/ui/lib/utils'
 import { Command as CommandPrimitive } from 'cmdk'
 import { SearchIcon } from 'lucide-react'
-
-import { cn } from '@workspace/ui/lib/utils'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@workspace/ui/components/dialog'
+import * as React from 'react'
 
 function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
   return (
     <CommandPrimitive
-      data-slot="command"
       className={cn(
         'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
         className,
       )}
+      data-slot="command"
       {...props}
     />
   )
 }
 
 function CommandDialog({
-  title = 'Command Palette',
-  description = 'Search for a command to run...',
   children,
   className,
+  description = 'Search for a command to run...',
   showCloseButton = true,
+  title = 'Command Palette',
   ...props
-}: React.ComponentProps<typeof Dialog> & {
-  title?: string
-  description?: string
+}: {
   className?: string
+  description?: string
   showCloseButton?: boolean
-}) {
+  title?: string
+} & React.ComponentProps<typeof Dialog>) {
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
@@ -48,44 +47,57 @@ function CommandDialog({
   )
 }
 
+function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return <CommandPrimitive.Empty className="py-6 text-center text-sm" data-slot="command-empty" {...props} />
+}
+
+function CommandGroup({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      className={cn(
+        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        className,
+      )}
+      data-slot="command-group"
+      {...props}
+    />
+  )
+}
+
 function CommandInput({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
-    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
+    <div className="flex h-9 items-center gap-2 border-b px-3" data-slot="command-input-wrapper">
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
-        data-slot="command-input"
         className={cn(
           'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
+        data-slot="command-input"
         {...props}
       />
     </div>
   )
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
-    <CommandPrimitive.List
-      data-slot="command-list"
-      className={cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
+    <CommandPrimitive.Item
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-slot="command-item"
       {...props}
     />
   )
 }
 
-function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
-  return <CommandPrimitive.Empty data-slot="command-empty" className="py-6 text-center text-sm" {...props} />
-}
-
-function CommandGroup({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Group>) {
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
   return (
-    <CommandPrimitive.Group
-      data-slot="command-group"
-      className={cn(
-        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
-        className,
-      )}
+    <CommandPrimitive.List
+      className={cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
+      data-slot="command-list"
       {...props}
     />
   )
@@ -94,21 +106,8 @@ function CommandGroup({ className, ...props }: React.ComponentProps<typeof Comma
 function CommandSeparator({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Separator>) {
   return (
     <CommandPrimitive.Separator
-      data-slot="command-separator"
       className={cn('bg-border -mx-1 h-px', className)}
-      {...props}
-    />
-  )
-}
-
-function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
-  return (
-    <CommandPrimitive.Item
-      data-slot="command-item"
-      className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
+      data-slot="command-separator"
       {...props}
     />
   )
@@ -117,8 +116,8 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Comman
 function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
-      data-slot="command-shortcut"
       className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      data-slot="command-shortcut"
       {...props}
     />
   )
@@ -127,11 +126,11 @@ function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) 
 export {
   Command,
   CommandDialog,
-  CommandInput,
-  CommandList,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
-  CommandShortcut,
+  CommandList,
   CommandSeparator,
+  CommandShortcut,
 }

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -1,124 +1,28 @@
 'use client'
 
-import * as React from 'react'
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu'
-import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
+import * as React from 'react'
 
 function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
   return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
 }
 
-function ContextMenuTrigger({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
-  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
-}
-
-function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
-  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
-}
-
-function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
-  return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
-}
-
-function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
-  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
-}
-
-function ContextMenuRadioGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
-  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />
-}
-
-function ContextMenuSubTrigger({
-  className,
-  inset,
-  children,
-  ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
-  inset?: boolean
-}) {
-  return (
-    <ContextMenuPrimitive.SubTrigger
-      data-slot="context-menu-sub-trigger"
-      data-inset={inset}
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <ChevronRightIcon className="ml-auto" />
-    </ContextMenuPrimitive.SubTrigger>
-  )
-}
-
-function ContextMenuSubContent({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
-  return (
-    <ContextMenuPrimitive.SubContent
-      data-slot="context-menu-sub-content"
-      className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function ContextMenuContent({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
-  return (
-    <ContextMenuPrimitive.Portal>
-      <ContextMenuPrimitive.Content
-        data-slot="context-menu-content"
-        className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
-          className,
-        )}
-        {...props}
-      />
-    </ContextMenuPrimitive.Portal>
-  )
-}
-
-function ContextMenuItem({
-  className,
-  inset,
-  variant = 'default',
-  ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
-  inset?: boolean
-  variant?: 'default' | 'destructive'
-}) {
-  return (
-    <ContextMenuPrimitive.Item
-      data-slot="context-menu-item"
-      data-inset={inset}
-      data-variant={variant}
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
 function ContextMenuCheckboxItem({
-  className,
-  children,
   checked,
+  children,
+  className,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) {
   return (
     <ContextMenuPrimitive.CheckboxItem
-      data-slot="context-menu-checkbox-item"
+      checked={checked}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
-      checked={checked}
+      data-slot="context-menu-checkbox-item"
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
@@ -131,18 +35,85 @@ function ContextMenuCheckboxItem({
   )
 }
 
-function ContextMenuRadioItem({
+function ContextMenuContent({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className,
+        )}
+        data-slot="context-menu-content"
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+}
+
+function ContextMenuItem({
   className,
+  inset,
+  variant = 'default',
+  ...props
+}: {
+  inset?: boolean
+  variant?: 'default' | 'destructive'
+} & React.ComponentProps<typeof ContextMenuPrimitive.Item>) {
+  return (
+    <ContextMenuPrimitive.Item
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-inset={inset}
+      data-slot="context-menu-item"
+      data-variant={variant}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: {
+  inset?: boolean
+} & React.ComponentProps<typeof ContextMenuPrimitive.Label>) {
+  return (
+    <ContextMenuPrimitive.Label
+      className={cn('text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      data-inset={inset}
+      data-slot="context-menu-label"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+}
+
+function ContextMenuRadioGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />
+}
+
+function ContextMenuRadioItem({
   children,
+  className,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
   return (
     <ContextMenuPrimitive.RadioItem
-      data-slot="context-menu-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
+      data-slot="context-menu-radio-item"
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
@@ -155,28 +126,11 @@ function ContextMenuRadioItem({
   )
 }
 
-function ContextMenuLabel({
-  className,
-  inset,
-  ...props
-}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
-  inset?: boolean
-}) {
-  return (
-    <ContextMenuPrimitive.Label
-      data-slot="context-menu-label"
-      data-inset={inset}
-      className={cn('text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
-      {...props}
-    />
-  )
-}
-
 function ContextMenuSeparator({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
   return (
     <ContextMenuPrimitive.Separator
-      data-slot="context-menu-separator"
       className={cn('bg-border -mx-1 my-1 h-px', className)}
+      data-slot="context-menu-separator"
       {...props}
     />
   )
@@ -185,27 +139,72 @@ function ContextMenuSeparator({ className, ...props }: React.ComponentProps<type
 function ContextMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
-      data-slot="context-menu-shortcut"
       className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      data-slot="context-menu-shortcut"
       {...props}
     />
   )
 }
 
+function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
+}
+
+function ContextMenuSubContent({ className, ...props }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
+      )}
+      data-slot="context-menu-sub-content"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSubTrigger({
+  children,
+  className,
+  inset,
+  ...props
+}: {
+  inset?: boolean
+} & React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger>) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-inset={inset}
+      data-slot="context-menu-sub-trigger"
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubTrigger>
+  )
+}
+
+function ContextMenuTrigger({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+}
+
 export {
   ContextMenu,
-  ContextMenuTrigger,
-  ContextMenuContent,
-  ContextMenuItem,
   ContextMenuCheckboxItem,
-  ContextMenuRadioItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
   ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuShortcut,
-  ContextMenuGroup,
-  ContextMenuPortal,
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
-  ContextMenuRadioGroup,
+  ContextMenuTrigger,
 }

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -1,64 +1,42 @@
 'use client'
 
-import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { XIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { XIcon } from 'lucide-react'
+import * as React from 'react'
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
-}
-
-function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
-}
-
-function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
 function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
-function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
-  return (
-    <DialogPrimitive.Overlay
-      data-slot="dialog-overlay"
-      className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
 function DialogContent({
-  className,
   children,
+  className,
   showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+}: {
   showCloseButton?: boolean
-}) {
+} & React.ComponentProps<typeof DialogPrimitive.Content>) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
-        data-slot="dialog-content"
         className={cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className,
         )}
+        data-slot="dialog-content"
         {...props}
       >
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close
-            data-slot="dialog-close"
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            data-slot="dialog-close"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -69,11 +47,11 @@ function DialogContent({
   )
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
   return (
-    <div
-      data-slot="dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+    <DialogPrimitive.Description
+      className={cn('text-muted-foreground text-sm', className)}
+      data-slot="dialog-description"
       {...props}
     />
   )
@@ -82,31 +60,52 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
 function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="dialog-footer"
       className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      data-slot="dialog-footer"
       {...props}
     />
   )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      data-slot="dialog-header"
+      {...props}
+    />
+  )
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      data-slot="dialog-overlay"
+      {...props}
+    />
+  )
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
 function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
-      data-slot="dialog-title"
       className={cn('text-lg leading-none font-semibold', className)}
+      data-slot="dialog-title"
       {...props}
     />
   )
 }
 
-function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
-  return (
-    <DialogPrimitive.Description
-      data-slot="dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
-      {...props}
-    />
-  )
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
 export {

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,21 +1,38 @@
 'use client'
 
-import * as React from 'react'
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
-import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
+import * as React from 'react'
 
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
 }
 
-function DropdownMenuPortal({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-}
-
-function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
-  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+function DropdownMenuCheckboxItem({
+  checked,
+  children,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      checked={checked}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-slot="dropdown-menu-checkbox-item"
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
 }
 
 function DropdownMenuContent({
@@ -26,12 +43,12 @@ function DropdownMenuContent({
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
-        data-slot="dropdown-menu-content"
-        sideOffset={sideOffset}
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
           className,
         )}
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
@@ -47,48 +64,43 @@ function DropdownMenuItem({
   inset,
   variant = 'default',
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+}: {
   inset?: boolean
   variant?: 'default' | 'destructive'
-}) {
+} & React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
   return (
     <DropdownMenuPrimitive.Item
-      data-slot="dropdown-menu-item"
-      data-inset={inset}
-      data-variant={variant}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
+      data-inset={inset}
+      data-slot="dropdown-menu-item"
+      data-variant={variant}
       {...props}
     />
   )
 }
 
-function DropdownMenuCheckboxItem({
+function DropdownMenuLabel({
   className,
-  children,
-  checked,
+  inset,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+}: {
+  inset?: boolean
+} & React.ComponentProps<typeof DropdownMenuPrimitive.Label>) {
   return (
-    <DropdownMenuPrimitive.CheckboxItem
-      data-slot="dropdown-menu-checkbox-item"
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
-      checked={checked}
+    <DropdownMenuPrimitive.Label
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      data-inset={inset}
+      data-slot="dropdown-menu-label"
       {...props}
-    >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.CheckboxItem>
+    />
   )
+}
+
+function DropdownMenuPortal({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
 }
 
 function DropdownMenuRadioGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
@@ -96,17 +108,17 @@ function DropdownMenuRadioGroup({ ...props }: React.ComponentProps<typeof Dropdo
 }
 
 function DropdownMenuRadioItem({
-  className,
   children,
+  className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
   return (
     <DropdownMenuPrimitive.RadioItem
-      data-slot="dropdown-menu-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
+      data-slot="dropdown-menu-radio-item"
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
@@ -119,28 +131,11 @@ function DropdownMenuRadioItem({
   )
 }
 
-function DropdownMenuLabel({
-  className,
-  inset,
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
-  inset?: boolean
-}) {
-  return (
-    <DropdownMenuPrimitive.Label
-      data-slot="dropdown-menu-label"
-      data-inset={inset}
-      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
-      {...props}
-    />
-  )
-}
-
 function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
   return (
     <DropdownMenuPrimitive.Separator
-      data-slot="dropdown-menu-separator"
       className={cn('bg-border -mx-1 my-1 h-px', className)}
+      data-slot="dropdown-menu-separator"
       {...props}
     />
   )
@@ -149,8 +144,8 @@ function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typ
 function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
-      data-slot="dropdown-menu-shortcut"
       className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      data-slot="dropdown-menu-shortcut"
       {...props}
     />
   )
@@ -160,22 +155,38 @@ function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuP
   return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
 }
 
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
+      )}
+      data-slot="dropdown-menu-sub-content"
+      {...props}
+    />
+  )
+}
+
 function DropdownMenuSubTrigger({
+  children,
   className,
   inset,
-  children,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+}: {
   inset?: boolean
-}) {
+} & React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger>) {
   return (
     <DropdownMenuPrimitive.SubTrigger
-      data-slot="dropdown-menu-sub-trigger"
-      data-inset={inset}
       className={cn(
         'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
         className,
       )}
+      data-inset={inset}
+      data-slot="dropdown-menu-sub-trigger"
       {...props}
     >
       {children}
@@ -184,36 +195,24 @@ function DropdownMenuSubTrigger({
   )
 }
 
-function DropdownMenuSubContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
-  return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
-        className,
-      )}
-      {...props}
-    />
-  )
+function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
 }
 
 export {
   DropdownMenu,
-  DropdownMenuPortal,
-  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuItem,
-  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 }

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -1,18 +1,17 @@
-import * as React from 'react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
     <input
-      type={type}
-      data-slot="input"
       className={cn(
         'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className,
       )}
+      data-slot="input"
+      type={type}
       {...props}
     />
   )

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -1,18 +1,17 @@
 'use client'
 
-import * as React from 'react'
 import * as LabelPrimitive from '@radix-ui/react-label'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
-      data-slot="label"
       className={cn(
         'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
         className,
       )}
+      data-slot="label"
       {...props}
     />
   )

--- a/packages/ui/src/components/menubar.tsx
+++ b/packages/ui/src/components/menubar.tsx
@@ -1,111 +1,34 @@
 'use client'
 
-import * as React from 'react'
 import * as MenubarPrimitive from '@radix-ui/react-menubar'
-import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react'
+import * as React from 'react'
 
 function Menubar({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.Root>) {
   return (
     <MenubarPrimitive.Root
-      data-slot="menubar"
       className={cn('bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs', className)}
-      {...props}
-    />
-  )
-}
-
-function MenubarMenu({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
-  return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />
-}
-
-function MenubarGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Group>) {
-  return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />
-}
-
-function MenubarPortal({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
-  return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />
-}
-
-function MenubarRadioGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
-  return <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />
-}
-
-function MenubarTrigger({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.Trigger>) {
-  return (
-    <MenubarPrimitive.Trigger
-      data-slot="menubar-trigger"
-      className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function MenubarContent({
-  className,
-  align = 'start',
-  alignOffset = -4,
-  sideOffset = 8,
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Content>) {
-  return (
-    <MenubarPortal>
-      <MenubarPrimitive.Content
-        data-slot="menubar-content"
-        align={align}
-        alignOffset={alignOffset}
-        sideOffset={sideOffset}
-        className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
-          className,
-        )}
-        {...props}
-      />
-    </MenubarPortal>
-  )
-}
-
-function MenubarItem({
-  className,
-  inset,
-  variant = 'default',
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Item> & {
-  inset?: boolean
-  variant?: 'default' | 'destructive'
-}) {
-  return (
-    <MenubarPrimitive.Item
-      data-slot="menubar-item"
-      data-inset={inset}
-      data-variant={variant}
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
+      data-slot="menubar"
       {...props}
     />
   )
 }
 
 function MenubarCheckboxItem({
-  className,
-  children,
   checked,
+  children,
+  className,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.CheckboxItem>) {
   return (
     <MenubarPrimitive.CheckboxItem
-      data-slot="menubar-checkbox-item"
+      checked={checked}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
-      checked={checked}
+      data-slot="menubar-checkbox-item"
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
@@ -118,14 +41,94 @@ function MenubarCheckboxItem({
   )
 }
 
-function MenubarRadioItem({ className, children, ...props }: React.ComponentProps<typeof MenubarPrimitive.RadioItem>) {
+function MenubarContent({
+  align = 'start',
+  alignOffset = -4,
+  className,
+  sideOffset = 8,
+  ...props
+}: React.ComponentProps<typeof MenubarPrimitive.Content>) {
+  return (
+    <MenubarPortal>
+      <MenubarPrimitive.Content
+        align={align}
+        alignOffset={alignOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
+          className,
+        )}
+        data-slot="menubar-content"
+        sideOffset={sideOffset}
+        {...props}
+      />
+    </MenubarPortal>
+  )
+}
+
+function MenubarGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Group>) {
+  return <MenubarPrimitive.Group data-slot="menubar-group" {...props} />
+}
+
+function MenubarItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: {
+  inset?: boolean
+  variant?: 'default' | 'destructive'
+} & React.ComponentProps<typeof MenubarPrimitive.Item>) {
+  return (
+    <MenubarPrimitive.Item
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-inset={inset}
+      data-slot="menubar-item"
+      data-variant={variant}
+      {...props}
+    />
+  )
+}
+
+function MenubarLabel({
+  className,
+  inset,
+  ...props
+}: {
+  inset?: boolean
+} & React.ComponentProps<typeof MenubarPrimitive.Label>) {
+  return (
+    <MenubarPrimitive.Label
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      data-inset={inset}
+      data-slot="menubar-label"
+      {...props}
+    />
+  )
+}
+
+function MenubarMenu({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
+  return <MenubarPrimitive.Menu data-slot="menubar-menu" {...props} />
+}
+
+function MenubarPortal({ ...props }: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
+  return <MenubarPrimitive.Portal data-slot="menubar-portal" {...props} />
+}
+
+function MenubarRadioGroup({ ...props }: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
+  return <MenubarPrimitive.RadioGroup data-slot="menubar-radio-group" {...props} />
+}
+
+function MenubarRadioItem({ children, className, ...props }: React.ComponentProps<typeof MenubarPrimitive.RadioItem>) {
   return (
     <MenubarPrimitive.RadioItem
-      data-slot="menubar-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
+      data-slot="menubar-radio-item"
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
@@ -138,28 +141,11 @@ function MenubarRadioItem({ className, children, ...props }: React.ComponentProp
   )
 }
 
-function MenubarLabel({
-  className,
-  inset,
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Label> & {
-  inset?: boolean
-}) {
-  return (
-    <MenubarPrimitive.Label
-      data-slot="menubar-label"
-      data-inset={inset}
-      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
-      {...props}
-    />
-  )
-}
-
 function MenubarSeparator({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.Separator>) {
   return (
     <MenubarPrimitive.Separator
-      data-slot="menubar-separator"
       className={cn('bg-border -mx-1 my-1 h-px', className)}
+      data-slot="menubar-separator"
       {...props}
     />
   )
@@ -168,8 +154,8 @@ function MenubarSeparator({ className, ...props }: React.ComponentProps<typeof M
 function MenubarShortcut({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
-      data-slot="menubar-shortcut"
       className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      data-slot="menubar-shortcut"
       {...props}
     />
   )
@@ -179,22 +165,35 @@ function MenubarSub({ ...props }: React.ComponentProps<typeof MenubarPrimitive.S
   return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />
 }
 
+function MenubarSubContent({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.SubContent>) {
+  return (
+    <MenubarPrimitive.SubContent
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
+      )}
+      data-slot="menubar-sub-content"
+      {...props}
+    />
+  )
+}
+
 function MenubarSubTrigger({
+  children,
   className,
   inset,
-  children,
   ...props
-}: React.ComponentProps<typeof MenubarPrimitive.SubTrigger> & {
+}: {
   inset?: boolean
-}) {
+} & React.ComponentProps<typeof MenubarPrimitive.SubTrigger>) {
   return (
     <MenubarPrimitive.SubTrigger
-      data-slot="menubar-sub-trigger"
-      data-inset={inset}
       className={cn(
         'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8',
         className,
       )}
+      data-inset={inset}
+      data-slot="menubar-sub-trigger"
       {...props}
     >
       {children}
@@ -203,14 +202,14 @@ function MenubarSubTrigger({
   )
 }
 
-function MenubarSubContent({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.SubContent>) {
+function MenubarTrigger({ className, ...props }: React.ComponentProps<typeof MenubarPrimitive.Trigger>) {
   return (
-    <MenubarPrimitive.SubContent
-      data-slot="menubar-sub-content"
+    <MenubarPrimitive.Trigger
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none',
         className,
       )}
+      data-slot="menubar-trigger"
       {...props}
     />
   )
@@ -218,19 +217,19 @@ function MenubarSubContent({ className, ...props }: React.ComponentProps<typeof 
 
 export {
   Menubar,
-  MenubarPortal,
-  MenubarMenu,
-  MenubarTrigger,
+  MenubarCheckboxItem,
   MenubarContent,
   MenubarGroup,
-  MenubarSeparator,
-  MenubarLabel,
   MenubarItem,
-  MenubarShortcut,
-  MenubarCheckboxItem,
+  MenubarLabel,
+  MenubarMenu,
+  MenubarPortal,
   MenubarRadioGroup,
   MenubarRadioItem,
+  MenubarSeparator,
+  MenubarShortcut,
   MenubarSub,
-  MenubarSubTrigger,
   MenubarSubContent,
+  MenubarSubTrigger,
+  MenubarTrigger,
 }

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,42 +1,41 @@
 'use client'
 
-import * as React from 'react'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
-}
-
-function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
-}
-
-function PopoverContent({
-  className,
-  align = 'center',
-  sideOffset = 4,
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
-  return (
-    <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
-          className,
-        )}
-        {...props}
-      />
-    </PopoverPrimitive.Portal>
-  )
 }
 
 function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }
+function PopoverContent({
+  align = 'center',
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        align={align}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          className,
+        )}
+        data-slot="popover-content"
+        sideOffset={sideOffset}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger }

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -1,28 +1,27 @@
 'use client'
 
-import * as React from 'react'
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
-import { CircleIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { CircleIcon } from 'lucide-react'
+import * as React from 'react'
 
 function RadioGroup({ className, ...props }: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
-  return <RadioGroupPrimitive.Root data-slot="radio-group" className={cn('grid gap-3', className)} {...props} />
+  return <RadioGroupPrimitive.Root className={cn('grid gap-3', className)} data-slot="radio-group" {...props} />
 }
 
 function RadioGroupItem({ className, ...props }: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
   return (
     <RadioGroupPrimitive.Item
-      data-slot="radio-group-item"
       className={cn(
         'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
+      data-slot="radio-group-item"
       {...props}
     >
       <RadioGroupPrimitive.Indicator
-        data-slot="radio-group-indicator"
         className="relative flex items-center justify-center"
+        data-slot="radio-group-indicator"
       >
         <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
       </RadioGroupPrimitive.Indicator>

--- a/packages/ui/src/components/resizable.tsx
+++ b/packages/ui/src/components/resizable.tsx
@@ -1,39 +1,24 @@
 'use client'
 
-import * as React from 'react'
+import { cn } from '@workspace/ui/lib/utils'
 import { GripVerticalIcon } from 'lucide-react'
+import * as React from 'react'
 import * as ResizablePrimitive from 'react-resizable-panels'
 
-import { cn } from '@workspace/ui/lib/utils'
-
-function ResizablePanelGroup({ className, ...props }: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
-  return (
-    <ResizablePrimitive.PanelGroup
-      data-slot="resizable-panel-group"
-      className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
-      {...props}
-    />
-  )
-}
-
-function ResizablePanel({ ...props }: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
-}
-
 function ResizableHandle({
-  withHandle,
   className,
+  withHandle,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: {
   withHandle?: boolean
-}) {
+} & React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle>) {
   return (
     <ResizablePrimitive.PanelResizeHandle
-      data-slot="resizable-handle"
       className={cn(
         'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
         className,
       )}
+      data-slot="resizable-handle"
       {...props}
     >
       {withHandle && (
@@ -45,4 +30,18 @@ function ResizableHandle({
   )
 }
 
-export { ResizablePanelGroup, ResizablePanel, ResizableHandle }
+function ResizablePanel({ ...props }: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizablePanelGroup({ className, ...props }: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+  return (
+    <ResizablePrimitive.PanelGroup
+      className={cn('flex h-full w-full data-[panel-group-direction=vertical]:flex-col', className)}
+      data-slot="resizable-panel-group"
+      {...props}
+    />
+  )
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -1,16 +1,15 @@
 'use client'
 
-import * as React from 'react'
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
-function ScrollArea({ className, children, ...props }: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+function ScrollArea({ children, className, ...props }: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
   return (
-    <ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn('relative', className)} {...props}>
+    <ScrollAreaPrimitive.Root className={cn('relative', className)} data-slot="scroll-area" {...props}>
       <ScrollAreaPrimitive.Viewport
-        data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        data-slot="scroll-area-viewport"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
@@ -27,19 +26,19 @@ function ScrollBar({
 }: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
   return (
     <ScrollAreaPrimitive.ScrollAreaScrollbar
-      data-slot="scroll-area-scrollbar"
-      orientation={orientation}
       className={cn(
         'flex touch-none p-px transition-colors select-none',
         orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent',
         orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent',
         className,
       )}
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
       {...props}
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
-        data-slot="scroll-area-thumb"
         className="bg-border relative flex-1 rounded-full"
+        data-slot="scroll-area-thumb"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,65 +1,30 @@
 'use client'
 
-import * as React from 'react'
 import * as SelectPrimitive from '@radix-ui/react-select'
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+import * as React from 'react'
 
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
-function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
-  return <SelectPrimitive.Group data-slot="select-group" {...props} />
-}
-
-function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
-}
-
-function SelectTrigger({
-  className,
-  size = 'default',
-  children,
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: 'sm' | 'default'
-}) {
-  return (
-    <SelectPrimitive.Trigger
-      data-slot="select-trigger"
-      data-size={size}
-      className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
-      </SelectPrimitive.Icon>
-    </SelectPrimitive.Trigger>
-  )
-}
-
 function SelectContent({
-  className,
   children,
+  className,
   position = 'popper',
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
-        data-slot="select-content"
         className={cn(
           'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,
         )}
+        data-slot="select-content"
         position={position}
         {...props}
       >
@@ -79,24 +44,18 @@ function SelectContent({
   )
 }
 
-function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
-  return (
-    <SelectPrimitive.Label
-      data-slot="select-label"
-      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
-      {...props}
-    />
-  )
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
 }
 
-function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
+function SelectItem({ children, className, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
   return (
     <SelectPrimitive.Item
-      data-slot="select-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
+      data-slot="select-item"
       {...props}
     >
       <span className="absolute right-2 flex size-3.5 items-center justify-center">
@@ -109,25 +68,13 @@ function SelectItem({ className, children, ...props }: React.ComponentProps<type
   )
 }
 
-function SelectSeparator({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
   return (
-    <SelectPrimitive.Separator
-      data-slot="select-separator"
-      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+    <SelectPrimitive.Label
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      data-slot="select-label"
       {...props}
     />
-  )
-}
-
-function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
-  return (
-    <SelectPrimitive.ScrollUpButton
-      data-slot="select-scroll-up-button"
-      className={cn('flex cursor-default items-center justify-center py-1', className)}
-      {...props}
-    >
-      <ChevronUpIcon className="size-4" />
-    </SelectPrimitive.ScrollUpButton>
   )
 }
 
@@ -137,13 +84,65 @@ function SelectScrollDownButton({
 }: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
   return (
     <SelectPrimitive.ScrollDownButton
-      data-slot="select-scroll-down-button"
       className={cn('flex cursor-default items-center justify-center py-1', className)}
+      data-slot="select-scroll-down-button"
       {...props}
     >
       <ChevronDownIcon className="size-4" />
     </SelectPrimitive.ScrollDownButton>
   )
+}
+
+function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      data-slot="select-scroll-up-button"
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectSeparator({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      data-slot="select-separator"
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  children,
+  className,
+  size = 'default',
+  ...props
+}: {
+  size?: 'default' | 'sm'
+} & React.ComponentProps<typeof SelectPrimitive.Trigger>) {
+  return (
+    <SelectPrimitive.Trigger
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      data-size={size}
+      data-slot="select-trigger"
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
 export {

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,25 +1,24 @@
 'use client'
 
-import * as React from 'react'
 import * as SeparatorPrimitive from '@radix-ui/react-separator'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Separator({
   className,
-  orientation = 'horizontal',
   decorative = true,
+  orientation = 'horizontal',
   ...props
 }: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
   return (
     <SeparatorPrimitive.Root
-      data-slot="separator"
-      decorative={decorative}
-      orientation={orientation}
       className={cn(
         'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
         className,
       )}
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
       {...props}
     />
   )

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,53 +1,30 @@
 'use client'
 
-import * as React from 'react'
 import * as SheetPrimitive from '@radix-ui/react-dialog'
-import { XIcon } from 'lucide-react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { XIcon } from 'lucide-react'
+import * as React from 'react'
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
-}
-
-function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
 }
 
 function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Close>) {
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
 }
 
-function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
-}
-
-function SheetOverlay({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
-  return (
-    <SheetPrimitive.Overlay
-      data-slot="sheet-overlay"
-      className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
 function SheetContent({
-  className,
   children,
+  className,
   side = 'right',
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
-  side?: 'top' | 'right' | 'bottom' | 'left'
-}) {
+}: {
+  side?: 'bottom' | 'left' | 'right' | 'top'
+} & React.ComponentProps<typeof SheetPrimitive.Content>) {
   return (
     <SheetPortal>
       <SheetOverlay />
       <SheetPrimitive.Content
-        data-slot="sheet-content"
         className={cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
@@ -60,6 +37,7 @@ function SheetContent({
             'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
           className,
         )}
+        data-slot="sheet-content"
         {...props}
       >
         {children}
@@ -72,32 +50,53 @@ function SheetContent({
   )
 }
 
-function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="sheet-header" className={cn('flex flex-col gap-1.5 p-4', className)} {...props} />
+function SheetDescription({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      className={cn('text-muted-foreground text-sm', className)}
+      data-slot="sheet-description"
+      {...props}
+    />
+  )
 }
 
 function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="sheet-footer" className={cn('mt-auto flex flex-col gap-2 p-4', className)} {...props} />
+  return <div className={cn('mt-auto flex flex-col gap-2 p-4', className)} data-slot="sheet-footer" {...props} />
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div className={cn('flex flex-col gap-1.5 p-4', className)} data-slot="sheet-header" {...props} />
+}
+
+function SheetOverlay({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      data-slot="sheet-overlay"
+      {...props}
+    />
+  )
+}
+
+function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
 }
 
 function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Title>) {
   return (
     <SheetPrimitive.Title
-      data-slot="sheet-title"
       className={cn('text-foreground font-semibold', className)}
+      data-slot="sheet-title"
       {...props}
     />
   )
 }
 
-function SheetDescription({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Description>) {
-  return (
-    <SheetPrimitive.Description
-      data-slot="sheet-description"
-      className={cn('text-muted-foreground text-sm', className)}
-      {...props}
-    />
-  )
+function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
 }
 
-export { Sheet, SheetTrigger, SheetClose, SheetContent, SheetHeader, SheetFooter, SheetTitle, SheetDescription }
+export { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger }

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -1,18 +1,19 @@
 'use client'
 
-import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
-import { cva, VariantProps } from 'class-variance-authority'
-import { PanelLeftIcon } from 'lucide-react'
+import type { VariantProps } from 'class-variance-authority';
 
-import { useIsMobile } from '@workspace/ui/hooks/use-mobile'
-import { cn } from '@workspace/ui/lib/utils'
+import { Slot } from '@radix-ui/react-slot'
 import { Button } from '@workspace/ui/components/button'
 import { Input } from '@workspace/ui/components/input'
 import { Separator } from '@workspace/ui/components/separator'
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@workspace/ui/components/sheet'
 import { Skeleton } from '@workspace/ui/components/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@workspace/ui/components/tooltip'
+import { useIsMobile } from '@workspace/ui/hooks/use-mobile'
+import { cn } from '@workspace/ui/lib/utils'
+import { cva } from 'class-variance-authority'
+import { PanelLeftIcon } from 'lucide-react'
+import * as React from 'react'
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state'
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -21,40 +22,279 @@ const SIDEBAR_WIDTH_MOBILE = '18rem'
 const SIDEBAR_WIDTH_ICON = '3rem'
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b'
 
-type SidebarContextProps = {
-  state: 'expanded' | 'collapsed'
-  open: boolean
-  setOpen: (open: boolean) => void
-  openMobile: boolean
-  setOpenMobile: (open: boolean) => void
+interface SidebarContextProps {
   isMobile: boolean
+  open: boolean
+  openMobile: boolean
+  setOpen: (open: boolean) => void
+  setOpenMobile: (open: boolean) => void
+  state: 'collapsed' | 'expanded'
   toggleSidebar: () => void
 }
 
-const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+const SidebarContext = React.createContext<null | SidebarContextProps>(null)
 
-function useSidebar() {
-  const context = React.useContext(SidebarContext)
-  if (!context) {
-    throw new Error('useSidebar must be used within a SidebarProvider.')
+function Sidebar({
+  children,
+  className,
+  collapsible = 'offcanvas',
+  side = 'left',
+  variant = 'sidebar',
+  ...props
+}: {
+  collapsible?: 'icon' | 'none' | 'offcanvas'
+  side?: 'left' | 'right'
+  variant?: 'floating' | 'inset' | 'sidebar'
+} & React.ComponentProps<'div'>) {
+  const { isMobile, openMobile, setOpenMobile, state } = useSidebar()
+
+  if (collapsible === 'none') {
+    return (
+      <div
+        className={cn('bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col', className)}
+        data-slot="sidebar"
+        {...props}
+      >
+        {children}
+      </div>
+    )
   }
 
-  return context
+  if (isMobile) {
+    return (
+      <Sheet onOpenChange={setOpenMobile} open={openMobile} {...props}>
+        <SheetContent
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          data-mobile="true"
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          side={side}
+          style={
+            {
+              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer text-sidebar-foreground hidden md:block"
+      data-collapsible={state === 'collapsed' ? collapsible : ''}
+      data-side={side}
+      data-slot="sidebar"
+      data-state={state}
+      data-variant={variant}
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        className={cn(
+          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
+          'group-data-[collapsible=offcanvas]:w-0',
+          'group-data-[side=right]:rotate-180',
+          variant === 'floating' || variant === 'inset'
+            ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
+        )}
+        data-slot="sidebar-gap"
+      />
+      <div
+        className={cn(
+          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
+          side === 'left'
+            ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+            : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+          // Adjust the padding for floating and inset variants.
+          variant === 'floating' || variant === 'inset'
+            ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+          className,
+        )}
+        data-slot="sidebar-container"
+        {...props}
+      >
+        <div
+          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        className,
+      )}
+      data-sidebar="content"
+      data-slot="sidebar-content"
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('flex flex-col gap-2 p-2', className)}
+      data-sidebar="footer"
+      data-slot="sidebar-footer"
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+      data-sidebar="group"
+      data-slot="sidebar-group"
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupAction({
+  asChild = false,
+  className,
+  ...props
+}: { asChild?: boolean } & React.ComponentProps<'button'>) {
+  const Comp = asChild ? Slot : 'button'
+
+  return (
+    <Comp
+      className={cn(
+        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        // Increases the hit area of the button on mobile.
+        'after:absolute after:-inset-2 md:after:hidden',
+        'group-data-[collapsible=icon]:hidden',
+        className,
+      )}
+      data-sidebar="group-action"
+      data-slot="sidebar-group-action"
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('w-full text-sm', className)}
+      data-sidebar="group-content"
+      data-slot="sidebar-group-content"
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  asChild = false,
+  className,
+  ...props
+}: { asChild?: boolean } & React.ComponentProps<'div'>) {
+  const Comp = asChild ? Slot : 'div'
+
+  return (
+    <Comp
+      className={cn(
+        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
+        className,
+      )}
+      data-sidebar="group-label"
+      data-slot="sidebar-group-label"
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('flex flex-col gap-2 p-2', className)}
+      data-sidebar="header"
+      data-slot="sidebar-header"
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({ className, ...props }: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      className={cn('bg-background h-8 w-full shadow-none', className)}
+      data-sidebar="input"
+      data-slot="sidebar-input"
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
+  return (
+    <main
+      className={cn(
+        'bg-background relative flex w-full flex-1 flex-col',
+        'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+        className,
+      )}
+      data-slot="sidebar-inset"
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      className={cn('flex w-full min-w-0 flex-col gap-1', className)}
+      data-sidebar="menu"
+      data-slot="sidebar-menu"
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      className={cn('group/menu-item relative', className)}
+      data-sidebar="menu-item"
+      data-slot="sidebar-menu-item"
+      {...props}
+    />
+  )
 }
 
 function SidebarProvider({
-  defaultOpen = true,
-  open: openProp,
-  onOpenChange: setOpenProp,
-  className,
-  style,
   children,
+  className,
+  defaultOpen = true,
+  onOpenChange: setOpenProp,
+  open: openProp,
+  style,
   ...props
-}: React.ComponentProps<'div'> & {
+}: {
   defaultOpen?: boolean
-  open?: boolean
   onOpenChange?: (open: boolean) => void
-}) {
+  open?: boolean
+} & React.ComponentProps<'div'>) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
 
@@ -63,7 +303,7 @@ function SidebarProvider({
   const [_open, _setOpen] = React.useState(defaultOpen)
   const open = openProp ?? _open
   const setOpen = React.useCallback(
-    (value: boolean | ((value: boolean) => boolean)) => {
+    (value: ((value: boolean) => boolean) | boolean) => {
       const openState = typeof value === 'function' ? value(open) : value
       if (setOpenProp) {
         setOpenProp(openState)
@@ -101,12 +341,12 @@ function SidebarProvider({
 
   const contextValue = React.useMemo<SidebarContextProps>(
     () => ({
-      state,
-      open,
-      setOpen,
       isMobile,
+      open,
       openMobile,
+      setOpen,
       setOpenMobile,
+      state,
       toggleSidebar,
     }),
     [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
@@ -116,6 +356,7 @@ function SidebarProvider({
     <SidebarContext.Provider value={contextValue}>
       <TooltipProvider delayDuration={0}>
         <div
+          className={cn('group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full', className)}
           data-slot="sidebar-wrapper"
           style={
             {
@@ -124,7 +365,6 @@ function SidebarProvider({
               ...style,
             } as React.CSSProperties
           }
-          className={cn('group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full', className)}
           {...props}
         >
           {children}
@@ -134,138 +374,12 @@ function SidebarProvider({
   )
 }
 
-function Sidebar({
-  side = 'left',
-  variant = 'sidebar',
-  collapsible = 'offcanvas',
-  className,
-  children,
-  ...props
-}: React.ComponentProps<'div'> & {
-  side?: 'left' | 'right'
-  variant?: 'sidebar' | 'floating' | 'inset'
-  collapsible?: 'offcanvas' | 'icon' | 'none'
-}) {
-  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
-
-  if (collapsible === 'none') {
-    return (
-      <div
-        data-slot="sidebar"
-        className={cn('bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col', className)}
-        {...props}
-      >
-        {children}
-      </div>
-    )
-  }
-
-  if (isMobile) {
-    return (
-      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
-        <SheetContent
-          data-sidebar="sidebar"
-          data-slot="sidebar"
-          data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
-          style={
-            {
-              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
-            } as React.CSSProperties
-          }
-          side={side}
-        >
-          <SheetHeader className="sr-only">
-            <SheetTitle>Sidebar</SheetTitle>
-            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
-          </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
-        </SheetContent>
-      </Sheet>
-    )
-  }
-
-  return (
-    <div
-      className="group peer text-sidebar-foreground hidden md:block"
-      data-state={state}
-      data-collapsible={state === 'collapsed' ? collapsible : ''}
-      data-variant={variant}
-      data-side={side}
-      data-slot="sidebar"
-    >
-      {/* This is what handles the sidebar gap on desktop */}
-      <div
-        data-slot="sidebar-gap"
-        className={cn(
-          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
-          'group-data-[collapsible=offcanvas]:w-0',
-          'group-data-[side=right]:rotate-180',
-          variant === 'floating' || variant === 'inset'
-            ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
-        )}
-      />
-      <div
-        data-slot="sidebar-container"
-        className={cn(
-          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
-          side === 'left'
-            ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-            : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
-          // Adjust the padding for floating and inset variants.
-          variant === 'floating' || variant === 'inset'
-            ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
-          className,
-        )}
-        {...props}
-      >
-        <div
-          data-sidebar="sidebar"
-          data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
-        >
-          {children}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar()
-
-  return (
-    <Button
-      data-sidebar="trigger"
-      data-slot="sidebar-trigger"
-      variant="ghost"
-      size="icon"
-      className={cn('size-7', className)}
-      onClick={(event) => {
-        onClick?.(event)
-        toggleSidebar()
-      }}
-      {...props}
-    >
-      <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
-    </Button>
-  )
-}
-
 function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
   const { toggleSidebar } = useSidebar()
 
   return (
     <button
-      data-sidebar="rail"
-      data-slot="sidebar-rail"
       aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
       className={cn(
         'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
         'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
@@ -275,53 +389,11 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
         '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
         className,
       )}
-      {...props}
-    />
-  )
-}
-
-function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
-  return (
-    <main
-      data-slot="sidebar-inset"
-      className={cn(
-        'bg-background relative flex w-full flex-1 flex-col',
-        'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function SidebarInput({ className, ...props }: React.ComponentProps<typeof Input>) {
-  return (
-    <Input
-      data-slot="sidebar-input"
-      data-sidebar="input"
-      className={cn('bg-background h-8 w-full shadow-none', className)}
-      {...props}
-    />
-  )
-}
-
-function SidebarHeader({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="sidebar-header"
-      data-sidebar="header"
-      className={cn('flex flex-col gap-2 p-2', className)}
-      {...props}
-    />
-  )
-}
-
-function SidebarFooter({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="sidebar-footer"
-      data-sidebar="footer"
-      className={cn('flex flex-col gap-2 p-2', className)}
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      onClick={toggleSidebar}
+      tabIndex={-1}
+      title="Toggle Sidebar"
       {...props}
     />
   )
@@ -330,161 +402,141 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<'div'>) {
 function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
-      data-slot="sidebar-separator"
-      data-sidebar="separator"
       className={cn('bg-sidebar-border mx-2 w-auto', className)}
+      data-sidebar="separator"
+      data-slot="sidebar-separator"
       {...props}
     />
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
+function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
   return (
-    <div
-      data-slot="sidebar-content"
-      data-sidebar="content"
-      className={cn(
-        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
-        className,
-      )}
+    <Button
+      className={cn('size-7', className)}
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      size="icon"
+      variant="ghost"
       {...props}
-    />
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
   )
 }
 
-function SidebarGroup({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="sidebar-group"
-      data-sidebar="group"
-      className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
-      {...props}
-    />
-  )
-}
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error('useSidebar must be used within a SidebarProvider.')
+  }
 
-function SidebarGroupLabel({
-  className,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'div'> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : 'div'
-
-  return (
-    <Comp
-      data-slot="sidebar-group-label"
-      data-sidebar="group-label"
-      className={cn(
-        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-        'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function SidebarGroupAction({
-  className,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : 'button'
-
-  return (
-    <Comp
-      data-slot="sidebar-group-action"
-      data-sidebar="group-action"
-      className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-        // Increases the hit area of the button on mobile.
-        'after:absolute after:-inset-2 md:after:hidden',
-        'group-data-[collapsible=icon]:hidden',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function SidebarGroupContent({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="sidebar-group-content"
-      data-sidebar="group-content"
-      className={cn('w-full text-sm', className)}
-      {...props}
-    />
-  )
-}
-
-function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
-  return (
-    <ul
-      data-slot="sidebar-menu"
-      data-sidebar="menu"
-      className={cn('flex w-full min-w-0 flex-col gap-1', className)}
-      {...props}
-    />
-  )
-}
-
-function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
-  return (
-    <li
-      data-slot="sidebar-menu-item"
-      data-sidebar="menu-item"
-      className={cn('group/menu-item relative', className)}
-      {...props}
-    />
-  )
+  return context
 }
 
 const sidebarMenuButtonVariants = cva(
   'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
     variants: {
+      size: {
+        default: 'h-8 text-sm',
+        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+        sm: 'h-7 text-xs',
+      },
       variant: {
         default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
         outline:
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
-      size: {
-        default: 'h-8 text-sm',
-        sm: 'h-7 text-xs',
-        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
     },
   },
 )
 
+function SidebarMenuAction({
+  asChild = false,
+  className,
+  showOnHover = false,
+  ...props
+}: {
+  asChild?: boolean
+  showOnHover?: boolean
+} & React.ComponentProps<'button'>) {
+  const Comp = asChild ? Slot : 'button'
+
+  return (
+    <Comp
+      className={cn(
+        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        // Increases the hit area of the button on mobile.
+        'after:absolute after:-inset-2 md:after:hidden',
+        'peer-data-[size=sm]/menu-button:top-1',
+        'peer-data-[size=default]/menu-button:top-1.5',
+        'peer-data-[size=lg]/menu-button:top-2.5',
+        'group-data-[collapsible=icon]:hidden',
+        showOnHover &&
+          'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
+        className,
+      )}
+      data-sidebar="menu-action"
+      data-slot="sidebar-menu-action"
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none',
+        'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
+        'peer-data-[size=sm]/menu-button:top-1',
+        'peer-data-[size=default]/menu-button:top-1.5',
+        'peer-data-[size=lg]/menu-button:top-2.5',
+        'group-data-[collapsible=icon]:hidden',
+        className,
+      )}
+      data-sidebar="menu-badge"
+      data-slot="sidebar-menu-badge"
+      {...props}
+    />
+  )
+}
+
 function SidebarMenuButton({
   asChild = false,
+  className,
   isActive = false,
-  variant = 'default',
   size = 'default',
   tooltip,
-  className,
+  variant = 'default',
   ...props
-}: React.ComponentProps<'button'> & {
+}: {
   asChild?: boolean
   isActive?: boolean
-  tooltip?: string | React.ComponentProps<typeof TooltipContent>
-} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  tooltip?: React.ComponentProps<typeof TooltipContent> | string
+} & React.ComponentProps<'button'> & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot : 'button'
   const { isMobile, state } = useSidebar()
 
   const button = (
     <Comp
-      data-slot="sidebar-menu-button"
+      className={cn(sidebarMenuButtonVariants({ size, variant }), className)}
+      data-active={isActive}
       data-sidebar="menu-button"
       data-size={size}
-      data-active={isActive}
-      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      data-slot="sidebar-menu-button"
       {...props}
     />
   )
@@ -502,59 +554,8 @@ function SidebarMenuButton({
   return (
     <Tooltip>
       <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent side="right" align="center" hidden={state !== 'collapsed' || isMobile} {...tooltip} />
+      <TooltipContent align="center" hidden={state !== 'collapsed' || isMobile} side="right" {...tooltip} />
     </Tooltip>
-  )
-}
-
-function SidebarMenuAction({
-  className,
-  asChild = false,
-  showOnHover = false,
-  ...props
-}: React.ComponentProps<'button'> & {
-  asChild?: boolean
-  showOnHover?: boolean
-}) {
-  const Comp = asChild ? Slot : 'button'
-
-  return (
-    <Comp
-      data-slot="sidebar-menu-action"
-      data-sidebar="menu-action"
-      className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
-        // Increases the hit area of the button on mobile.
-        'after:absolute after:-inset-2 md:after:hidden',
-        'peer-data-[size=sm]/menu-button:top-1',
-        'peer-data-[size=default]/menu-button:top-1.5',
-        'peer-data-[size=lg]/menu-button:top-2.5',
-        'group-data-[collapsible=icon]:hidden',
-        showOnHover &&
-          'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) {
-  return (
-    <div
-      data-slot="sidebar-menu-badge"
-      data-sidebar="menu-badge"
-      className={cn(
-        'text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none',
-        'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
-        'peer-data-[size=sm]/menu-button:top-1',
-        'peer-data-[size=default]/menu-button:top-1.5',
-        'peer-data-[size=lg]/menu-button:top-2.5',
-        'group-data-[collapsible=icon]:hidden',
-        className,
-      )}
-      {...props}
-    />
   )
 }
 
@@ -562,9 +563,9 @@ function SidebarMenuSkeleton({
   className,
   showIcon = false,
   ...props
-}: React.ComponentProps<'div'> & {
+}: {
   showIcon?: boolean
-}) {
+} & React.ComponentProps<'div'>) {
   // Random width between 50 to 90%.
   const width = React.useMemo(() => {
     return `${Math.floor(Math.random() * 40) + 50}%`
@@ -572,9 +573,9 @@ function SidebarMenuSkeleton({
 
   return (
     <div
-      data-slot="sidebar-menu-skeleton"
-      data-sidebar="menu-skeleton"
       className={cn('flex h-8 items-center gap-2 rounded-md px-2', className)}
+      data-sidebar="menu-skeleton"
+      data-slot="sidebar-menu-skeleton"
       {...props}
     >
       {showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
@@ -594,24 +595,13 @@ function SidebarMenuSkeleton({
 function SidebarMenuSub({ className, ...props }: React.ComponentProps<'ul'>) {
   return (
     <ul
-      data-slot="sidebar-menu-sub"
-      data-sidebar="menu-sub"
       className={cn(
         'border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5',
         'group-data-[collapsible=icon]:hidden',
         className,
       )}
-      {...props}
-    />
-  )
-}
-
-function SidebarMenuSubItem({ className, ...props }: React.ComponentProps<'li'>) {
-  return (
-    <li
-      data-slot="sidebar-menu-sub-item"
-      data-sidebar="menu-sub-item"
-      className={cn('group/menu-sub-item relative', className)}
+      data-sidebar="menu-sub"
+      data-slot="sidebar-menu-sub"
       {...props}
     />
   )
@@ -619,23 +609,19 @@ function SidebarMenuSubItem({ className, ...props }: React.ComponentProps<'li'>)
 
 function SidebarMenuSubButton({
   asChild = false,
-  size = 'md',
-  isActive = false,
   className,
+  isActive = false,
+  size = 'md',
   ...props
-}: React.ComponentProps<'a'> & {
+}: {
   asChild?: boolean
-  size?: 'sm' | 'md'
   isActive?: boolean
-}) {
+  size?: 'md' | 'sm'
+} & React.ComponentProps<'a'>) {
   const Comp = asChild ? Slot : 'a'
 
   return (
     <Comp
-      data-slot="sidebar-menu-sub-button"
-      data-sidebar="menu-sub-button"
-      data-size={size}
-      data-active={isActive}
       className={cn(
         'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
@@ -644,6 +630,21 @@ function SidebarMenuSubButton({
         'group-data-[collapsible=icon]:hidden',
         className,
       )}
+      data-active={isActive}
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-slot="sidebar-menu-sub-button"
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({ className, ...props }: React.ComponentProps<'li'>) {
+  return (
+    <li
+      className={cn('group/menu-sub-item relative', className)}
+      data-sidebar="menu-sub-item"
+      data-slot="sidebar-menu-sub-item"
       {...props}
     />
   )

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@workspace/ui/lib/utils'
 
 function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="skeleton" className={cn('bg-accent animate-pulse rounded-md', className)} {...props} />
+  return <div className={cn('bg-accent animate-pulse rounded-md', className)} data-slot="skeleton" {...props} />
 }
 
 export { Skeleton }

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -1,22 +1,24 @@
 'use client'
 
+import type { ToasterProps } from 'sonner';
+
 import { useTheme } from 'next-themes'
-import { Toaster as Sonner, ToasterProps } from 'sonner'
+import { Toaster as Sonner } from 'sonner'
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = 'system' } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps['theme']}
       className="toaster group"
       style={
         {
           '--normal-bg': 'var(--popover)',
-          '--normal-text': 'var(--popover-foreground)',
           '--normal-border': 'var(--border)',
+          '--normal-text': 'var(--popover-foreground)',
         } as React.CSSProperties
       }
+      theme={theme as ToasterProps['theme']}
       {...props}
     />
   )

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,25 +1,24 @@
 'use client'
 
-import * as React from 'react'
 import * as SwitchPrimitive from '@radix-ui/react-switch'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
   return (
     <SwitchPrimitive.Root
-      data-slot="switch"
       className={cn(
         'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
+      data-slot="switch"
       {...props}
     >
       <SwitchPrimitive.Thumb
-        data-slot="switch-thumb"
         className={cn(
           'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
         )}
+        data-slot="switch-thumb"
       />
     </SwitchPrimitive.Root>
   )

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,40 +1,44 @@
 'use client'
 
-import * as React from 'react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (
-    <div data-slot="table-container" className="relative w-full overflow-x-auto">
-      <table data-slot="table" className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    <div className="relative w-full overflow-x-auto" data-slot="table-container">
+      <table className={cn('w-full caption-bottom text-sm', className)} data-slot="table" {...props} />
     </div>
   )
 }
 
-function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
-  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />
-}
-
 function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
-  return <tbody data-slot="table-body" className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+  return <tbody className={cn('[&_tr:last-child]:border-0', className)} data-slot="table-body" {...props} />
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
   return (
-    <tfoot
-      data-slot="table-footer"
-      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+    <caption className={cn('text-muted-foreground mt-4 text-sm', className)} data-slot="table-caption" {...props} />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      className={cn(
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      data-slot="table-cell"
       {...props}
     />
   )
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   return (
-    <tr
-      data-slot="table-row"
-      className={cn('hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors', className)}
+    <tfoot
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      data-slot="table-footer"
       {...props}
     />
   )
@@ -43,33 +47,28 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
 function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   return (
     <th
-      data-slot="table-head"
       className={cn(
         'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
+      data-slot="table-head"
       {...props}
     />
   )
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead className={cn('[&_tr]:border-b', className)} data-slot="table-header" {...props} />
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   return (
-    <td
-      data-slot="table-cell"
-      className={cn(
-        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
-        className,
-      )}
+    <tr
+      className={cn('hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors', className)}
+      data-slot="table-row"
       {...props}
     />
   )
 }
 
-function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
-  return (
-    <caption data-slot="table-caption" className={cn('text-muted-foreground mt-4 text-sm', className)} {...props} />
-  )
-}
-
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow }

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,22 +1,25 @@
 'use client'
 
-import * as React from 'react'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
-  return <TabsPrimitive.Root data-slot="tabs" className={cn('flex flex-col gap-2', className)} {...props} />
+  return <TabsPrimitive.Root className={cn('flex flex-col gap-2', className)} data-slot="tabs" {...props} />
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content className={cn('flex-1 outline-none', className)} data-slot="tabs-content" {...props} />
 }
 
 function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
   return (
     <TabsPrimitive.List
-      data-slot="tabs-list"
       className={cn(
         'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
         className,
       )}
+      data-slot="tabs-list"
       {...props}
     />
   )
@@ -25,18 +28,14 @@ function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimi
 function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
-      data-slot="tabs-trigger"
       className={cn(
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
+      data-slot="tabs-trigger"
       {...props}
     />
   )
 }
 
-function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
-  return <TabsPrimitive.Content data-slot="tabs-content" className={cn('flex-1 outline-none', className)} {...props} />
-}
-
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsContent, TabsList, TabsTrigger }

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -1,15 +1,14 @@
-import * as React from 'react'
-
 import { cn } from '@workspace/ui/lib/utils'
+import * as React from 'react'
 
 function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
-      data-slot="textarea"
       className={cn(
         'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className,
       )}
+      data-slot="textarea"
       {...props}
     />
   )

--- a/packages/ui/src/components/toggle-group.tsx
+++ b/packages/ui/src/components/toggle-group.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import * as React from 'react'
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group'
-import { type VariantProps } from 'class-variance-authority'
-
-import { cn } from '@workspace/ui/lib/utils'
 import { toggleVariants } from '@workspace/ui/components/toggle'
+import { cn } from '@workspace/ui/lib/utils'
+import { type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 const ToggleGroupContext = React.createContext<VariantProps<typeof toggleVariants>>({
   size: 'default',
@@ -13,50 +12,50 @@ const ToggleGroupContext = React.createContext<VariantProps<typeof toggleVariant
 })
 
 function ToggleGroup({
-  className,
-  variant,
-  size,
   children,
+  className,
+  size,
+  variant,
   ...props
 }: React.ComponentProps<typeof ToggleGroupPrimitive.Root> & VariantProps<typeof toggleVariants>) {
   return (
     <ToggleGroupPrimitive.Root
-      data-slot="toggle-group"
-      data-variant={variant}
-      data-size={size}
       className={cn(
         'group/toggle-group flex w-fit items-center rounded-md data-[variant=outline]:shadow-xs',
         className,
       )}
+      data-size={size}
+      data-slot="toggle-group"
+      data-variant={variant}
       {...props}
     >
-      <ToggleGroupContext.Provider value={{ variant, size }}>{children}</ToggleGroupContext.Provider>
+      <ToggleGroupContext.Provider value={{ size, variant }}>{children}</ToggleGroupContext.Provider>
     </ToggleGroupPrimitive.Root>
   )
 }
 
 function ToggleGroupItem({
-  className,
   children,
-  variant,
+  className,
   size,
+  variant,
   ...props
 }: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & VariantProps<typeof toggleVariants>) {
   const context = React.useContext(ToggleGroupContext)
 
   return (
     <ToggleGroupPrimitive.Item
-      data-slot="toggle-group-item"
-      data-variant={context.variant || variant}
-      data-size={context.size || size}
       className={cn(
         toggleVariants({
-          variant: context.variant || variant,
           size: context.size || size,
+          variant: context.variant || variant,
         }),
         'min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l',
         className,
       )}
+      data-size={context.size || size}
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
       {...props}
     >
       {children}

--- a/packages/ui/src/components/toggle.tsx
+++ b/packages/ui/src/components/toggle.tsx
@@ -1,40 +1,39 @@
 'use client'
 
-import * as React from 'react'
 import * as TogglePrimitive from '@radix-ui/react-toggle'
-import { cva, type VariantProps } from 'class-variance-authority'
-
 import { cn } from '@workspace/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 const toggleVariants = cva(
   "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
   {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
     variants: {
+      size: {
+        default: 'h-9 px-2 min-w-9',
+        lg: 'h-10 px-2.5 min-w-10',
+        sm: 'h-8 px-1.5 min-w-8',
+      },
       variant: {
         default: 'bg-transparent',
         outline: 'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
       },
-      size: {
-        default: 'h-9 px-2 min-w-9',
-        sm: 'h-8 px-1.5 min-w-8',
-        lg: 'h-10 px-2.5 min-w-10',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-      size: 'default',
     },
   },
 )
 
 function Toggle({
   className,
-  variant,
   size,
+  variant,
   ...props
 }: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
   return (
-    <TogglePrimitive.Root data-slot="toggle" className={cn(toggleVariants({ variant, size, className }))} {...props} />
+    <TogglePrimitive.Root className={cn(toggleVariants({ className, size, variant }))} data-slot="toggle" {...props} />
   )
 }
 

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,13 +1,8 @@
 'use client'
 
-import * as React from 'react'
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
-
 import { cn } from '@workspace/ui/lib/utils'
-
-function TooltipProvider({ delayDuration = 0, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
-  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />
-}
+import * as React from 'react'
 
 function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
@@ -17,25 +12,21 @@ function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root
   )
 }
 
-function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
-}
-
 function TooltipContent({
+  children,
   className,
   sideOffset = 0,
-  children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
-        data-slot="tooltip-content"
-        sideOffset={sideOffset}
         className={cn(
           'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
           className,
         )}
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
         {...props}
       >
         {children}
@@ -45,4 +36,12 @@ function TooltipContent({
   )
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+function TooltipProvider({ delayDuration = 0, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from 'clsx'
+import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {

--- a/packages/ui/vitest.config.mts
+++ b/packages/ui/vitest.config.mts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config'
 import { sharedConfig } from '@workspace/config-vitest'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   ...sharedConfig,

--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint \"./**/*.{ts,mjs}\""
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",

--- a/packages/wallet-standard/src/setup.ts
+++ b/packages/wallet-standard/src/setup.ts
@@ -1,4 +1,5 @@
 import { registerWallet } from '@wallet-standard/core'
+
 import { SamuiWallet } from './wallet'
 
 export function setup() {

--- a/packages/wallet-standard/src/wallet.ts
+++ b/packages/wallet-standard/src/wallet.ts
@@ -10,6 +10,7 @@ import {
   type SolanaSignTransactionFeature,
 } from '@solana/wallet-standard-features'
 import {
+  type IdentifierArray,
   StandardConnect,
   type StandardConnectFeature,
   StandardDisconnect,
@@ -17,39 +18,31 @@ import {
   StandardEvents,
   type StandardEventsFeature,
   type Wallet,
+  type WalletAccount,
   type WalletIcon,
   type WalletVersion,
-  type IdentifierArray,
-  type WalletAccount,
 } from '@wallet-standard/core'
+
 import { connect } from './features/connect'
 import { disconnect } from './features/disconnect'
 import { on } from './features/events'
 import { signAndSendTransaction } from './features/sign-and-send-transaction'
-import { signTransaction } from './features/sign-transaction'
-import { signMessage } from './features/sign-message'
 import { signIn } from './features/sign-in'
+import { signMessage } from './features/sign-message'
+import { signTransaction } from './features/sign-transaction'
 import { icon } from './icon'
 
-type WalletFeatures = StandardConnectFeature &
-  StandardDisconnectFeature &
-  StandardEventsFeature &
-  SolanaSignAndSendTransactionFeature &
-  SolanaSignTransactionFeature &
+type WalletFeatures = SolanaSignAndSendTransactionFeature &
+  SolanaSignInFeature &
   SolanaSignMessageFeature &
-  SolanaSignInFeature
+  SolanaSignTransactionFeature &
+  StandardConnectFeature &
+  StandardDisconnectFeature &
+  StandardEventsFeature
 
 export class SamuiWallet implements Wallet {
-  get version(): WalletVersion {
-    return '1.0.0'
-  }
-
-  get name(): string {
-    return 'Samui'
-  }
-
-  get icon(): WalletIcon {
-    return icon
+  get accounts(): readonly WalletAccount[] {
+    return []
   }
 
   get chains(): IdentifierArray {
@@ -58,40 +51,48 @@ export class SamuiWallet implements Wallet {
 
   get features(): WalletFeatures {
     return {
-      [StandardConnect]: {
-        version: this.version,
-        connect,
-      },
-      [StandardDisconnect]: {
-        version: this.version,
-        disconnect,
-      },
-      [StandardEvents]: {
-        version: this.version,
-        on,
-      },
       [SolanaSignAndSendTransaction]: {
-        version: this.version,
-        supportedTransactionVersions: ['legacy', 0],
         signAndSendTransaction,
-      },
-      [SolanaSignTransaction]: {
-        version: this.version,
         supportedTransactionVersions: ['legacy', 0],
-        signTransaction,
-      },
-      [SolanaSignMessage]: {
         version: this.version,
-        signMessage,
       },
       [SolanaSignIn]: {
-        version: this.version,
         signIn,
+        version: this.version,
+      },
+      [SolanaSignMessage]: {
+        signMessage,
+        version: this.version,
+      },
+      [SolanaSignTransaction]: {
+        signTransaction,
+        supportedTransactionVersions: ['legacy', 0],
+        version: this.version,
+      },
+      [StandardConnect]: {
+        connect,
+        version: this.version,
+      },
+      [StandardDisconnect]: {
+        disconnect,
+        version: this.version,
+      },
+      [StandardEvents]: {
+        on,
+        version: this.version,
       },
     }
   }
 
-  get accounts(): readonly WalletAccount[] {
-    return []
+  get icon(): WalletIcon {
+    return icon
+  }
+
+  get name(): string {
+    return 'Samui'
+  }
+
+  get version(): WalletVersion {
+    return '1.0.0'
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       eslint-plugin-only-warn:
         specifier: ^1.1.0
         version: 1.1.0
+      eslint-plugin-perfectionist:
+        specifier: ^4.15.1
+        version: 4.15.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.37.0(jiti@2.6.1))
@@ -4108,6 +4111,12 @@ packages:
     resolution: {integrity: sha512-2tktqUAT+Q3hCAU0iSf4xAN1k9zOpjK5WO8104mB0rT/dGhOa09582HN5HlbxNbPRZ0THV7nLGvzugcNOSjzfA==}
     engines: {node: '>=6'}
 
+  eslint-plugin-perfectionist@4.15.1:
+    resolution: {integrity: sha512-MHF0cBoOG0XyBf7G0EAFCuJJu4I18wy0zAoT1OHfx2o6EOx1EFTIzr2HGeuZa1kDcusoX0xJ9V7oZmaeFd773Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      eslint: '>=8.45.0'
+
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
     engines: {node: '>=10'}
@@ -5718,6 +5727,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  natural-orderby@5.0.0:
+    resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
+    engines: {node: '>=18'}
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -11628,9 +11641,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.37.0(jiti@2.6.1))
       globals: 16.4.0
@@ -11652,7 +11665,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11663,18 +11676,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11687,7 +11700,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11698,7 +11711,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11717,6 +11730,16 @@ snapshots:
       - supports-color
 
   eslint-plugin-only-warn@1.1.0: {}
+
+  eslint-plugin-perfectionist@4.15.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.37.0(jiti@2.6.1)
+      natural-orderby: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
@@ -13606,6 +13629,8 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  natural-orderby@5.0.0: {}
 
   negotiator@0.6.3: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,9 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
+    "lint:fix": {
+      "dependsOn": ["^lint:fix"]
+    },
     "check-types": {
       "dependsOn": ["^check-types"]
     },

--- a/turbo/generators/templates/pkg/base/package.json.hbs
+++ b/turbo/generators/templates/pkg/base/package.json.hbs
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint \"**/{src}/**/*.{ts,mjs}\""
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/turbo/generators/templates/pkg/react-ui/package.json.hbs
+++ b/turbo/generators/templates/pkg/react-ui/package.json.hbs
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint . --max-warnings 0"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",


### PR DESCRIPTION
This PR adds makes the linting stricter:

- add `lint:fix` workspace command
- consistent `lint` and `lint:fix` scripts across apps and packages 
- add [perfectionist/recommended-alphabetical](https://perfectionist.dev/configs/recommended-alphabetical). a-z FTW 🤓
- enable `@typescript-eslint/consistent-type-imports` to automatically organize imports. Fixes #29 

This should enable in a more consistent repo, less thinking, cleaner git diffs and ultimately a prettier codebase 💅. 