### PR TITLE
feat: add ui-avatar/ui-icon and button-group

### DIFF
--- a/packages/features/src/dev/dev-routes.tsx
+++ b/packages/features/src/dev/dev-routes.tsx
@@ -13,11 +13,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@workspace/ui/components/select.js'
+import { UiAvatar } from '@workspace/ui/components/ui-avatar.js'
+import { getColorByName, uiColorNames } from '@workspace/ui/lib/get-initials-colors.js'
 import { useMemo, useState } from 'react'
 
 export default function DevRoutes() {
   return (
     <div className="space-y-6">
+      <DevUiAvatars />
+      <DevUiColors />
       <DevDbTables />
       <DevDbClusterFindMany />
     </div>
@@ -45,6 +49,7 @@ function DevClusterSelect({ select }: { select: (type: ClusterType | undefined) 
     </Select>
   )
 }
+
 function DevDbClusterFindMany() {
   const [input, setInput] = useState<ClusterInputFindMany>({})
   const query = useDbClusterFindMany({ input })
@@ -75,6 +80,41 @@ function DevDbTables() {
       </CardHeader>
       <CardContent>
         <pre>{JSON.stringify(tables, null, 2)}</pre>
+      </CardContent>
+    </Card>
+  )
+}
+
+function DevUiAvatars() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>ui avatars</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4 grid-cols-4 justify-items-center">
+        <UiAvatar className="size-16" label="beeman" />
+        <UiAvatar className="size-16" label="tobeycodes" />
+        <UiAvatar className="size-16" label="beeman" src="https://github.com/beeman.png" />
+        <UiAvatar className="size-16" label="tobeycodes" src="https://github.com/tobeycodes.png" />
+      </CardContent>
+    </Card>
+  )
+}
+function DevUiColors() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>ui colors</CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-4 grid-cols-4">
+        {uiColorNames.map((uiColorName) => {
+          const { bg, text } = getColorByName(uiColorName)
+          return (
+            <div className={`${bg} ${text} p-4 text-center`} key={uiColorName}>
+              {uiColorName}
+            </div>
+          )
+        })}
       </CardContent>
     </Card>
   )

--- a/packages/settings/src/data-access/settings-page.ts
+++ b/packages/settings/src/data-access/settings-page.ts
@@ -1,12 +1,8 @@
-import type { LucideProps } from 'lucide-react'
-import type * as react from 'react'
-import type { ForwardRefExoticComponent } from 'react'
-
-export type SettingsIcon = ForwardRefExoticComponent<Omit<LucideProps, 'ref'> & react.RefAttributes<SVGSVGElement>>
+import type { UiIconLucide } from '@workspace/ui/components/ui-icon'
 
 export interface SettingsPage {
   description: string
-  icon: SettingsIcon
+  icon: UiIconLucide
   id: string
   name: string
 }

--- a/packages/settings/src/ui/settings-ui-page-header-icon.tsx
+++ b/packages/settings/src/ui/settings-ui-page-header-icon.tsx
@@ -1,5 +1,0 @@
-import type { SettingsPage } from '../data-access/settings-page.js'
-
-export function SettingsUiPageHeaderIcon({ page: { icon: Icon } }: { page: SettingsPage }) {
-  return <Icon className="h-6 w-6" />
-}

--- a/packages/settings/src/ui/settings-ui-page-header.tsx
+++ b/packages/settings/src/ui/settings-ui-page-header.tsx
@@ -1,12 +1,13 @@
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+
 import type { SettingsPage } from '../data-access/settings-page.js'
 
