### PR TITLE
feat: use zod to define db entities

### DIFF
--- a/packages/db-react/src/db-account-options.tsx
+++ b/packages/db-react/src/db-account-options.tsx
@@ -1,19 +1,23 @@
+import type { AccountInputCreate } from '@workspace/db/dto/account-input-create'
+import type { AccountInputFindMany } from '@workspace/db/dto/account-input-find-many'
+import type { AccountInputUpdate } from '@workspace/db/dto/account-input-update'
+
 import { type MutateOptions, mutationOptions, queryOptions } from '@tanstack/react-query'
 import { db } from '@workspace/db/db'
-import { dbAccountCreate, type DbAccountCreateInput } from '@workspace/db/db-account-create'
+import { dbAccountCreate } from '@workspace/db/db-account-create'
 import { dbAccountDelete } from '@workspace/db/db-account-delete'
-import { dbAccountFindMany, type DbAccountFindManyInput } from '@workspace/db/db-account-find-many'
+import { dbAccountFindMany } from '@workspace/db/db-account-find-many'
 import { dbAccountFindUnique } from '@workspace/db/db-account-find-unique'
-import { dbAccountUpdate, type DbAccountUpdateInput } from '@workspace/db/db-account-update'
+import { dbAccountUpdate } from '@workspace/db/db-account-update'
 
-export type DbAccountCreateMutateOptions = MutateOptions<string, Error, { input: DbAccountCreateInput }>
+export type DbAccountCreateMutateOptions = MutateOptions<string, Error, { input: AccountInputCreate }>
 export type DbAccountDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
-export type DbAccountUpdateMutateOptions = MutateOptions<number, Error, { input: DbAccountUpdateInput }>
+export type DbAccountUpdateMutateOptions = MutateOptions<number, Error, { input: AccountInputUpdate }>
 
 export const dbAccountOptions = {
   create: (props: DbAccountCreateMutateOptions = {}) =>
     mutationOptions({
-      mutationFn: ({ input }: { input: DbAccountCreateInput }) => dbAccountCreate(db, input),
+      mutationFn: ({ input }: { input: AccountInputCreate }) => dbAccountCreate(db, input),
       ...props,
     }),
   delete: (props: DbAccountDeleteMutateOptions = {}) =>
@@ -21,7 +25,7 @@ export const dbAccountOptions = {
       mutationFn: ({ id }: { id: string }) => dbAccountDelete(db, id),
       ...props,
     }),
-  findMany: (input: DbAccountFindManyInput) =>
+  findMany: (input: AccountInputFindMany) =>
     queryOptions({
       queryFn: () => dbAccountFindMany(db, input),
       queryKey: ['dbAccountFindMany', input],
@@ -33,7 +37,7 @@ export const dbAccountOptions = {
     }),
   update: (props: DbAccountUpdateMutateOptions = {}) =>
     mutationOptions({
-      mutationFn: ({ id, input }: { id: string; input: DbAccountUpdateInput }) => dbAccountUpdate(db, id, input),
+      mutationFn: ({ id, input }: { id: string; input: AccountInputUpdate }) => dbAccountUpdate(db, id, input),
       ...props,
     }),
 }

--- a/packages/db-react/src/db-cluster-options.tsx
+++ b/packages/db-react/src/db-cluster-options.tsx
@@ -1,19 +1,23 @@
+import type { ClusterInputCreate } from '@workspace/db/dto/cluster-input-create'
+import type { ClusterInputFindMany } from '@workspace/db/dto/cluster-input-find-many'
+import type { ClusterInputUpdate } from '@workspace/db/dto/cluster-input-update'
+
 import { type MutateOptions, mutationOptions, queryOptions } from '@tanstack/react-query'
 import { db } from '@workspace/db/db'
-import { dbClusterCreate, type DbClusterCreateInput } from '@workspace/db/db-cluster-create'
+import { dbClusterCreate } from '@workspace/db/db-cluster-create'
 import { dbClusterDelete } from '@workspace/db/db-cluster-delete'
-import { dbClusterFindMany, type DbClusterFindManyInput } from '@workspace/db/db-cluster-find-many'
+import { dbClusterFindMany } from '@workspace/db/db-cluster-find-many'
 import { dbClusterFindUnique } from '@workspace/db/db-cluster-find-unique'
-import { dbClusterUpdate, type DbClusterUpdateInput } from '@workspace/db/db-cluster-update'
+import { dbClusterUpdate } from '@workspace/db/db-cluster-update'
 
-export type DbClusterCreateMutateOptions = MutateOptions<string, Error, { input: DbClusterCreateInput }>
+export type DbClusterCreateMutateOptions = MutateOptions<string, Error, { input: ClusterInputCreate }>
 export type DbClusterDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
-export type DbClusterUpdateMutateOptions = MutateOptions<number, Error, { input: DbClusterUpdateInput }>
+export type DbClusterUpdateMutateOptions = MutateOptions<number, Error, { input: ClusterInputUpdate }>
 
 export const dbClusterOptions = {
   create: (props: DbClusterCreateMutateOptions = {}) =>
     mutationOptions({
-      mutationFn: ({ input }: { input: DbClusterCreateInput }) => dbClusterCreate(db, input),
+      mutationFn: ({ input }: { input: ClusterInputCreate }) => dbClusterCreate(db, input),
       ...props,
     }),
   delete: (props: DbClusterDeleteMutateOptions = {}) =>
@@ -21,7 +25,7 @@ export const dbClusterOptions = {
       mutationFn: ({ id }: { id: string }) => dbClusterDelete(db, id),
       ...props,
     }),
-  findMany: (input: DbClusterFindManyInput) =>
+  findMany: (input: ClusterInputFindMany) =>
     queryOptions({
       queryFn: () => dbClusterFindMany(db, input),
       queryKey: ['dbClusterFindMany', input],
@@ -33,7 +37,7 @@ export const dbClusterOptions = {
     }),
   update: (props: DbClusterUpdateMutateOptions) =>
     mutationOptions({
-      mutationFn: ({ id, input }: { id: string; input: DbClusterUpdateInput }) => dbClusterUpdate(db, id, input),
+      mutationFn: ({ id, input }: { id: string; input: ClusterInputUpdate }) => dbClusterUpdate(db, id, input),
       ...props,
     }),
 }

