### PR TITLE
feat: improve keypair generation and helpers

### DIFF
--- a/packages/core/src/ellipsify.ts
+++ b/packages/core/src/ellipsify.ts
@@ -1,0 +1,8 @@
+export function ellipsify(str: string = '', len: number = 4, delimiter: string = '..'): string {
+  if (!str || typeof str !== 'string') {
+    return ''
+  }
+  const strLen = str.length
+  const limit = len * 2 + delimiter.length
+  return strLen >= limit ? str.substring(0, len) + delimiter + str.substring(strLen - len, strLen) : str
+}

--- a/packages/keypair/src/convert-byte-array-to-json.spec.ts
+++ b/packages/keypair/src/convert-byte-array-to-json.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertByteArrayToJson } from './convert-byte-array-to-json'
+
+describe('convert-byte-array-to-json', () => {
+  describe('expected behavior', () => {
+    it('should convert a byte array to a JSON string', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const byteArray = new Uint8Array([1, 2, 3, 4, 5])
+      const expectedJson = '[1,2,3,4,5]'
+
+      // ACT
+      const result = convertByteArrayToJson(byteArray)
+
+      // ASSERT
+      expect(result).toBe(expectedJson)
+    })
+
+    it('should return an empty JSON array string for an empty byte array', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const byteArray = new Uint8Array([])
+      const expectedJson = '[]'
+
+      // ACT
+      const result = convertByteArrayToJson(byteArray)
+
+      // ASSERT
+      expect(result).toBe(expectedJson)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid input type', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidInput = [1, 2, 3, 4, 5]
+
+      // ACT & ASSERT
+      // @ts-expect-error: testing invalid input
+      expect(() => convertByteArrayToJson(invalidInput)).toThrow(`Invalid input: expected a Uint8Array`)
+    })
+  })
+})

--- a/packages/keypair/src/convert-byte-array-to-json.ts
+++ b/packages/keypair/src/convert-byte-array-to-json.ts
@@ -1,0 +1,6 @@
+export function convertByteArrayToJson(byteArray: Uint8Array): string {
+  if (!(byteArray instanceof Uint8Array)) {
+    throw new Error('Invalid input: expected a Uint8Array')
+  }
+  return JSON.stringify([...byteArray])
+}

--- a/packages/keypair/src/convert-json-to-byte-array.spec.ts
+++ b/packages/keypair/src/convert-json-to-byte-array.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertJsonToByteArray } from './convert-json-to-byte-array'
+
+describe('convert-json-to-byte-array', () => {
+  describe('expected behavior', () => {
+    it('should convert a JSON string to a byte array', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const json = '[1,2,3,4,5]'
+      const expectedByteArray = new Uint8Array([1, 2, 3, 4, 5])
+
+      // ACT
+      const result = convertJsonToByteArray(json)
+
+      // ASSERT
+      expect(result).toEqual(expectedByteArray)
+    })
+
+    it('should return an empty byte array for an empty JSON array string', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const json = '[]'
+      const expectedByteArray = new Uint8Array([])
+
+      // ACT
+      const result = convertJsonToByteArray(json)
+
+      // ASSERT
+      expect(result).toEqual(expectedByteArray)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid input type', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidInput = [1, 2, 3, 4, 5]
+
+      // ACT & ASSERT
+      // @ts-expect-error: testing invalid input
+      expect(() => convertJsonToByteArray(invalidInput)).toThrow(`Invalid input: expected a string`)
+    })
+
+    it('should throw an error for an invalid JSON string', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidJson = 'not a json string'
+
+      // ACT & ASSERT
+      expect(() => convertJsonToByteArray(invalidJson)).toThrow('Invalid JSON: failed to parse')
+    })
+
+    it('should throw an error for a JSON that is not an array', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidJson = '{"foo":"bar"}'
+
+      // ACT & ASSERT
+      expect(() => convertJsonToByteArray(invalidJson)).toThrow('Invalid JSON: expected an array')
+    })
+
+    it('should throw an error for a JSON array with non-numeric values', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidJson = '[1,2,"3",4,5]'
+
+      // ACT & ASSERT
+      expect(() => convertJsonToByteArray(invalidJson)).toThrow(
+        'Invalid JSON: array must contain only numbers between 0 and 255',
+      )
+    })
+
+    it('should throw an error for a JSON array with numbers outside the byte range', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidJson = '[1,2,256,4,5]'
+
+      // ACT & ASSERT
+      expect(() => convertJsonToByteArray(invalidJson)).toThrow(
+        'Invalid JSON: array must contain only numbers between 0 and 255',
+      )
+    })
+  })
+})

