### PR TITLE
feat: make sure to set the activeAccountId when creating the first Account

### DIFF
--- a/packages/db/src/db-account-create.ts
+++ b/packages/db/src/db-account-create.ts
@@ -3,6 +3,8 @@ import { tryCatch } from '@workspace/core/try-catch'
 import type { Database } from './database'
 import type { AccountInputCreate } from './dto/account-input-create'
 
+import { dbPreferenceCreate } from './db-preference-create'
+import { dbPreferenceFindUniqueByKey } from './db-preference-find-unique-by-key'
 import { accountSchemaCreate } from './schema/account-schema-create'
 
 export async function dbAccountCreate(db: Database, input: AccountInputCreate): Promise<string> {
@@ -19,6 +21,11 @@ export async function dbAccountCreate(db: Database, input: AccountInputCreate): 
   if (error) {
     console.log(error)
     throw new Error(`Error creating account`)
+  }
+
+  const activeAccountId = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+  if (!activeAccountId) {
+    await dbPreferenceCreate(db, { key: 'activeAccountId', value: data })
   }
   return data
 }

--- a/packages/db/src/schema/preference-key-schema.ts
+++ b/packages/db/src/schema/preference-key-schema.ts
@@ -1,3 +1,3 @@
 import { z } from 'zod'
 
-export const preferenceKeySchema = z.enum(['activeClusterId'])
+export const preferenceKeySchema = z.enum(['activeAccountId', 'activeClusterId'])

--- a/packages/db/test/db-account-create.test.ts
+++ b/packages/db/test/db-account-create.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindMany } from '../src/db-account-find-many'
+import { dbPreferenceFindUniqueByKey } from '../src/db-preference-find-unique-by-key'
 import { createDbTest, testAccountInputCreate } from './test-helpers'
 
 const db = createDbTest()
@@ -11,6 +12,7 @@ const db = createDbTest()
 describe('db-account-create', () => {
   beforeEach(async () => {
     await db.accounts.clear()
+    await db.preferences.clear()
   })
 
   describe('expected behavior', () => {
@@ -25,6 +27,22 @@ describe('db-account-create', () => {
       // ASSERT
       const items = await dbAccountFindMany(db)
       expect(items.map((i) => i.name)).toContain(input.name)
+    })
+
+    it('should create an account and set activeAccountId preference', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const input = testAccountInputCreate()
+      // ACT
+      const activeAccountIdBefore = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+      const result = await dbAccountCreate(db, input)
+      const activeAccountIdAfter = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+
+      // ASSERT
+      const items = await dbAccountFindMany(db)
+      expect(items.map((i) => i.name)).toContain(input.name)
+      expect(activeAccountIdBefore).toBeNull()
+      expect(activeAccountIdAfter?.value).toBe(result)
     })
   })
 

--- a/packages/settings/src/settings-feature-account-list.tsx
+++ b/packages/settings/src/settings-feature-account-list.tsx
@@ -1,5 +1,7 @@
 import { useDbAccountDelete } from '@workspace/db-react/use-db-account-delete'
 import { useDbAccountLive } from '@workspace/db-react/use-db-account-live'
+import { useDbPreferenceFindUnique } from '@workspace/db-react/use-db-preference-find-unique-by-key'
+import { useDbPreferenceUpdateByKey } from '@workspace/db-react/use-db-preference-update-by-key'
 import { Button } from '@workspace/ui/components/button'
 import { Card, CardContent } from '@workspace/ui/components/card'
 import { toastError } from '@workspace/ui/lib/toast-error'
@@ -18,6 +20,8 @@ export function SettingsFeatureAccountList() {
     onSuccess: () => toastSuccess('Account deleted'),
   })
   const items = useDbAccountLive()