--- a/packages/db-react/src/db-wallet-options.tsx
+++ b/packages/db-react/src/db-wallet-options.tsx
@@ -1,19 +1,23 @@
+import type { WalletInputCreate } from '@workspace/db/dto/wallet-input-create'
+import type { WalletInputFindMany } from '@workspace/db/dto/wallet-input-find-many'
+import type { WalletInputUpdate } from '@workspace/db/dto/wallet-input-update'
+
 import { type MutateOptions, mutationOptions, queryOptions } from '@tanstack/react-query'
 import { db } from '@workspace/db/db'
-import { dbWalletCreate, type DbWalletCreateInput } from '@workspace/db/db-wallet-create'
+import { dbWalletCreate } from '@workspace/db/db-wallet-create'
 import { dbWalletDelete } from '@workspace/db/db-wallet-delete'
-import { dbWalletFindMany, type DbWalletFindManyInput } from '@workspace/db/db-wallet-find-many'
+import { dbWalletFindMany } from '@workspace/db/db-wallet-find-many'
 import { dbWalletFindUnique } from '@workspace/db/db-wallet-find-unique'
-import { dbWalletUpdate, type DbWalletUpdateInput } from '@workspace/db/db-wallet-update'
+import { dbWalletUpdate } from '@workspace/db/db-wallet-update'
 
-export type DbWalletCreateMutateOptions = MutateOptions<string, Error, { input: DbWalletCreateInput }>
+export type DbWalletCreateMutateOptions = MutateOptions<string, Error, { input: WalletInputCreate }>
 export type DbWalletDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
-export type DbWalletUpdateMutateOptions = MutateOptions<number, Error, { input: DbWalletUpdateInput }>
+export type DbWalletUpdateMutateOptions = MutateOptions<number, Error, { input: WalletInputUpdate }>
 
 export const dbWalletOptions = {
   create: (props: DbWalletCreateMutateOptions = {}) =>
     mutationOptions({
-      mutationFn: ({ input }: { input: DbWalletCreateInput }) => dbWalletCreate(db, input),
+      mutationFn: ({ input }: { input: WalletInputCreate }) => dbWalletCreate(db, input),
       ...props,
     }),
   delete: (props: DbWalletDeleteMutateOptions = {}) =>
@@ -21,7 +25,7 @@ export const dbWalletOptions = {
       mutationFn: ({ id }: { id: string }) => dbWalletDelete(db, id),
       ...props,
     }),
-  findMany: (input: DbWalletFindManyInput) =>
+  findMany: (input: WalletInputFindMany) =>
     queryOptions({
       queryFn: () => dbWalletFindMany(db, input),
       queryKey: ['dbWalletFindMany', input],
@@ -33,7 +37,7 @@ export const dbWalletOptions = {
     }),
   update: (props: DbWalletUpdateMutateOptions = {}) =>
     mutationOptions({
-      mutationFn: ({ id, input }: { id: string; input: DbWalletUpdateInput }) => dbWalletUpdate(db, id, input),
+      mutationFn: ({ id, input }: { id: string; input: WalletInputUpdate }) => dbWalletUpdate(db, id, input),
       ...props,
     }),
 }

--- a/packages/db-react/src/use-db-account-find-many.tsx
+++ b/packages/db-react/src/use-db-account-find-many.tsx
@@ -1,9 +1,9 @@
-import type { DbAccountFindManyInput } from '@workspace/db/db-account-find-many'
+import type { AccountInputFindMany } from '@workspace/db/dto/account-input-find-many'
 
 import { useQuery } from '@tanstack/react-query'
 
 import { dbAccountOptions } from './db-account-options'
 