--- a/packages/keypair/src/convert-json-to-byte-array.ts
+++ b/packages/keypair/src/convert-json-to-byte-array.ts
@@ -1,0 +1,20 @@
+export function convertJsonToByteArray(json: string): Uint8Array {
+  if (typeof json !== 'string') {
+    throw new Error('Invalid input: expected a string')
+  }
+  try {
+    const arr = JSON.parse(json)
+    if (!Array.isArray(arr)) {
+      throw new Error('Invalid JSON: expected an array')
+    }
+    if (arr.some((item) => typeof item !== 'number' || item < 0 || item > 255)) {
+      throw new Error('Invalid JSON: array must contain only numbers between 0 and 255')
+    }
+    return new Uint8Array(arr)
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('Invalid JSON')) {
+      throw e
+    }
+    throw new Error('Invalid JSON: failed to parse')
+  }
+}

--- a/packages/keypair/src/convert-key-pair-to-json.spec.ts
+++ b/packages/keypair/src/convert-key-pair-to-json.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertKeyPairToJson } from './convert-key-pair-to-json'
+import { createKeyPairSignerFromBip39 } from './create-key-pair-signer-from-bip39'
+
+describe('convert-key-pair-to-json', () => {
+  describe('expected behavior', () => {
+    it('should convert a CryptoKeyPair to a JSON string', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const keyPairSigner = await createKeyPairSignerFromBip39({ extractable: true, mnemonic })
+      const cryptoKeyPair = keyPairSigner.keyPair
+      // prettier-ignore
+      const expectedJson = `[186,78,68,54,63,205,1,141,2,89,45,80,77,168,215,120,56,57,72,222,50,140,31,236,254,35,208,163,138,186,225,18,67,194,241,235,28,5,209,235,248,58,150,42,218,71,43,177,183,62,55,96,216,41,59,146,121,132,223,24,39,109,3,163]`
+
+      // ACT
+      const result = await convertKeyPairToJson(cryptoKeyPair)
+
+      // ASSERT
+      expect(result).toBe(expectedJson)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error if the key is not extractable', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const keyPairSigner = await createKeyPairSignerFromBip39({ extractable: false, mnemonic })
+      const cryptoKeyPair = keyPairSigner.keyPair
+
+      // ACT & ASSERT
+      await expect(convertKeyPairToJson(cryptoKeyPair)).rejects.toThrow('key is not extractable')
+    })
+  })
+})

--- a/packages/keypair/src/convert-key-pair-to-json.ts
+++ b/packages/keypair/src/convert-key-pair-to-json.ts
@@ -1,0 +1,8 @@
+import { convertByteArrayToJson } from './convert-byte-array-to-json'
+import { extractByteArrayFromCryptoKeyPair } from './extract-byte-array-from-crypto-key-pair'
+
+export async function convertKeyPairToJson(keypair: CryptoKeyPair): Promise<string> {
+  const byteArray = await extractByteArrayFromCryptoKeyPair(keypair)
+
+  return convertByteArrayToJson(byteArray)
+}