-import { SettingsUiPageHeaderIcon } from './settings-ui-page-header-icon.js'
 import { SettingsUiPageHeaderTitle } from './settings-ui-page-header-title.js'
 
 export function SettingsUiPageHeader({ page }: { page: SettingsPage }) {
   return (
     <div className="px-2 flex gap-2 items-center">
-      <SettingsUiPageHeaderIcon page={page} />
+      <UiIcon icon={page.icon} />
       <SettingsUiPageHeaderTitle page={page} />
     </div>
   )

--- a/packages/ui/src/components/button-group.tsx
+++ b/packages/ui/src/components/button-group.tsx
@@ -1,0 +1,74 @@
+import { Slot } from '@radix-ui/react-slot'
+import { Separator } from '@workspace/ui/components/separator'
+import { cn } from '@workspace/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2",
+  {
+    defaultVariants: {
+      orientation: 'horizontal',
+    },
+    variants: {
+      orientation: {
+        horizontal:
+          '[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none',
+        vertical:
+          'flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none',
+      },
+    },
+  },
+)
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      data-orientation={orientation}
+      data-slot="button-group"
+      role="group"
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = 'vertical',
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      className={cn('bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto', className)}
+      data-slot="button-group-separator"
+      orientation={orientation}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupText({
+  asChild = false,
+  className,
+  ...props
+}: {
+  asChild?: boolean
+} & React.ComponentProps<'div'>) {
+  const Comp = asChild ? Slot : 'div'
+
+  return (
+    <Comp
+      className={cn(
+        "bg-muted flex items-center gap-2 rounded-md border px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants }

--- a/packages/ui/src/components/ui-avatar.tsx
+++ b/packages/ui/src/components/ui-avatar.tsx
@@ -1,0 +1,18 @@
+import { useMemo } from 'react'
+
+import { getInitialsColor } from '../lib/get-initials-colors.js'
+import { getInitials } from '../lib/get-initials.js'
+import { Avatar, AvatarFallback, AvatarImage } from './avatar.js'
+
+export function UiAvatar({ className, label, src }: { className?: string; label: string; src?: string }) {
+  const initials = useMemo(() => getInitials(label), [label])
+  const { bg, text } = useMemo(() => getInitialsColor(initials), [initials])
+  return (
+    <Avatar className={className}>
+      {src ? <AvatarImage src={src} /> : null}
+      <AvatarFallback className={`${bg} ${text}`} delayMs={src ? 600 : undefined}>
+        {initials}
+      </AvatarFallback>
+    </Avatar>
+  )
+}

--- a/packages/ui/src/components/ui-icon.tsx
+++ b/packages/ui/src/components/ui-icon.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+import type * as react from 'react'
+import type { ForwardRefExoticComponent } from 'react'
+
+export type UiIconLucide = ForwardRefExoticComponent<Omit<LucideProps, 'ref'> & react.RefAttributes<SVGSVGElement>>
+
+export function UiIcon({ className = 'h-6 w-6', icon: Icon }: { className?: string; icon: UiIconLucide }) {
+  return <Icon className={className} />
+}

--- a/packages/ui/src/lib/get-initials-colors.spec.ts
+++ b/packages/ui/src/lib/get-initials-colors.spec.ts
@@ -1,0 +1,25 @@
+/*
+ * From https://github.com/mantinedev/mantine and adapted for Tailwind
+ * MIT License
+ * Copyright (c) 2021 Vitaly Rtishchev
+ */
+import { describe, expect, it } from 'vitest'
+
+import { getInitialsColor } from './get-initials-colors.js'
+
+describe('get-initials-color', () => {
+  it('should return color based on initials', () => {
+    expect(getInitialsColor('John Mol')).toStrictEqual({
+      bg: 'bg-pink-100 dark:bg-pink-900',
+      text: 'text-pink-800 dark:text-pink-300',
+    })
+    expect(getInitialsColor('John')).toStrictEqual({
+      bg: 'bg-lime-100 dark:bg-lime-900',
+      text: 'text-lime-800 dark:text-lime-300',
+    })
+    expect(getInitialsColor('Jane Doe')).toStrictEqual({
+      bg: 'bg-indigo-100 dark:bg-indigo-900',
+      text: 'text-indigo-800 dark:text-indigo-300',
+    })
+  })
+})

--- a/packages/ui/src/lib/get-initials-colors.ts
+++ b/packages/ui/src/lib/get-initials-colors.ts
@@ -1,0 +1,75 @@
+/*
+ * From https://github.com/mantinedev/mantine and adapted for Tailwind
+ * MIT License
+ * Copyright (c) 2021 Vitaly Rtishchev
+ */
+function hashCode(input: string) {
+  let hash = 0
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input.charCodeAt(i)
+    hash = (hash << 5) - hash + char
+    hash |= 0
+  }
+  return hash
+}
+
+const colorMap: Record<UiColorName, UiColorPair> = {
+  blue: { bg: 'bg-blue-100 dark:bg-blue-900', text: 'text-blue-800 dark:text-blue-300' },
+  cyan: { bg: 'bg-cyan-100 dark:bg-cyan-900', text: 'text-cyan-800 dark:text-cyan-300' },
+  green: { bg: 'bg-green-100 dark:bg-green-900', text: 'text-green-800 dark:text-green-300' },
+  indigo: { bg: 'bg-indigo-100 dark:bg-indigo-900', text: 'text-indigo-800 dark:text-indigo-300' },
+  lime: { bg: 'bg-lime-100 dark:bg-lime-900', text: 'text-lime-800 dark:text-lime-300' },
+  orange: { bg: 'bg-orange-100 dark:bg-orange-900', text: 'text-orange-800 dark:text-orange-300' },
+  pink: { bg: 'bg-pink-100 dark:bg-pink-900', text: 'text-pink-800 dark:text-pink-300' },
+  purple: { bg: 'bg-purple-100 dark:bg-purple-900', text: 'text-purple-800 dark:text-purple-300' },
+  red: { bg: 'bg-red-100 dark:bg-red-900', text: 'text-red-800 dark:text-red-300' },
+  teal: { bg: 'bg-teal-100 dark:bg-teal-900', text: 'text-teal-800 dark:text-teal-300' },
+  violet: { bg: 'bg-violet-100 dark:bg-violet-900', text: 'text-violet-800 dark:text-violet-300' },
+  yellow: { bg: 'bg-yellow-100 dark:bg-yellow-900', text: 'text-yellow-800 dark:text-yellow-300' },
+}
+
+// These colors are sorted the same way as here https://tailwindcss.com/docs/colors
+export const uiColorNames: UiColorName[] = [
+  'red',
+  'orange',
+  'yellow',
+  'lime',
+  'green',
+  'teal',
+  'cyan',
+  'blue',
+  'indigo',
+  'violet',
+  'purple',
+  'pink',
+]
+
+export type UiColorName =
+  | 'blue'
+  | 'cyan'
+  | 'green'
+  | 'indigo'
+  | 'lime'
+  | 'orange'
+  | 'pink'
+  | 'purple'
+  | 'red'
+  | 'teal'
+  | 'violet'
+  | 'yellow'
+
+export interface UiColorPair {
+  bg: string
+  text: string
+}
+
+export function getColorByName(colorName: UiColorName): UiColorPair {
+  return colorMap[colorName]
+}
+
+export function getInitialsColor(name: string): UiColorPair {
+  const hash = hashCode(name)
+  const index = Math.abs(hash) % uiColorNames.length
+
+  return getColorByName(uiColorNames[index] ?? 'blue')
+}

--- a/packages/ui/src/lib/get-initials.spec.ts
+++ b/packages/ui/src/lib/get-initials.spec.ts
@@ -1,0 +1,17 @@
+/*
+ * From https://github.com/mantinedev/mantine
+ * MIT License
+ * Copyright (c) 2021 Vitaly Rtishchev
+ */
+import { describe, expect, it } from 'vitest'
+
+import { getInitials } from './get-initials.js'
+
+describe('get-initials', () => {
+  it('should return initials', () => {
+    expect(getInitials('John Mol')).toBe('JM')
+    expect(getInitials('John')).toBe('JO')
+    expect(getInitials('John Doe')).toBe('JD')
+    expect(getInitials('John Doe', 1)).toBe('J')
+  })
+})

--- a/packages/ui/src/lib/get-initials.ts
+++ b/packages/ui/src/lib/get-initials.ts
@@ -1,0 +1,18 @@
+/*
+ * From https://github.com/mantinedev/mantine
+ * MIT License
+ * Copyright (c) 2021 Vitaly Rtishchev
+ */
+export function getInitials(name: string, limit = 2): string {
+  const split = name.split(' ')
+
+  if (split.length === 1) {
+    return name.slice(0, limit).toUpperCase()
+  }
+
+  return split
+    .map((word) => word[0])
+    .slice(0, limit)
+    .join('')
+    .toUpperCase()
+}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,8 +1,9 @@
 @import 'tailwindcss';
+@import 'tw-animate-css';
+
 @source "../../../**/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";
 
-@import 'tw-animate-css';
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
- Adds the button-group from Shadcn
- Creates a custom component for the avatar and icon
- Vendors in and adjusts the get-initials and get-initials-colors from Mantine to make the avatars pretty
 
<img width="820" height="495" alt="image" src="https://github.com/user-attachments/assets/7b87947d-7156-4e00-98ce-65daf2bf9374" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new UI components for avatars, icons, and button groups, and integrate them into the application with updated styles.
> 
>   - **Components**:
>     - Add `ButtonGroup`, `ButtonGroupSeparator`, and `ButtonGroupText` in `button-group.tsx`.
>     - Add `UiAvatar` in `ui-avatar.tsx` using `getInitials` and `getInitialsColor`.
>     - Add `UiIcon` in `ui-icon.tsx`.
>   - **Utilities**:
>     - Add `getInitials` in `get-initials.ts` and `getInitialsColor` in `get-initials-colors.ts`.
>     - Add tests for `getInitials` and `getInitialsColor`.
>   - **Integration**:
>     - Use `UiAvatar` and `UiIcon` in `dev-routes.tsx` and `settings-page.ts`.
>     - Remove `SettingsUiPageHeaderIcon` and replace with `UiIcon` in `settings-ui-page-header.tsx`.
>   - **Styles**:
>     - Update `globals.css` to include new styles and imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ec53fe8400a5d85ddf5145a5cffdc785480d6206. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->