-export function useDbAccountFindMany({ input }: { input: DbAccountFindManyInput }) {
+export function useDbAccountFindMany({ input }: { input: AccountInputFindMany }) {
   return useQuery(dbAccountOptions.findMany(input))
 }

--- a/packages/db-react/src/use-db-cluster-find-many.tsx
+++ b/packages/db-react/src/use-db-cluster-find-many.tsx
@@ -1,9 +1,9 @@
-import type { DbClusterFindManyInput } from '@workspace/db/db-cluster-find-many'
+import type { ClusterInputFindMany } from '@workspace/db/dto/cluster-input-find-many'
 
 import { useQuery } from '@tanstack/react-query'
 
 import { dbClusterOptions } from './db-cluster-options'
 
-export function useDbClusterFindMany({ input }: { input: DbClusterFindManyInput }) {
+export function useDbClusterFindMany({ input }: { input: ClusterInputFindMany }) {
   return useQuery(dbClusterOptions.findMany(input))
 }

--- a/packages/db-react/src/use-db-wallet-find-many.tsx
+++ b/packages/db-react/src/use-db-wallet-find-many.tsx
@@ -1,9 +1,9 @@
-import type { DbWalletFindManyInput } from '@workspace/db/db-wallet-find-many'
+import type { WalletInputFindMany } from '@workspace/db/dto/wallet-input-find-many'
 
 import { useQuery } from '@tanstack/react-query'
 
 import { dbWalletOptions } from './db-wallet-options'
 
-export function useDbWalletFindMany({ input }: { input: DbWalletFindManyInput }) {
+export function useDbWalletFindMany({ input }: { input: WalletInputFindMany }) {
   return useQuery(dbWalletOptions.findMany(input))
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@workspace/core": "workspace:*",
-    "dexie": "^4.2.1"
+    "dexie": "^4.2.1",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/packages/db/src/db-account-create.ts
+++ b/packages/db/src/db-account-create.ts
@@ -1,15 +1,15 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
-import type { Account } from './entity/account'
+import type { AccountInputCreate } from './dto/account-input-create'
 
-export type DbAccountCreateInput = Omit<Account, 'createdAt' | 'id' | 'updatedAt'>
+import { accountSchemaCreate } from './schema/account-schema-create'
 
-export async function dbAccountCreate(db: Database, input: DbAccountCreateInput): Promise<string> {
+export async function dbAccountCreate(db: Database, input: AccountInputCreate): Promise<string> {
   const now = new Date()
   const { data, error } = await tryCatch(
     db.accounts.add({
-      ...input,
+      ...accountSchemaCreate.parse(input),
       createdAt: now,
       id: crypto.randomUUID(),
       updatedAt: now,

--- a/packages/db/src/db-account-find-many.ts
+++ b/packages/db/src/db-account-find-many.ts
@@ -1,20 +1,22 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
+import type { AccountInputFindMany } from './dto/account-input-find-many'
 import type { Account } from './entity/account'
 
-export type DbAccountFindManyInput = Partial<Pick<Account, 'id' | 'name'>>
+import { accountSchemaFindMany } from './schema/account-schema-find-many'
 
-export async function dbAccountFindMany(db: Database, input: DbAccountFindManyInput = {}): Promise<Account[]> {
+export async function dbAccountFindMany(db: Database, input: AccountInputFindMany = {}): Promise<Account[]> {
+  const parsedInput = accountSchemaFindMany.parse(input)
   const { data, error } = await tryCatch(db.accounts.toArray())
   if (error) {
     console.log(error)
     throw new Error(`Error finding accounts`)
   }
   return data.filter((item) => {
-    const matchId = !input.id || item.id === input.id
-    const matchName = !input.name || item.name.includes(input.name)
+    const matchId = !parsedInput.id || item.id === parsedInput.id
+    const matchName = !parsedInput.name || item.name.includes(parsedInput.name)
 
-    return matchName && matchId
+    return matchId && matchName
   })
 }

--- a/packages/db/src/db-account-update.ts
+++ b/packages/db/src/db-account-update.ts
@@ -1,14 +1,14 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
-import type { Account } from './entity/account'
+import type { AccountInputUpdate } from './dto/account-input-update'
 
-export type DbAccountUpdateInput = Partial<Omit<Account, 'createdAt' | 'id' | 'updatedAt'>>
+import { accountSchemaUpdate } from './schema/account-schema-update'
 
-export async function dbAccountUpdate(db: Database, id: string, input: DbAccountUpdateInput): Promise<number> {
+export async function dbAccountUpdate(db: Database, id: string, input: AccountInputUpdate): Promise<number> {
   const { data, error } = await tryCatch(
     db.accounts.update(id, {
-      ...input,
+      ...accountSchemaUpdate.parse(input),
       updatedAt: new Date(),
     }),
   )

--- a/packages/db/src/db-cluster-create.ts
+++ b/packages/db/src/db-cluster-create.ts
@@ -1,15 +1,15 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
-import type { Cluster } from './entity/cluster'
+import type { ClusterInputCreate } from './dto/cluster-input-create'
 
-export type DbClusterCreateInput = Omit<Cluster, 'createdAt' | 'id' | 'updatedAt'>
+import { clusterSchemaCreate } from './schema/cluster-schema-create'
 
-export async function dbClusterCreate(db: Database, input: DbClusterCreateInput): Promise<string> {
+export async function dbClusterCreate(db: Database, input: ClusterInputCreate): Promise<string> {
   const now = new Date()
   const { data, error } = await tryCatch(
     db.clusters.add({
-      ...input,
+      ...clusterSchemaCreate.parse(input),
       createdAt: now,
       id: crypto.randomUUID(),
       updatedAt: now,

--- a/packages/db/src/db-cluster-find-many.ts
+++ b/packages/db/src/db-cluster-find-many.ts
@@ -1,21 +1,23 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
+import type { ClusterInputFindMany } from './dto/cluster-input-find-many'
 import type { Cluster } from './entity/cluster'
 
-export type DbClusterFindManyInput = Partial<Pick<Cluster, 'endpoint' | 'id' | 'name' | 'type'>>
+import { clusterSchemaFindMany } from './schema/cluster-schema-find-many'
 
-export async function dbClusterFindMany(db: Database, input: DbClusterFindManyInput = {}): Promise<Cluster[]> {
+export async function dbClusterFindMany(db: Database, input: ClusterInputFindMany = {}): Promise<Cluster[]> {
+  const parsedInput = clusterSchemaFindMany.parse(input)
   const { data, error } = await tryCatch(db.clusters.toArray())
   if (error) {
     console.log(error)
     throw new Error(`Error finding clusters`)
   }
   return data?.filter((item) => {
-    const matchEndpoint = !input.endpoint || item.endpoint.includes(input.endpoint)
-    const matchId = !input.id || item.id === input.id
-    const matchName = !input.name || item.name.includes(input.name)
-    const matchType = !input.type || item.type === input.type
+    const matchEndpoint = !parsedInput.endpoint || item.endpoint.includes(parsedInput.endpoint)
+    const matchId = !parsedInput.id || item.id === parsedInput.id
+    const matchName = !parsedInput.name || item.name.includes(parsedInput.name)
+    const matchType = !parsedInput.type || item.type === parsedInput.type
 
     return matchName && matchType && matchEndpoint && matchId
   })

--- a/packages/db/src/db-cluster-update.ts
+++ b/packages/db/src/db-cluster-update.ts
@@ -1,14 +1,14 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
-import type { Cluster } from './entity/cluster'
+import type { ClusterInputUpdate } from './dto/cluster-input-update'
 
-export type DbClusterUpdateInput = Partial<Omit<Cluster, 'createdAt' | 'id' | 'updatedAt'>>
+import { clusterSchemaUpdate } from './schema/cluster-schema-update'
 
-export async function dbClusterUpdate(db: Database, id: string, input: DbClusterUpdateInput): Promise<number> {
+export async function dbClusterUpdate(db: Database, id: string, input: ClusterInputUpdate): Promise<number> {
   const { data, error } = await tryCatch(
     db.clusters.update(id, {
-      ...input,
+      ...clusterSchemaUpdate.parse(input),
       updatedAt: new Date(),
     }),
   )

--- a/packages/db/src/db-wallet-create.ts
+++ b/packages/db/src/db-wallet-create.ts
@@ -1,15 +1,15 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
-import type { Wallet } from './entity/wallet'
+import type { WalletInputCreate } from './dto/wallet-input-create'
 
-export type DbWalletCreateInput = Omit<Wallet, 'createdAt' | 'id' | 'updatedAt'>
+import { walletSchemaCreate } from './schema/wallet-schema-create'
 
-export async function dbWalletCreate(db: Database, input: DbWalletCreateInput): Promise<string> {
+export async function dbWalletCreate(db: Database, input: WalletInputCreate): Promise<string> {
   const now = new Date()
   const { data, error } = await tryCatch(
     db.wallets.add({
-      ...input,
+      ...walletSchemaCreate.parse(input),
       createdAt: now,
       id: crypto.randomUUID(),
       updatedAt: now,

--- a/packages/db/src/db-wallet-find-many.ts
+++ b/packages/db/src/db-wallet-find-many.ts
@@ -1,22 +1,23 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
+import type { WalletInputFindMany } from './dto/wallet-input-find-many'
 import type { Wallet } from './entity/wallet'
 
-export type DbWalletFindManyInput = Partial<Pick<Wallet, 'id' | 'name' | 'publicKey' | 'type'>> &
-  Pick<Wallet, 'accountId'>
+import { walletSchemaFindMany } from './schema/wallet-schema-find-many'
 
-export async function dbWalletFindMany(db: Database, input: DbWalletFindManyInput): Promise<Wallet[]> {
-  const { data, error } = await tryCatch(db.wallets.where('accountId').equals(input.accountId).toArray())
+export async function dbWalletFindMany(db: Database, input: WalletInputFindMany): Promise<Wallet[]> {
+  const parsedInput = walletSchemaFindMany.parse(input)
+  const { data, error } = await tryCatch(db.wallets.where('accountId').equals(parsedInput.accountId).toArray())
   if (error) {
     console.log(error)
-    throw new Error(`Error finding wallets for account id ${input.accountId}`)
+    throw new Error(`Error finding wallets for account id ${parsedInput.accountId}`)
   }
   return data?.filter((item) => {
-    const matchId = !input.id || item.id === input.id
-    const matchName = !input.name || item.name.includes(input.name)
-    const matchPublicKey = !input.publicKey || item.publicKey === input.publicKey
-    const matchType = !input.type || item.type === input.type
+    const matchId = !parsedInput.id || item.id === parsedInput.id
+    const matchName = !parsedInput.name || item.name.includes(parsedInput.name)
+    const matchPublicKey = !parsedInput.publicKey || item.publicKey === parsedInput.publicKey
+    const matchType = !parsedInput.type || item.type === parsedInput.type
 
     return matchId && matchName && matchPublicKey && matchType
   })

--- a/packages/db/src/db-wallet-update.ts
+++ b/packages/db/src/db-wallet-update.ts
@@ -1,14 +1,14 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
-import type { Wallet } from './entity/wallet'
+import type { WalletInputUpdate } from './dto/wallet-input-update'
 
-export type DbWalletUpdateInput = Partial<Omit<Wallet, 'createdAt' | 'id' | 'updatedAt'>>
+import { walletSchemaUpdate } from './schema/wallet-schema-update'
 
-export async function dbWalletUpdate(db: Database, id: string, input: DbWalletUpdateInput): Promise<number> {
+export async function dbWalletUpdate(db: Database, id: string, input: WalletInputUpdate): Promise<number> {
   const { data, error } = await tryCatch(
     db.wallets.update(id, {
-      ...input,
+      ...walletSchemaUpdate.parse(input),
       updatedAt: new Date(),
     }),
   )

--- a/packages/db/src/dto/account-input-create.ts
+++ b/packages/db/src/dto/account-input-create.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { accountSchemaCreate } from '../schema/account-schema-create'
+
+export type AccountInputCreate = z.infer<typeof accountSchemaCreate>

--- a/packages/db/src/dto/account-input-find-many.ts
+++ b/packages/db/src/dto/account-input-find-many.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { accountSchemaFindMany } from '../schema/account-schema-find-many'
+
+export type AccountInputFindMany = z.infer<typeof accountSchemaFindMany>

--- a/packages/db/src/dto/account-input-update.ts
+++ b/packages/db/src/dto/account-input-update.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { accountSchemaUpdate } from '../schema/account-schema-update'
+
+export type AccountInputUpdate = z.infer<typeof accountSchemaUpdate>

--- a/packages/db/src/dto/cluster-input-create.ts
+++ b/packages/db/src/dto/cluster-input-create.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { clusterSchemaCreate } from '../schema/cluster-schema-create'
+
+export type ClusterInputCreate = z.infer<typeof clusterSchemaCreate>

--- a/packages/db/src/dto/cluster-input-find-many.ts
+++ b/packages/db/src/dto/cluster-input-find-many.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { clusterSchemaFindMany } from '../schema/cluster-schema-find-many'
+
+export type ClusterInputFindMany = z.infer<typeof clusterSchemaFindMany>

--- a/packages/db/src/dto/cluster-input-update.ts
+++ b/packages/db/src/dto/cluster-input-update.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { clusterSchemaUpdate } from '../schema/cluster-schema-update'
+
+export type ClusterInputUpdate = z.infer<typeof clusterSchemaUpdate>

--- a/packages/db/src/dto/wallet-input-create.ts
+++ b/packages/db/src/dto/wallet-input-create.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { walletSchemaCreate } from '../schema/wallet-schema-create'
+
+export type WalletInputCreate = z.infer<typeof walletSchemaCreate>

--- a/packages/db/src/dto/wallet-input-find-many.ts
+++ b/packages/db/src/dto/wallet-input-find-many.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { walletSchemaFindMany } from '../schema/wallet-schema-find-many'
+
+export type WalletInputFindMany = z.infer<typeof walletSchemaFindMany>

--- a/packages/db/src/dto/wallet-input-update.ts
+++ b/packages/db/src/dto/wallet-input-update.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { walletSchemaUpdate } from '../schema/wallet-schema-update'
+
+export type WalletInputUpdate = z.infer<typeof walletSchemaUpdate>

--- a/packages/db/src/entity/account.ts
+++ b/packages/db/src/entity/account.ts
@@ -1,8 +1,5 @@
-export interface Account {
-  createdAt: Date
-  id: string
-  mnemonic: string
-  name: string
-  secret: string
-  updatedAt: Date
-}
+import type { z } from 'zod'
+
+import type { accountSchema } from '../schema/account-schema'
+
+export type Account = z.infer<typeof accountSchema>

--- a/packages/db/src/entity/cluster-type.ts
+++ b/packages/db/src/entity/cluster-type.ts
@@ -1,1 +1,5 @@
-export type ClusterType = 'solana:devnet' | 'solana:localnet' | 'solana:mainnet' | 'solana:testnet'
+import type { z } from 'zod'
+
+import type { clusterTypeSchema } from '../schema/cluster-type-schema'
+
+export type ClusterType = z.infer<typeof clusterTypeSchema>

--- a/packages/db/src/entity/cluster.ts
+++ b/packages/db/src/entity/cluster.ts
@@ -1,10 +1,5 @@
-import type { ClusterType } from './cluster-type'
+import type { z } from 'zod'
 
-export interface Cluster {
-  createdAt: Date
-  endpoint: string
-  id: string
-  name: string
-  type: ClusterType
-  updatedAt: Date
-}
+import type { clusterSchema } from '../schema/cluster-schema'
+
+export type Cluster = z.infer<typeof clusterSchema>

--- a/packages/db/src/entity/wallet-type.ts
+++ b/packages/db/src/entity/wallet-type.ts
@@ -1,1 +1,5 @@
-export type WalletType = 'Derived' | 'Imported' | 'Watched'
+import type { z } from 'zod'
+
+import type { walletTypeSchema } from '../schema/wallet-type-schema'
+
+export type WalletType = z.infer<typeof walletTypeSchema>

--- a/packages/db/src/entity/wallet.ts
+++ b/packages/db/src/entity/wallet.ts
@@ -1,12 +1,5 @@
-import type { WalletType } from './wallet-type'
+import type { z } from 'zod'
 
-export interface Wallet {
-  accountId: string
-  createdAt: Date
-  id: string
-  name: string
-  publicKey: string
-  secretKey?: string
-  type: WalletType
-  updatedAt: Date
-}
+import type { walletSchema } from '../schema/wallet-schema'
+
+export type Wallet = z.infer<typeof walletSchema>

--- a/packages/db/src/schema/account-schema-create.ts
+++ b/packages/db/src/schema/account-schema-create.ts
@@ -1,0 +1,3 @@
+import { accountSchema } from './account-schema'
+
+export const accountSchemaCreate = accountSchema.omit({ createdAt: true, id: true, updatedAt: true })

--- a/packages/db/src/schema/account-schema-find-many.ts
+++ b/packages/db/src/schema/account-schema-find-many.ts
@@ -1,0 +1,3 @@
+import { accountSchema } from './account-schema'
+
+export const accountSchemaFindMany = accountSchema.pick({ id: true, name: true }).partial()

--- a/packages/db/src/schema/account-schema-update.ts
+++ b/packages/db/src/schema/account-schema-update.ts
@@ -1,0 +1,3 @@
+import { accountSchema } from './account-schema'
+
+export const accountSchemaUpdate = accountSchema.omit({ createdAt: true, id: true, updatedAt: true }).partial()

--- a/packages/db/src/schema/account-schema.ts
+++ b/packages/db/src/schema/account-schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const accountSchema = z.object({
+  createdAt: z.date(),
+  id: z.string(),
+  mnemonic: z.string(),
+  name: z.string(),
+  secret: z.string(),
+  updatedAt: z.date(),
+})

--- a/packages/db/src/schema/cluster-schema-create.ts
+++ b/packages/db/src/schema/cluster-schema-create.ts
@@ -1,0 +1,3 @@
+import { clusterSchema } from './cluster-schema'
+
+export const clusterSchemaCreate = clusterSchema.omit({ createdAt: true, id: true, updatedAt: true })

--- a/packages/db/src/schema/cluster-schema-find-many.ts
+++ b/packages/db/src/schema/cluster-schema-find-many.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+import { clusterSchema } from './cluster-schema'
+
+export const clusterSchemaFindMany = clusterSchema
+  .pick({ endpoint: true, id: true, name: true, type: true })
+  .extend({ endpoint: z.string() })
+  .partial()

--- a/packages/db/src/schema/cluster-schema-update.ts
+++ b/packages/db/src/schema/cluster-schema-update.ts
@@ -1,0 +1,3 @@
+import { clusterSchema } from './cluster-schema'
+
+export const clusterSchemaUpdate = clusterSchema.omit({ createdAt: true, id: true, updatedAt: true }).partial()

--- a/packages/db/src/schema/cluster-schema.ts
+++ b/packages/db/src/schema/cluster-schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+import { clusterTypeSchema } from './cluster-type-schema'
+
+export const clusterSchema = z.object({
+  createdAt: z.date(),
+  endpoint: z.url(),
+  id: z.string(),
+  name: z.string(),
+  type: clusterTypeSchema,
+  updatedAt: z.date(),
+})

--- a/packages/db/src/schema/cluster-type-schema.ts
+++ b/packages/db/src/schema/cluster-type-schema.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod'
+
+export const clusterTypeSchema = z.enum(['solana:devnet', 'solana:localnet', 'solana:mainnet', 'solana:testnet'])

--- a/packages/db/src/schema/wallet-schema-create.ts
+++ b/packages/db/src/schema/wallet-schema-create.ts
@@ -1,0 +1,3 @@
+import { walletSchema } from './wallet-schema'
+
+export const walletSchemaCreate = walletSchema.omit({ createdAt: true, id: true, updatedAt: true })

--- a/packages/db/src/schema/wallet-schema-find-many.ts
+++ b/packages/db/src/schema/wallet-schema-find-many.ts
@@ -1,0 +1,13 @@
+import { walletSchema } from './wallet-schema'
+
+export const walletSchemaFindMany = walletSchema
+  .pick({
+    id: true,
+    name: true,
+    publicKey: true,
+    type: true,
+  })
+  .partial()
+  .extend({
+    accountId: walletSchema.shape.accountId,
+  })

--- a/packages/db/src/schema/wallet-schema-update.ts
+++ b/packages/db/src/schema/wallet-schema-update.ts
@@ -1,0 +1,3 @@
+import { walletSchema } from './wallet-schema'
+
+export const walletSchemaUpdate = walletSchema.omit({ createdAt: true, id: true, updatedAt: true }).partial()

--- a/packages/db/src/schema/wallet-schema.ts
+++ b/packages/db/src/schema/wallet-schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+import { walletTypeSchema } from './wallet-type-schema'
+
+export const walletSchema = z.object({
+  accountId: z.string(),
+  createdAt: z.date(),
+  id: z.string(),
+  name: z.string(),
+  publicKey: z.string(),
+  secretKey: z.string().optional(),
+  type: walletTypeSchema,
+  updatedAt: z.date(),
+})

--- a/packages/db/src/schema/wallet-type-schema.ts
+++ b/packages/db/src/schema/wallet-type-schema.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod'
+
+export const walletTypeSchema = z.enum(['Derived', 'Imported', 'Watched'])

--- a/packages/db/test/db-account-create.test.ts
+++ b/packages/db/test/db-account-create.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbAccountCreateInput } from '../src/db-account-create'
+import type { AccountInputCreate } from '../src/dto/account-input-create'
 
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindMany } from '../src/db-account-find-many'
@@ -19,7 +19,7 @@ describe('db-account-create', () => {
     it('should create an account', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
+      const input: AccountInputCreate = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
 
       // ACT
       await dbAccountCreate(db, input)
@@ -42,7 +42,7 @@ describe('db-account-create', () => {
     it('should throw an error when creating an account fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbAccountCreateInput = { mnemonic: 'baz', name: 'test', secret: 'bar' }
+      const input: AccountInputCreate = { mnemonic: 'baz', name: 'test', secret: 'bar' }
       vi.spyOn(db.accounts, 'add').mockImplementationOnce(
         () => Promise.reject(new Error('Test error')) as PromiseExtended<string>,
       )

--- a/packages/db/test/db-account-delete.test.ts
+++ b/packages/db/test/db-account-delete.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbAccountCreateInput } from '../src/db-account-create'
+import type { AccountInputCreate } from '../src/dto/account-input-create'
 
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountDelete } from '../src/db-account-delete'
@@ -20,7 +20,7 @@ describe('db-account-delete', () => {
     it('should delete an account', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
+      const input: AccountInputCreate = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
       const id = await dbAccountCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-account-find-many.test.ts
+++ b/packages/db/test/db-account-find-many.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbAccountCreateInput } from '../src/db-account-create'
+import type { AccountInputCreate } from '../src/dto/account-input-create'
 import type { Account } from '../src/entity/account'
 
 import { dbAccountCreate } from '../src/db-account-create'
@@ -20,9 +20,9 @@ describe('db-account-find-many', () => {
     it('should find many accounts by a partial name', async () => {
       // ARRANGE
       expect.assertions(2)
-      const account1: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Alpha', secret: 's' }
-      const account2: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Beta', secret: 's' }
-      const account3: DbAccountCreateInput = { mnemonic: 'm', name: 'Another One', secret: 's' }
+      const account1: AccountInputCreate = { mnemonic: 'm', name: 'Test Account Alpha', secret: 's' }
+      const account2: AccountInputCreate = { mnemonic: 'm', name: 'Test Account Beta', secret: 's' }
+      const account3: AccountInputCreate = { mnemonic: 'm', name: 'Another One', secret: 's' }
       await dbAccountCreate(db, account1)
       await dbAccountCreate(db, account2)
       await dbAccountCreate(db, account3)
@@ -38,8 +38,8 @@ describe('db-account-find-many', () => {
     it('should find many accounts by id', async () => {
       // ARRANGE
       expect.assertions(2)
-      const account1: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Alpha', secret: 's' }
-      const account2: DbAccountCreateInput = { mnemonic: 'm', name: 'Test Account Beta', secret: 's' }
+      const account1: AccountInputCreate = { mnemonic: 'm', name: 'Test Account Alpha', secret: 's' }
+      const account2: AccountInputCreate = { mnemonic: 'm', name: 'Test Account Beta', secret: 's' }
       const id1 = await dbAccountCreate(db, account1)
       await dbAccountCreate(db, account2)
 

--- a/packages/db/test/db-account-find-unique.test.ts
+++ b/packages/db/test/db-account-find-unique.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbAccountCreateInput } from '../src/db-account-create'
+import type { AccountInputCreate } from '../src/dto/account-input-create'
 import type { Account } from '../src/entity/account'
 
 import { dbAccountCreate } from '../src/db-account-create'
@@ -20,7 +20,7 @@ describe('db-account-find-unique', () => {
     it('should find a unique account', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
+      const input: AccountInputCreate = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
       const id = await dbAccountCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-account-update.test.ts
+++ b/packages/db/test/db-account-update.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbAccountCreateInput } from '../src/db-account-create'
+import type { AccountInputCreate } from '../src/dto/account-input-create'
 
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindUnique } from '../src/db-account-find-unique'
@@ -20,7 +20,7 @@ describe('db-account-update', () => {
     it('should update an account', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbAccountCreateInput = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
+      const input: AccountInputCreate = { mnemonic: 'baz', name: randomName('account'), secret: 'bar' }
       const id = await dbAccountCreate(db, input)
       const newName = randomName('newName')
 

--- a/packages/db/test/db-cluster-create.test.ts
+++ b/packages/db/test/db-cluster-create.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbClusterCreateInput } from '../src/db-cluster-create'
+import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
 
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindMany } from '../src/db-cluster-find-many'
@@ -19,7 +19,7 @@ describe('db-cluster-create', () => {
     it('should create a cluster', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbClusterCreateInput = {
+      const input: ClusterInputCreate = {
         endpoint: 'http://localhost:8899',
         name: randomName('cluster'),
         type: 'solana:devnet',
@@ -46,7 +46,7 @@ describe('db-cluster-create', () => {
     it('should throw an error when creating a cluster fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbClusterCreateInput = {
+      const input: ClusterInputCreate = {
         endpoint: 'http://localhost:8899',
         name: 'test',
         type: 'solana:devnet',
@@ -57,6 +57,19 @@ describe('db-cluster-create', () => {
 
       // ACT & ASSERT
       await expect(dbClusterCreate(db, input)).rejects.toThrow('Error creating cluster')
+    })
+
+    it('should throw an error with an invalid endpoint', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input: ClusterInputCreate = {
+        endpoint: 'not-a-url',
+        name: randomName('cluster'),
+        type: 'solana:devnet',
+      }
+
+      // ACT & ASSERT
+      await expect(dbClusterCreate(db, input)).rejects.toThrow()
     })
   })
 })

--- a/packages/db/test/db-cluster-delete.test.ts
+++ b/packages/db/test/db-cluster-delete.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbClusterCreateInput } from '../src/db-cluster-create'
+import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
 
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterDelete } from '../src/db-cluster-delete'
@@ -20,7 +20,7 @@ describe('db-cluster', () => {
     it('should delete a cluster', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbClusterCreateInput = {
+      const input: ClusterInputCreate = {
         endpoint: 'http://localhost:8899',
         name: randomName('cluster'),
         type: 'solana:devnet',

--- a/packages/db/test/db-cluster-find-many.test.ts
+++ b/packages/db/test/db-cluster-find-many.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbClusterCreateInput } from '../src/db-cluster-create'
+import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
 import type { Cluster } from '../src/entity/cluster'
 
 import { dbClusterCreate } from '../src/db-cluster-create'
@@ -20,15 +20,15 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial name', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:devnet' }
-      const cluster3: DbClusterCreateInput = { endpoint: 'ep3', name: 'Another One', type: 'solana:devnet' }
+      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
+      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
+      const cluster3: ClusterInputCreate = { endpoint: 'https://some.co', name: 'Another One', type: 'solana:devnet' }
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
 
       // ACT
-      const items = await dbClusterFindMany(db, { name: 'Test Cluster' })
+      const items = await dbClusterFindMany(db, { name: 'Test' })
 
       // ASSERT
       expect(items).toHaveLength(2)
@@ -38,8 +38,8 @@ describe('db-cluster', () => {
     it('should find many clusters by id', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:mainnet' }
+      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
+      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
       const id1 = await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
 
@@ -54,9 +54,9 @@ describe('db-cluster', () => {
     it('should find many clusters by type', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:mainnet' }
-      const cluster3: DbClusterCreateInput = { endpoint: 'ep3', name: 'Another One', type: 'solana:devnet' }
+      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
+      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
+      const cluster3: ClusterInputCreate = { endpoint: 'https://test.co', name: 'Another One', type: 'solana:devnet' }
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
@@ -72,21 +72,9 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial endpoint', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = {
-        endpoint: 'http://test.com',
-        name: 'Test Cluster Alpha',
-        type: 'solana:devnet',
-      }
-      const cluster2: DbClusterCreateInput = {
-        endpoint: 'http://test.com',
-        name: 'Test Cluster Beta',
-        type: 'solana:devnet',
-      }
-      const cluster3: DbClusterCreateInput = {
-        endpoint: 'http://another.com',
-        name: 'Another One',
-        type: 'solana:devnet',
-      }
+      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
+      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
+      const cluster3: ClusterInputCreate = { endpoint: 'https://some.co', name: 'Another One', type: 'solana:devnet' }
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
@@ -102,9 +90,9 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial name and type', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: DbClusterCreateInput = { endpoint: 'ep1', name: 'Test Cluster Alpha', type: 'solana:devnet' }
-      const cluster2: DbClusterCreateInput = { endpoint: 'ep2', name: 'Test Cluster Beta', type: 'solana:mainnet' }
-      const cluster3: DbClusterCreateInput = { endpoint: 'ep3', name: 'Another One', type: 'solana:devnet' }
+      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
+      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
+      const cluster3: ClusterInputCreate = { endpoint: 'https://some.co', name: 'Another One', type: 'solana:devnet' }
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)

--- a/packages/db/test/db-cluster-find-unique.test.ts
+++ b/packages/db/test/db-cluster-find-unique.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbClusterCreateInput } from '../src/db-cluster-create'
+import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
 import type { Cluster } from '../src/entity/cluster'
 
 import { dbClusterCreate } from '../src/db-cluster-create'
@@ -20,7 +20,7 @@ describe('db-cluster', () => {
     it('should find a unique cluster', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbClusterCreateInput = {
+      const input: ClusterInputCreate = {
         endpoint: 'http://localhost:8899',
         name: randomName('cluster'),
         type: 'solana:devnet',

--- a/packages/db/test/db-cluster-update.test.ts
+++ b/packages/db/test/db-cluster-update.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbClusterCreateInput } from '../src/db-cluster-create'
+import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
 
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
@@ -20,7 +20,7 @@ describe('db-cluster', () => {
     it('should update a cluster', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbClusterCreateInput = {
+      const input: ClusterInputCreate = {
         endpoint: 'http://localhost:8899',
         name: randomName('cluster'),
         type: 'solana:devnet',

--- a/packages/db/test/db-wallet-create.test.ts
+++ b/packages/db/test/db-wallet-create.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbWalletCreateInput } from '../src/db-wallet-create'
+import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindMany } from '../src/db-wallet-find-many'
@@ -20,7 +20,7 @@ describe('db-wallet-create', () => {
       // ARRANGE
       expect.assertions(1)
       const accountId = crypto.randomUUID()
-      const input: DbWalletCreateInput = {
+      const input: WalletInputCreate = {
         accountId,
         name: randomName('wallet'),
         publicKey: crypto.randomUUID(),
@@ -48,7 +48,7 @@ describe('db-wallet-create', () => {
     it('should throw an error when creating a wallet fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbWalletCreateInput = {
+      const input: WalletInputCreate = {
         accountId: 'test-account',
         name: 'test',
         publicKey: 'test-pk',

--- a/packages/db/test/db-wallet-delete.test.ts
+++ b/packages/db/test/db-wallet-delete.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbWalletCreateInput } from '../src/db-wallet-create'
+import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletDelete } from '../src/db-wallet-delete'
@@ -20,7 +20,7 @@ describe('db-wallet-delete', () => {
     it('should delete a wallet', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: DbWalletCreateInput = {
+      const input: WalletInputCreate = {
         accountId: crypto.randomUUID(),
         name: randomName('wallet'),
         publicKey: crypto.randomUUID(),

--- a/packages/db/test/db-wallet-find-many.test.ts
+++ b/packages/db/test/db-wallet-find-many.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbWalletCreateInput } from '../src/db-wallet-create'
+import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindMany } from '../src/db-wallet-find-many'
@@ -19,19 +19,19 @@ describe('db-wallet-find-many', () => {
       expect.assertions(2)
       const accountId1 = crypto.randomUUID()
       const accountId2 = crypto.randomUUID()
-      const wallet1: DbWalletCreateInput = {
+      const wallet1: WalletInputCreate = {
         accountId: accountId1,
         name: randomName('wallet-1'),
         publicKey: crypto.randomUUID(),
         type: 'Derived',
       }
-      const wallet2: DbWalletCreateInput = {
+      const wallet2: WalletInputCreate = {
         accountId: accountId1,
         name: randomName('wallet-2'),
         publicKey: crypto.randomUUID(),
         type: 'Imported',
       }
-      const wallet3: DbWalletCreateInput = {
+      const wallet3: WalletInputCreate = {
         accountId: accountId2,
         name: randomName('wallet-3'),
         publicKey: crypto.randomUUID(),
@@ -53,19 +53,19 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: DbWalletCreateInput = {
+      const wallet1: WalletInputCreate = {
         accountId,
         name: 'Trading Wallet',
         publicKey: crypto.randomUUID(),
         type: 'Derived',
       }
-      const wallet2: DbWalletCreateInput = {
+      const wallet2: WalletInputCreate = {
         accountId,
         name: 'Staking Wallet',
         publicKey: crypto.randomUUID(),
         type: 'Imported',
       }
-      const wallet3: DbWalletCreateInput = {
+      const wallet3: WalletInputCreate = {
         accountId,
         name: 'Savings',
         publicKey: crypto.randomUUID(),
@@ -87,19 +87,19 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: DbWalletCreateInput = {
+      const wallet1: WalletInputCreate = {
         accountId,
         name: 'Trading Wallet',
         publicKey: crypto.randomUUID(),
         type: 'Derived',
       }
-      const wallet2: DbWalletCreateInput = {
+      const wallet2: WalletInputCreate = {
         accountId,
         name: 'Staking Wallet',
         publicKey: crypto.randomUUID(),
         type: 'Imported',
       }
-      const wallet3: DbWalletCreateInput = {
+      const wallet3: WalletInputCreate = {
         accountId,
         name: 'Savings Wallet',
         publicKey: crypto.randomUUID(),
@@ -121,25 +121,25 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: DbWalletCreateInput = {
+      const wallet1: WalletInputCreate = {
         accountId,
         name: 'Trading Wallet',
         publicKey: crypto.randomUUID(),
         type: 'Derived',
       }
-      const wallet2: DbWalletCreateInput = {
+      const wallet2: WalletInputCreate = {
         accountId,
         name: 'Staking Wallet',
         publicKey: crypto.randomUUID(),
         type: 'Imported',
       }
-      const wallet3: DbWalletCreateInput = {
+      const wallet3: WalletInputCreate = {
         accountId,
         name: 'Savings',
         publicKey: crypto.randomUUID(),
         type: 'Watched',
       }
-      const wallet4: DbWalletCreateInput = {
+      const wallet4: WalletInputCreate = {
         accountId,
         name: 'Another Trading Wallet',
         publicKey: crypto.randomUUID(),
@@ -162,13 +162,13 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: DbWalletCreateInput = {
+      const wallet1: WalletInputCreate = {
         accountId,
         name: 'Wallet 1',
         publicKey: crypto.randomUUID(),
         type: 'Derived',
       }
-      const wallet2: DbWalletCreateInput = {
+      const wallet2: WalletInputCreate = {
         accountId,
         name: 'Wallet 2',
         publicKey: crypto.randomUUID(),
@@ -189,13 +189,13 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: DbWalletCreateInput = {
+      const wallet1: WalletInputCreate = {
         accountId,
         name: 'Wallet 1',
         publicKey: crypto.randomUUID(),
         type: 'Derived',
       }
-      const wallet2: DbWalletCreateInput = {
+      const wallet2: WalletInputCreate = {
         accountId,
         name: 'Wallet 2',
         publicKey: crypto.randomUUID(),

--- a/packages/db/test/db-wallet-find-unique.test.ts
+++ b/packages/db/test/db-wallet-find-unique.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbWalletCreateInput } from '../src/db-wallet-create'
+import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 import type { Wallet } from '../src/entity/wallet'
 
 import { dbWalletCreate } from '../src/db-wallet-create'
@@ -20,7 +20,7 @@ describe('db-wallet-find-unique', () => {
     it('should find a unique wallet', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbWalletCreateInput = {
+      const input: WalletInputCreate = {
         accountId: crypto.randomUUID(),
         name: randomName('wallet'),
         publicKey: crypto.randomUUID(),

--- a/packages/db/test/db-wallet-update.test.ts
+++ b/packages/db/test/db-wallet-update.test.ts
@@ -2,7 +2,7 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DbWalletCreateInput } from '../src/db-wallet-create'
+import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
@@ -20,7 +20,7 @@ describe('db-wallet-update', () => {
     it('should update a wallet', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: DbWalletCreateInput = {
+      const input: WalletInputCreate = {
         accountId: crypto.randomUUID(),
         name: randomName('wallet'),
         publicKey: crypto.randomUUID(),

--- a/packages/features/src/dev/dev-routes.tsx
+++ b/packages/features/src/dev/dev-routes.tsx
@@ -1,4 +1,4 @@
-import type { DbClusterFindManyInput } from '@workspace/db/db-cluster-find-many'
+import type { ClusterInputFindMany } from '@workspace/db/dto/cluster-input-find-many'
 import type { ClusterType } from '@workspace/db/entity/cluster-type'
 
 import { useDbClusterFindMany } from '@workspace/db-react/use-db-cluster-find-many'
@@ -46,7 +46,7 @@ function DevClusterSelect({ select }: { select: (type: ClusterType | undefined) 
   )
 }
 function DevDbClusterFindMany() {
-  const [input, setInput] = useState<DbClusterFindManyInput>({})
+  const [input, setInput] = useState<ClusterInputFindMany>({})
   const query = useDbClusterFindMany({ input })
 
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     vitest:
       specifier: 3.2.4
       version: 3.2.4
+    zod:
+      specifier: ^4.1.12
+      version: 4.1.12
 
 importers:
 
@@ -370,6 +373,9 @@ importers:
       dexie:
         specifier: ^4.2.1
         version: 4.2.1
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.12
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -11768,9 +11774,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.37.0(jiti@2.6.1))
       globals: 16.4.0
@@ -11792,7 +11798,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11803,18 +11809,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11827,7 +11833,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11838,7 +11844,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   typescript: 5.9.3
   typescript-eslint: 8.46.0
   vitest: 3.2.4
+  zod: ^4.1.12
 minimumReleaseAge: 1440
 packages:
   - 'apps/*'


### PR DESCRIPTION
This PR refactors the database entities to using a Zod schema as the source of truth and infer the types from that.

This is in preparation for the work done in #47 where we want to validate the form using a Zod schema.