--- a/packages/keypair/src/create-hdkey-from-mnemonic.spec.ts
+++ b/packages/keypair/src/create-hdkey-from-mnemonic.spec.ts
@@ -1,0 +1,44 @@
+import { HDKey } from 'micro-key-producer/slip10.js'
+import { describe, expect, it } from 'vitest'
+
+import { createHDKeyFromMnemonic } from './create-hdkey-from-mnemonic'
+
+describe('create-hdkey-from-mnemonic', () => {
+  describe('expected behavior', () => {
+    it('should create an HDKey from a mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+
+      // ACT
+      const result = await createHDKeyFromMnemonic({ mnemonic })
+
+      // ASSERT
+      expect(result).toBeInstanceOf(HDKey)
+    })
+
+    it('should create an HDKey from a mnemonic with a passphrase', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const passphrase = 'test-passphrase'
+
+      // ACT
+      const result = await createHDKeyFromMnemonic({ mnemonic, passphrase })
+
+      // ASSERT
+      expect(result).toBeInstanceOf(HDKey)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'this is not a valid mnemonic'
+
+      // ACT & ASSERT
+      await expect(createHDKeyFromMnemonic({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+  })
+})

--- a/packages/keypair/src/create-key-pair-signer-from-bip39.spec.ts
+++ b/packages/keypair/src/create-key-pair-signer-from-bip39.spec.ts
@@ -3,26 +3,66 @@ import { describe, expect, it } from 'vitest'
 import { createKeyPairSignerFromBip39 } from './create-key-pair-signer-from-bip39'
 
 describe('create-key-pair-signer-from-bip39', () => {
-  it('should create a keypair signer from a mnemonic', async () => {
-    // ARRANGE
-    expect.assertions(1)
-    const mnemonic = 'afford canoe observe bone master venture shoot erode regular coffee dose cute'
-    const address = 'SFYog9EU62yDjJUAAhwiWvehTkvXNhW4nAbBTFzou3T'
-    // ACT
-    const result = await createKeyPairSignerFromBip39({ mnemonic })
-    // ASSERT
-    expect(result.address).toEqual(address)
+  describe('expected behavior', () => {
+    it('should create a keypair signer from a mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'afford canoe observe bone master venture shoot erode regular coffee dose cute'
+      const address = 'SFYog9EU62yDjJUAAhwiWvehTkvXNhW4nAbBTFzou3T'
+      // ACT
+      const result = await createKeyPairSignerFromBip39({ mnemonic })
+      // ASSERT
+      expect(result.address).toEqual(address)
+    })
+
+    it('should create a keypair signer from a mnemonic with passphrase', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'tower mandate pupil dance furnace scheme wisdom envelope next fantasy flavor merit'
+      const address = 'SFDXaLas2FdpiGn9gtvaxx5jFG7L7QAwY8KvWCu6B5d'
+      const passphrase = 'foobar'
+      // ACT
+      const result = await createKeyPairSignerFromBip39({ mnemonic, passphrase })
+      // ASSERT
+      expect(result.address).toEqual(address)
+    })
   })
 
-  it('should create a keypair signer from a mnemonic with passphrase', async () => {
-    // ARRANGE
-    expect.assertions(1)
-    const mnemonic = 'tower mandate pupil dance furnace scheme wisdom envelope next fantasy flavor merit'
-    const address = 'SFDXaLas2FdpiGn9gtvaxx5jFG7L7QAwY8KvWCu6B5d'
-    const passphrase = 'foobar'
-    // ACT
-    const result = await createKeyPairSignerFromBip39({ mnemonic, passphrase })
-    // ASSERT
-    expect(result.address).toEqual(address)
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'this is not a valid mnemonic'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip39({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for an empty mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = ''
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip39({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a wrong word count', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'one two three'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip39({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a word not in the wordlist', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'dummy canoe observe bone master venture shoot erode regular coffee dose cute'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip39({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
   })
 })

--- a/packages/keypair/src/create-key-pair-signer-from-bip39.ts
+++ b/packages/keypair/src/create-key-pair-signer-from-bip39.ts
@@ -5,9 +5,11 @@ import { createKeyPairSignerFromPrivateKeyBytes } from '@solana/kit'
 import { createSeedFromMnemonic } from './create-seed-from-mnemonic'
 
 export async function createKeyPairSignerFromBip39({
+  extractable = false,
   mnemonic,
   passphrase = '',
 }: {
+  extractable?: boolean
   mnemonic: string
   passphrase?: string
 }): Promise<KeyPairSigner> {
@@ -16,5 +18,5 @@ export async function createKeyPairSignerFromBip39({
   const privateKeyBytes = seed.subarray(0, 32)
 
   // TODO: Address Happy Path blindness
-  return await createKeyPairSignerFromPrivateKeyBytes(new Uint8Array(privateKeyBytes))
+  return await createKeyPairSignerFromPrivateKeyBytes(new Uint8Array(privateKeyBytes), extractable)
 }

--- a/packages/keypair/src/create-key-pair-signer-from-bip44.spec.ts
+++ b/packages/keypair/src/create-key-pair-signer-from-bip44.spec.ts
@@ -3,38 +3,151 @@ import { describe, expect, it } from 'vitest'
 import { createKeyPairSignerFromBip44 } from './create-key-pair-signer-from-bip44'
 
 describe('create-key-pair-signer-from-bip44', () => {
-  it('should create a keypair signer from a mnemonic set', async () => {
-    // ARRANGE
-    expect.assertions(2)
-    const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
-    const addresses = [
-      'Sse6jwfCWiULhm9JYZ8zRCYQW39FavVdsDG3BEPqPLP',
-      'GNmrTk9RSmkbith158xKQoF9jwRwz9jxsPE2xNrvVeGG',
-      '3tsF1zkbPPzyxaBZMGKYFuUA5NHzWEwyLAK6XYhUa8eP',
-      '3fSmpZ2PrWj9ijMpWQKLM7wetzTJmU5GonHbrpSq9v3x',
-    ]
-    // ACT
-    const result = await createKeyPairSignerFromBip44({ mnemonic, to: 4 })
-    // ASSERT
-    expect(result.map((s) => s.address)).toEqual(addresses)
-    expect(result.length).toEqual(4)
+  describe('expected behavior', () => {
+    it('should create a keypair signer from a mnemonic set', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
+      const addresses = [
+        'Sse6jwfCWiULhm9JYZ8zRCYQW39FavVdsDG3BEPqPLP',
+        'GNmrTk9RSmkbith158xKQoF9jwRwz9jxsPE2xNrvVeGG',
+        '3tsF1zkbPPzyxaBZMGKYFuUA5NHzWEwyLAK6XYhUa8eP',
+        '3fSmpZ2PrWj9ijMpWQKLM7wetzTJmU5GonHbrpSq9v3x',
+      ]
+      // ACT
+      const result = await createKeyPairSignerFromBip44({ mnemonic, to: 4 })
+      // ASSERT
+      expect(result.map((s) => s.address)).toEqual(addresses)
+      expect(result.length).toEqual(4)
+    })
+
+    it('should create a keypair signer from a mnemonic set with passphrase', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const mnemonic = 'toy inner shy cup come mansion nurse curtain anger spatial blush vessel'
+      const addresses = [
+        'SBsMscGCqSQiD8YKygSr3zyU9S41EFCMGBbsqDdh4Jx',
+        'Hrue7ZeLn51qKf5N8xX3QYfJS6xXzZCgv2LkKunUfsXs',
+        '7EsaA27a4742Hy5CpEfH8SXKHhiDaDL8JGsSsh1raipS',
+        'EMkbgVEkJpvFXBrceJNJgaioA7bYL3BrafvjZAorfpuy',
+      ]
+      const passphrase = 'foobar'
+      // ACT
+      const result = await createKeyPairSignerFromBip44({ mnemonic, passphrase, to: 4 })
+      // ASSERT
+      expect(result.map((s) => s.address)).toEqual(addresses)
+      expect(result.length).toEqual(4)
+    })
+
+    it('should create a non-extractable keypair by default', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
+
+      // ACT
+      const result = await createKeyPairSignerFromBip44({ mnemonic, to: 1 })
+      if (!result[0]) {
+        throw new Error('keypair not created')
+      }
+      const keyPair = result[0].keyPair
+
+      // ASSERT
+      await expect(crypto.subtle.exportKey('jwk', keyPair.privateKey)).rejects.toThrow('key is not extractable')
+    })
+
+    it('should create an extractable keypair when specified', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
+
+      // ACT
+      const result = await createKeyPairSignerFromBip44({ extractable: true, mnemonic, to: 1 })
+      if (!result[0]) {
+        throw new Error('keypair not created')
+      }
+      const keyPair = result[0].keyPair
+      const jwk = await crypto.subtle.exportKey('jwk', keyPair.privateKey)
+
+      // ASSERT
+      expect(jwk).toBeDefined()
+    })
   })
 
-  it('should create a keypair signer from a mnemonic set with passphrase', async () => {
-    // ARRANGE
-    expect.assertions(2)
-    const mnemonic = 'toy inner shy cup come mansion nurse curtain anger spatial blush vessel'
-    const addresses = [
-      'SBsMscGCqSQiD8YKygSr3zyU9S41EFCMGBbsqDdh4Jx',
-      'Hrue7ZeLn51qKf5N8xX3QYfJS6xXzZCgv2LkKunUfsXs',
-      '7EsaA27a4742Hy5CpEfH8SXKHhiDaDL8JGsSsh1raipS',
-      'EMkbgVEkJpvFXBrceJNJgaioA7bYL3BrafvjZAorfpuy',
-    ]
-    const passphrase = 'foobar'
-    // ACT
-    const result = await createKeyPairSignerFromBip44({ mnemonic, passphrase, to: 4 })
-    // ASSERT
-    expect(result.map((s) => s.address)).toEqual(addresses)
-    expect(result.length).toEqual(4)
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'this is not a valid mnemonic'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ mnemonic, to: 1 })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for an empty mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = ''
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ mnemonic, to: 1 })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a wrong word count', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'one two three'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ mnemonic, to: 1 })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a word not in the wordlist', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'dummy canoe observe bone master venture shoot erode regular coffee dose zebra'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ mnemonic, to: 1 })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error if to is 0', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ mnemonic, to: 0 })).rejects.toThrow('to must be a positive number')
+    })
+
+    it('should throw an error if to is negative', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ mnemonic, to: -1 })).rejects.toThrow('to must be a positive number')
+    })
+
+    it('should throw an error if from is negative', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ from: -1, mnemonic })).rejects.toThrow(
+        'from must be a positive number',
+      )
+    })
+
+    it('should throw an error if to is not greater than from', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'kid search occur scrub tumble dove transfer prevent mirror brush gravity fork'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromBip44({ from: 1, mnemonic, to: 1 })).rejects.toThrow(
+        'to must be greater than from',
+      )
+    })
   })
 })

