### PR TITLE
feat: make sure to set the activeWalletId when creating the first Wallet

### DIFF
--- a/packages/db/src/db-wallet-create.ts
+++ b/packages/db/src/db-wallet-create.ts
@@ -3,6 +3,8 @@ import { tryCatch } from '@workspace/core/try-catch'
 import type { Database } from './database'
 import type { WalletInputCreate } from './dto/wallet-input-create'
 
+import { dbPreferenceCreate } from './db-preference-create'
+import { dbPreferenceFindUniqueByKey } from './db-preference-find-unique-by-key'
 import { walletSchemaCreate } from './schema/wallet-schema-create'
 
 export async function dbWalletCreate(db: Database, input: WalletInputCreate): Promise<string> {
@@ -21,5 +23,11 @@ export async function dbWalletCreate(db: Database, input: WalletInputCreate): Pr
     console.log(error)
     throw new Error(`Error creating wallet`)
   }
+
+  const activeWalletId = await dbPreferenceFindUniqueByKey(db, 'activeWalletId')
+  if (!activeWalletId) {
+    await dbPreferenceCreate(db, { key: 'activeWalletId', value: data })
+  }
+
   return data
 }

--- a/packages/db/src/schema/preference-key-schema.ts
+++ b/packages/db/src/schema/preference-key-schema.ts
@@ -1,3 +1,3 @@
 import { z } from 'zod'
 
-export const preferenceKeySchema = z.enum(['activeAccountId', 'activeClusterId'])
+export const preferenceKeySchema = z.enum(['activeAccountId', 'activeClusterId', 'activeWalletId'])

--- a/packages/settings/src/settings-feature-account-details.tsx
+++ b/packages/settings/src/settings-feature-account-details.tsx
@@ -1,4 +1,6 @@
 import { useDbAccountFindUnique } from '@workspace/db-react/use-db-account-find-unique'
+import { useDbPreferenceFindUnique } from '@workspace/db-react/use-db-preference-find-unique-by-key'
+import { useDbPreferenceUpdateByKey } from '@workspace/db-react/use-db-preference-update-by-key'
 import { useDbWalletFindMany } from '@workspace/db-react/use-db-wallet-find-many'
 import { Card, CardContent, CardHeader, CardTitle } from '@workspace/ui/components/card'
 import { Spinner } from '@workspace/ui/components/spinner'
@@ -22,6 +24,9 @@ export function SettingsFeatureAccountDetails() {
     isLoading: isLoadingWallets,
     refetch,
   } = useDbWalletFindMany({ input: { accountId } })
+  const { data } = useDbPreferenceFindUnique({ key: 'activeWalletId' })
+  const { mutateAsync } = useDbPreferenceUpdateByKey('activeWalletId')
+
   const deriveWallet = useDeriveAndCreateWallet()
 
   if (isLoading || isLoadingWallets) {
@@ -44,11 +49,18 @@ export function SettingsFeatureAccountDetails() {
       </CardHeader>
       <CardContent className="grid gap-6">
         <SettingsUiWalletTable
+          activeId={data?.value ?? null}
           deriveWallet={async () => {
             await deriveWallet.mutateAsync({ index: wallets?.length ?? 0, item })
             await refetch()
           }}
           items={wallets ?? []}
+          setActive={async (item) => {
+            if (!data?.id) {
+              return
+            }
+            await mutateAsync({ input: { value: item.id } })
+          }}
         />
       </CardContent>
     </Card>

--- a/packages/settings/src/ui/settings-ui-account-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list-item.tsx
@@ -29,7 +29,7 @@ export function SettingsUiAccountListItem({
         </ItemTitle>
       </ItemContent>
       <ItemActions>
-        {activeId == item.id ? null : (
+        {activeId === item.id ? null : (
           <UiTooltip content="Set as active">
             <Button
               onClick={async (e) => {

--- a/packages/settings/src/ui/settings-ui-wallet-table.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-table.tsx
@@ -2,9 +2,20 @@ import type { Wallet } from '@workspace/db/entity/wallet'
 
 import { Button } from '@workspace/ui/components/button'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
-import { LucidePlus } from 'lucide-react'
+import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
+import { LucideCheck, LucidePlus } from 'lucide-react'
 
-export function SettingsUiWalletTable({ deriveWallet, items }: { deriveWallet: () => void; items: Wallet[] }) {
+export function SettingsUiWalletTable({
+  activeId,
+  deriveWallet,
+  items,
+  setActive,
+}: {
+  activeId: null | string
+  deriveWallet: () => void
+  items: Wallet[]
+  setActive: (item: Wallet) => Promise<void>
+}) {
   return (
     <Table>
       <TableHeader>
@@ -12,9 +23,9 @@ export function SettingsUiWalletTable({ deriveWallet, items }: { deriveWallet: (
           <TableHead className="w-[20px]">#</TableHead>
           <TableHead>Name</TableHead>
           <TableHead>PublicKey</TableHead>
-          <TableHead className="flex justify-end pr-0">
-            <Button onClick={deriveWallet} size="sm" variant="outline">
-              <LucidePlus /> Derive Wallet
+          <TableHead className="flex justify-end">
+            <Button onClick={deriveWallet} size="icon" variant="outline">
+              <LucidePlus />
             </Button>
           </TableHead>
         </TableRow>
@@ -24,8 +35,15 @@ export function SettingsUiWalletTable({ deriveWallet, items }: { deriveWallet: (
           <TableRow key={item.id}>
             <TableCell>{item.derivationIndex}</TableCell>
             <TableCell>{item.name}</TableCell>
-            <TableCell className="font-mono text-xs" colSpan={2}>
-              {item.publicKey}
+            <TableCell className="font-mono text-xs">{item.publicKey}</TableCell>
+            <TableCell>
+              {activeId === item.id ? null : (
+                <UiTooltip content="Set as active">
+                  <Button onClick={() => setActive(item)} size="icon" variant="outline">
+                    <LucideCheck className="text-green-500 size-4" />
+                  </Button>
+                </UiTooltip>
+              )}
             </TableCell>
           </TableRow>
         ))}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure `activeWalletId` is set when creating the first wallet and update UI components to handle active wallet state.
> 
>   - **Behavior**:
>     - `dbWalletCreate` in `db-wallet-create.ts` now sets `activeWalletId` if not already set when creating a wallet.
>     - Updates `preferenceKeySchema` in `preference-key-schema.ts` to include `activeWalletId`.
>   - **Tests**:
>     - Adds test in `db-wallet-create.test.ts` to verify `activeWalletId` is set when creating the first wallet.
>   - **UI**:
>     - `SettingsFeatureAccountDetails` and `SettingsUiWalletTable` updated to handle active wallet state.
>     - `SettingsUiAccountListItem` and `SettingsUiWalletTable` updated to allow setting a wallet as active.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 17898196a802e53afb247e66113dc4f8da5a8f5d. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->