+  const { data } = useDbPreferenceFindUnique({ key: 'activeAccountId' })
+  const { mutateAsync } = useDbPreferenceUpdateByKey('activeAccountId')
 
   return items.length ? (
     <SettingsUiPageCard
@@ -28,7 +32,17 @@ export function SettingsFeatureAccountList() {
       }
       page={page}
     >
-      <SettingsUiAccountList deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })} items={items} />
+      <SettingsUiAccountList
+        activeId={data?.value ?? null}
+        deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })}
+        items={items}
+        setActive={async (item) => {
+          if (!data?.id) {
+            return
+          }
+          await mutateAsync({ input: { value: item.id } })
+        }}
+      />
     </SettingsUiPageCard>
   ) : (
     <Card>

--- a/packages/settings/src/ui/settings-ui-account-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list-item.tsx
@@ -2,20 +2,25 @@ import type { Account } from '@workspace/db/entity/account'
 
 import { Button } from '@workspace/ui/components/button'
 import { Item, ItemActions, ItemContent, ItemTitle } from '@workspace/ui/components/item'
-import { LucidePencil, LucideTrash } from 'lucide-react'
+import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
+import { LucideCheck, LucidePencil, LucideTrash } from 'lucide-react'
 import { Link } from 'react-router'
 
 import { SettingsUiAccountItem } from './settings-ui-account-item.js'
 
 export function SettingsUiAccountListItem({
+  activeId,
   deleteItem,
   item,
+  setActive,
 }: {
+  activeId: null | string
   deleteItem: (item: Account) => Promise<void>
   item: Account
+  setActive: (item: Account) => Promise<void>
 }) {
   return (
-    <Item key={item.id} role="listitem" variant="outline">
+    <Item key={item.id} role="listitem" variant={activeId === item.id ? 'muted' : 'outline'}>
       <ItemContent>
         <ItemTitle className="line-clamp-1">
           <Link to={`./${item.id}`}>
@@ -24,24 +29,42 @@ export function SettingsUiAccountListItem({
         </ItemTitle>
       </ItemContent>
       <ItemActions>
-        <Button asChild size="icon" variant="outline">
-          <Link to={`./${item.id}`}>
-            <LucidePencil className="size-4" />
-          </Link>
-        </Button>
-        <Button
-          onClick={async (e) => {
-            e.preventDefault()
-            if (!window.confirm('Are you sure?')) {
-              return
-            }
-            await deleteItem(item)
-          }}
-          size="icon"
-          variant="outline"
-        >
-          <LucideTrash className="text-red-500 size-4" />
-        </Button>
+        {activeId == item.id ? null : (
+          <UiTooltip content="Set as active">
+            <Button
+              onClick={async (e) => {
+                e.preventDefault()
+                await setActive(item)
+              }}
+              size="icon"
+              variant="outline"
+            >
+              <LucideCheck className="text-green-500 size-4" />
+            </Button>
+          </UiTooltip>
+        )}
+        <UiTooltip content="Edit">
+          <Button asChild size="icon" variant="outline">
+            <Link to={`./${item.id}`}>
+              <LucidePencil className="size-4" />
+            </Link>
+          </Button>
+        </UiTooltip>
+        <UiTooltip content="Delete">
+          <Button
+            onClick={async (e) => {
+              e.preventDefault()
+              if (!window.confirm('Are you sure?')) {
+                return
+              }
+              await deleteItem(item)
+            }}
+            size="icon"
+            variant="outline"
+          >
+            <LucideTrash className="text-red-500 size-4" />
+          </Button>
+        </UiTooltip>
       </ItemActions>
     </Item>
   )

--- a/packages/settings/src/ui/settings-ui-account-list.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list.tsx
@@ -6,16 +6,26 @@ import { ItemGroup } from '@workspace/ui/components/item'
 import { SettingsUiAccountListItem } from './settings-ui-account-list-item.js'
 
 export function SettingsUiAccountList({
+  activeId,
   deleteItem,
   items,
+  setActive,
 }: {
+  activeId: null | string
   deleteItem: (item: Account) => Promise<void>
   items: Array<{ wallets?: Wallet[] } & Account>
+  setActive: (item: Account) => Promise<void>
 }) {
   return (
     <ItemGroup className="gap-4">
       {items.map((item) => (
-        <SettingsUiAccountListItem deleteItem={deleteItem} item={item} key={item.id} />
+        <SettingsUiAccountListItem
+          activeId={activeId}
+          deleteItem={deleteItem}
+          item={item}
+          key={item.id}
+          setActive={setActive}
+        />
       ))}
     </ItemGroup>
   )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set `activeAccountId` when creating the first account and update UI to manage active account status.
> 
>   - **Behavior**:
>     - `dbAccountCreate` in `db-account-create.ts` now sets `activeAccountId` preference if not already set.
>     - Updates `preferenceKeySchema` in `preference-key-schema.ts` to include `activeAccountId`.
>   - **Tests**:
>     - Adds test in `db-account-create.test.ts` to verify `activeAccountId` is set when creating the first account.
>   - **UI**:
>     - `SettingsFeatureAccountList` in `settings-feature-account-list.tsx` now shows active account and allows setting active account.
>     - `SettingsUiAccountListItem` in `settings-ui-account-list-item.tsx` displays a check icon to set an account as active.
>     - `SettingsUiAccountList` in `settings-ui-account-list.tsx` passes `activeId` and `setActive` props to list items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 8e95070dec2992391809fb241cc553d007e3099f. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->