--- a/packages/keypair/src/create-key-pair-signer-from-json.spec.ts
+++ b/packages/keypair/src/create-key-pair-signer-from-json.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertKeyPairToJson } from './convert-key-pair-to-json'
+import { createKeyPairSignerFromBip39 } from './create-key-pair-signer-from-bip39'
+import { createKeyPairSignerFromJson } from './create-key-pair-signer-from-json'
+
+describe('create-key-pair-signer-from-json', () => {
+  describe('expected behavior', () => {
+    it('should create a KeyPairSigner from a JSON string', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const keyPairSigner = await createKeyPairSignerFromBip39({ extractable: true, mnemonic })
+      const json = await convertKeyPairToJson(keyPairSigner.keyPair)
+
+      // ACT
+      const result = await createKeyPairSignerFromJson({ json })
+
+      // ASSERT
+      expect(result.address).toBe(keyPairSigner.address)
+    })
+
+    it('should create an extractable keypair when specified', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const keyPairSigner = await createKeyPairSignerFromBip39({ extractable: true, mnemonic })
+      const json = await convertKeyPairToJson(keyPairSigner.keyPair)
+
+      // ACT
+      const result = await createKeyPairSignerFromJson({ extractable: true, json })
+      const jwk = await crypto.subtle.exportKey('jwk', result.keyPair.privateKey)
+
+      // ASSERT
+      expect(jwk).toBeDefined()
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error for invalid JSON', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const json = 'invalid-json'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromJson({ json })).rejects.toThrow('Invalid JSON: failed to parse')
+    })
+
+    it('should throw an error for a JSON that is not a 64-byte array', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const json = '[1,2,3]'
+
+      // ACT & ASSERT
+      await expect(createKeyPairSignerFromJson({ json })).rejects.toThrow('Invalid JSON: expected a 64-byte array')
+    })
+  })
+})

