### PR TITLE
fix: enable eslint option --max-warnings=0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix"
   },
   "dependencies": {
     "hono": "^4.9.10"

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -10,8 +10,8 @@
     "compile": "tsc --noEmit",
     "postinstall": "wxt prepare",
     "check-types": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix"
   },
   "dependencies": {
     "@workspace/wallet-standard": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,8 +7,8 @@
     "access": "public"
   },
   "scripts": {
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix",
     "test": "vitest run",
     "test:watch": "vitest --watch"
   },

--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",

--- a/turbo/generators/templates/pkg/base/package.json.hbs
+++ b/turbo/generators/templates/pkg/base/package.json.hbs
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/turbo/generators/templates/pkg/react-ui/package.json.hbs
+++ b/turbo/generators/templates/pkg/react-ui/package.json.hbs
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "check-types": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "eslint . --max-warnings=0 --fix"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",


### PR DESCRIPTION
We had [eslint-plugin-only-warn](https://github.com/samui-build/samui-wallet/blob/fb34fd83f8ee20d0974ec1a07f8bb7dde7f30135/packages/config-eslint/base.js#L34) already configured so the only thing left is add `--max-warnings=0` to the `lint` and `lint:fix` scripts.