--- a/packages/keypair/src/create-key-pair-signer-from-json.ts
+++ b/packages/keypair/src/create-key-pair-signer-from-json.ts
@@ -1,0 +1,21 @@
+import type { KeyPairSigner } from '@solana/kit'
+
+import { createKeyPairSignerFromPrivateKeyBytes } from '@solana/kit'
+
+import { convertJsonToByteArray } from './convert-json-to-byte-array'
+
+export async function createKeyPairSignerFromJson({
+  extractable = false,
+  json,
+}: {
+  extractable?: boolean
+  json: string
+}): Promise<KeyPairSigner> {
+  const byteArray = convertJsonToByteArray(json)
+  if (byteArray.length !== 64) {
+    throw new Error('Invalid JSON: expected a 64-byte array')
+  }
+  const privateKeyBytes = byteArray.slice(0, 32)
+
+  return await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes, extractable)
+}

--- a/packages/keypair/src/create-seed-from-mnemonic.spec.ts
+++ b/packages/keypair/src/create-seed-from-mnemonic.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSeedFromMnemonic } from './create-seed-from-mnemonic'
+
+describe('create-seed-from-mnemonic', () => {
+  describe('expected behavior', () => {
+    it('should create a seed from a mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+
+      // ACT
+      const result = await createSeedFromMnemonic({ mnemonic })
+
+      // ASSERT
+      expect(result).toBeInstanceOf(Uint8Array)
+      expect(result.length).toBe(64)
+    })
+
+    it('should create a seed from a mnemonic with a passphrase', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const passphrase = 'test-passphrase'
+
+      // ACT
+      const result = await createSeedFromMnemonic({ mnemonic, passphrase })
+
+      // ASSERT
+      expect(result).toBeInstanceOf(Uint8Array)
+      expect(result.length).toBe(64)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'this is not a valid mnemonic'
+
+      // ACT & ASSERT
+      await expect(createSeedFromMnemonic({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for an empty mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = ''
+
+      // ACT & ASSERT
+      await expect(createSeedFromMnemonic({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a wrong word count', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'one two three'
+
+      // ACT & ASSERT
+      await expect(createSeedFromMnemonic({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a word not in the wordlist', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'dummy canoe observe bone master venture shoot erode regular coffee dose zebra'
+
+      // ACT & ASSERT
+      await expect(createSeedFromMnemonic({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+  })
+})

--- a/packages/keypair/src/create-seed-from-mnemonic.ts
+++ b/packages/keypair/src/create-seed-from-mnemonic.ts
@@ -1,6 +1,8 @@
 import * as bip39 from '@scure/bip39'
 import { tryCatch } from '@workspace/core/try-catch'
 
+import { validateMnemonic } from './validate-mnemonic'
+
 export async function createSeedFromMnemonic({
   mnemonic,
   passphrase,
@@ -8,7 +10,10 @@ export async function createSeedFromMnemonic({
   mnemonic: string
   passphrase?: string
 }): Promise<Uint8Array> {
+  validateMnemonic({ mnemonic })
+
   const { data, error } = await tryCatch(bip39.mnemonicToSeed(mnemonic, passphrase))
+
   if (error) {
     throw new Error('Error creating seed from mnemonic')
   }

--- a/packages/keypair/src/derivation-paths.ts
+++ b/packages/keypair/src/derivation-paths.ts
@@ -1,0 +1,3 @@
+export const derivationPaths = {
+  default: `m/44'/501'/i'/0'`,
+} as const

--- a/packages/keypair/src/derive-from-mnemonic-at-index.spec.ts
+++ b/packages/keypair/src/derive-from-mnemonic-at-index.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveFromMnemonicAtIndex } from './derive-from-mnemonic-at-index'
+
+describe('derive-from-mnemonic-at-index', () => {
+  describe('expected behavior', () => {
+    it('should derive a wallet at a specific index from a mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const derivationIndex = 1
+      const expectedAddress = 'AWjbG5SH5VEay5ksZbGHHgJhYRhM1rsN5Z538cfFvs4a'
+
+      // ACT
+      const result = await deriveFromMnemonicAtIndex({ derivationIndex, mnemonic })
+
+      // ASSERT
+      expect(result.publicKey).toBe(expectedAddress)
+      expect(result.derivationPath).toContain(`/${derivationIndex}'/`)
+      expect(result.name).toBe('AWjb..vs4a')
+      expect(result.secretKey).toBeDefined()
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'this is not a valid mnemonic'
+
+      // ACT & ASSERT
+      await expect(deriveFromMnemonicAtIndex({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for an empty mnemonic', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = ''
+
+      // ACT & ASSERT
+      await expect(deriveFromMnemonicAtIndex({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a wrong word count', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'one two three'
+
+      // ACT & ASSERT
+      await expect(deriveFromMnemonicAtIndex({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a word not in the wordlist', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'afford canoe observe bone master venture shoot erode regular coffee dose blockchain'
+
+      // ACT & ASSERT
+      await expect(deriveFromMnemonicAtIndex({ mnemonic })).rejects.toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a negative derivation index', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const derivationIndex = -1
+
+      // ACT & ASSERT
+      await expect(deriveFromMnemonicAtIndex({ derivationIndex, mnemonic })).rejects.toThrow(
+        'Error creating KeyPair signer from mnemonic',
+      )
+    })
+  })
+})

--- a/packages/keypair/src/derive-from-mnemonic-at-index.ts
+++ b/packages/keypair/src/derive-from-mnemonic-at-index.ts
@@ -1,0 +1,53 @@
+import { ellipsify } from '@workspace/core/ellipsify'
+import { tryCatch } from '@workspace/core/try-catch'
+
+import { convertKeyPairToJson } from './convert-key-pair-to-json'
+import { createKeyPairSignerFromBip44 } from './create-key-pair-signer-from-bip44'
+import { derivationPaths } from './derivation-paths'
+
+export interface DerivedWallet {
+  derivationPath: string
+  name: string
+  publicKey: string
+  secretKey: string
+}
+export interface DeriveFromMnemonicAtIndexProps {
+  derivationIndex?: number
+  derivationPath?: string
+  mnemonic: string
+}
+
+export async function deriveFromMnemonicAtIndex({
+  derivationIndex = 0,
+  derivationPath = derivationPaths.default,
+  mnemonic,
+}: DeriveFromMnemonicAtIndexProps): Promise<DerivedWallet> {
+  const { data: signers, error } = await tryCatch(
+    createKeyPairSignerFromBip44({
+      derivationPath,
+      extractable: true,
+      from: derivationIndex,
+      mnemonic,
+      to: derivationIndex + 1,
+    }),
+  )
+  if (error) {
+    if (error instanceof Error && error.message.includes('Invalid mnemonic')) {
+      throw error
+    }
+    throw new Error(`Error creating KeyPair signer from mnemonic`)
+  }
+  const signer = signers.length ? signers[0] : undefined
+  if (!signer) {
+    throw new Error(`Error creating KeyPair signer from mnemonic`)
+  }
+
+  const secretKey = await convertKeyPairToJson(signer.keyPair)
+
+  return {
+    derivationPath: derivationPath.replace('i', `${derivationIndex}`),
+    name: ellipsify(signer.address.toString()),
+    publicKey: signer.address.toString(),
+    secretKey,
+  }
+}

--- a/packages/keypair/src/extract-byte-array-from-crypto-key-pair.spec.ts
+++ b/packages/keypair/src/extract-byte-array-from-crypto-key-pair.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertByteArrayToJson } from './convert-byte-array-to-json'
+import { createKeyPairSignerFromBip39 } from './create-key-pair-signer-from-bip39'
+import { extractByteArrayFromCryptoKeyPair } from './extract-byte-array-from-crypto-key-pair'
+
+describe('extract-byte-array-from-crypto-key-pair', () => {
+  describe('expected behavior', () => {
+    it('should extract a 64-byte array representing the private and public keys', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const keyPairSigner = await createKeyPairSignerFromBip39({ extractable: true, mnemonic })
+      const cryptoKeyPair = keyPairSigner.keyPair
+
+      // ACT
+      const result = await extractByteArrayFromCryptoKeyPair(cryptoKeyPair)
+
+      // ASSERT
+      expect(result).toBeInstanceOf(Uint8Array)
+      expect(result.length).toBe(64)
+      // prettier-ignore
+      expect(convertByteArrayToJson(result)).toBe(`[186,78,68,54,63,205,1,141,2,89,45,80,77,168,215,120,56,57,72,222,50,140,31,236,254,35,208,163,138,186,225,18,67,194,241,235,28,5,209,235,248,58,150,42,218,71,43,177,183,62,55,96,216,41,59,146,121,132,223,24,39,109,3,163]`,)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error if the key is not extractable', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+      const keyPairSigner = await createKeyPairSignerFromBip39({ extractable: false, mnemonic })
+      const cryptoKeyPair = keyPairSigner.keyPair
+
+      // ACT & ASSERT
+      await expect(extractByteArrayFromCryptoKeyPair(cryptoKeyPair)).rejects.toThrow('key is not extractable')
+    })
+
+    it('should throw an error for null input', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidInput = null
+
+      // ACT & ASSERT
+      // @ts-expect-error: testing invalid input
+      await expect(extractByteArrayFromCryptoKeyPair(invalidInput)).rejects.toThrow(
+        `Cannot read properties of null (reading 'publicKey')`,
+      )
+    })
+
+    it('should throw an error for undefined input', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidInput = undefined
+
+      // ACT & ASSERT
+      // @ts-expect-error: testing invalid input
+      await expect(extractByteArrayFromCryptoKeyPair(invalidInput)).rejects.toThrow(
+        `Cannot read properties of undefined (reading 'publicKey')`,
+      )
+    })
+
+    it('should throw an error for a non-CryptoKeyPair object', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidInput = {}
+
+      // ACT & ASSERT
+      // @ts-expect-error: testing invalid input
+      await expect(extractByteArrayFromCryptoKeyPair(invalidInput)).rejects.toThrow(
+        `Failed to execute 'exportKey' on 'SubtleCrypto': 2nd argument is not of type CryptoKey.`,
+      )
+    })
+  })
+})

--- a/packages/keypair/src/extract-byte-array-from-crypto-key-pair.ts
+++ b/packages/keypair/src/extract-byte-array-from-crypto-key-pair.ts
@@ -1,0 +1,24 @@
+export async function extractByteArrayFromCryptoKeyPair(keypair: CryptoKeyPair): Promise<Uint8Array> {
+  const [rawPublicKey, privateKeyJwk] = await Promise.all([
+    crypto.subtle.exportKey('raw', keypair.publicKey),
+    crypto.subtle.exportKey('jwk', keypair.privateKey),
+  ])
+
+  if (!privateKeyJwk.d) {
+    throw new Error('Failed to export private key from JWK.')
+  }
+
+  // JWK's 'd' property is Base64URL. It must be converted to standard Base64 before decoding.
+  const base64 = privateKeyJwk.d.replace(/-/g, '+').replace(/_/g, '/')
+  const binaryString = atob(base64)
+  const privateKeyBytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0))
+
+  const publicKeyBytes = new Uint8Array(rawPublicKey)
+
+  // Concatenate the two Uint8Arrays.
+  const combined = new Uint8Array(privateKeyBytes.length + publicKeyBytes.length)
+  combined.set(privateKeyBytes)
+  combined.set(publicKeyBytes, privateKeyBytes.length)
+
+  return combined
+}

--- a/packages/keypair/src/generate-mnemonic.spec.ts
+++ b/packages/keypair/src/generate-mnemonic.spec.ts
@@ -4,27 +4,40 @@ import { generateMnemonic } from './generate-mnemonic'
 import { getMnemonicWordlist } from './get-mnemonic-wordlist'
 
 describe('generate-mnemonic', () => {
-  it('should generate a 12-word mnemonic', async () => {
-    // ARRANGE
-    expect.assertions(3)
-    const wordlist = getMnemonicWordlist()
-    // ACT
-    const result = generateMnemonic()
-    // ASSERT
-    expect(typeof result).toEqual('string')
-    expect(result.split(' ').length).toEqual(12)
-    expect(result.split(' ').every((word) => wordlist.includes(word))).toEqual(true)
+  describe('expected behavior', () => {
+    it('should generate a 12-word mnemonic', () => {
+      // ARRANGE
+      expect.assertions(3)
+      const wordlist = getMnemonicWordlist()
+      // ACT
+      const result = generateMnemonic()
+      // ASSERT
+      expect(typeof result).toEqual('string')
+      expect(result.split(' ').length).toEqual(12)
+      expect(result.split(' ').every((word) => wordlist.includes(word))).toEqual(true)
+    })
+
+    it('should generate a 24-word mnemonic', () => {
+      // ARRANGE
+      expect.assertions(3)
+      const wordlist = getMnemonicWordlist()
+      // ACT
+      const result = generateMnemonic({ strength: 256 })
+      // ASSERT
+      expect(typeof result).toEqual('string')
+      expect(result.split(' ').length).toEqual(24)
+      expect(result.split(' ').every((word) => wordlist.includes(word))).toEqual(true)
+    })
   })
 
-  it('should generate a 24-word mnemonic', async () => {
-    // ARRANGE
-    expect.assertions(3)
-    const wordlist = getMnemonicWordlist()
-    // ACT
-    const result = generateMnemonic({ strength: 256 })
-    // ASSERT
-    expect(typeof result).toEqual('string')
-    expect(result.split(' ').length).toEqual(24)
-    expect(result.split(' ').every((word) => wordlist.includes(word))).toEqual(true)
+  describe('unexpected behavior', () => {
+    it('should throw an error for invalid strength', () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT & ASSERT
+      // @ts-expect-error: testing invalid input
+      expect(() => generateMnemonic({ strength: 512 })).toThrow('strength must be 128 or 256')
+    })
   })
 })

--- a/packages/keypair/src/key-pair-signer.ts
+++ b/packages/keypair/src/key-pair-signer.ts
@@ -1,0 +1,3 @@
+import type { KeyPairSigner } from '@solana/kit'
+
+export type { KeyPairSigner }

--- a/packages/keypair/src/validate-mnemonic.spec.ts
+++ b/packages/keypair/src/validate-mnemonic.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateMnemonic } from './validate-mnemonic'
+
+describe('validate-mnemonic', () => {
+  describe('expected behavior', () => {
+    it('should not throw an error for a valid mnemonic', () => {
+      // ARRANGE
+      const mnemonic = 'pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter'
+
+      // ACT & ASSERT
+      expect(() => validateMnemonic({ mnemonic })).not.toThrow()
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error for an invalid mnemonic', () => {
+      // ARRANGE
+      const mnemonic = 'this is not a valid mnemonic'
+
+      // ACT & ASSERT
+      expect(() => validateMnemonic({ mnemonic })).toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for an empty mnemonic', () => {
+      // ARRANGE
+      const mnemonic = ''
+
+      // ACT & ASSERT
+      expect(() => validateMnemonic({ mnemonic })).toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a wrong word count', () => {
+      // ARRANGE
+      const mnemonic = 'one two three'
+
+      // ACT & ASSERT
+      expect(() => validateMnemonic({ mnemonic })).toThrow('Invalid mnemonic')
+    })
+
+    it('should throw an error for a mnemonic with a word not in the wordlist', () => {
+      // ARRANGE
+      const mnemonic = 'dummy canoe observe bone master venture shoot erode regular coffee dose zebra'
+
+      // ACT & ASSERT
+      expect(() => validateMnemonic({ mnemonic })).toThrow('Invalid mnemonic')
+    })
+  })
+})

--- a/packages/keypair/src/validate-mnemonic.ts
+++ b/packages/keypair/src/validate-mnemonic.ts
@@ -1,0 +1,11 @@
+import * as bip39 from '@scure/bip39'
+
+import { getMnemonicWordlist } from './get-mnemonic-wordlist'
+
+export function validateMnemonic({ mnemonic }: { mnemonic: string }) {
+  const wordlist = getMnemonicWordlist()
+  if (!bip39.validateMnemonic(mnemonic, wordlist)) {
+    throw new Error('Invalid mnemonic')
+  }
+  return mnemonic
+}


### PR DESCRIPTION
- Key pairs can now be marked as extractable (default = false), allowing them to be exported.
- New utility functions have been added to convert key pairs to and from JSON format.
- Input validation has been improved for BIP39 and BIP44 functions, with better error handling for invalid mnemonics and derivation parameters.
- A new helper function is included to simplify deriving a single wallet at a specific index.
- Test coverage has been expanded to include these new features and edge cases.