### PR TITLE
refactor: dry up tests with input helpers

### DIFF
--- a/packages/db/src/db-preference-create.ts
+++ b/packages/db/src/db-preference-create.ts
@@ -2,11 +2,12 @@ import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from './database'
 import type { PreferenceInputCreate } from './dto/preference-input-create'
+import type { PreferenceKey } from './entity/preference-key'
 
 import { preferenceKeySchema } from './schema/preference-key-schema'
 import { preferenceSchemaCreate } from './schema/preference-schema-create'
 
-export async function dbPreferenceCreate(db: Database, input: PreferenceInputCreate): Promise<string> {
+export async function dbPreferenceCreate(db: Database, input: PreferenceInputCreate): Promise<PreferenceKey> {
   const now = new Date()
   // TODO: Add runtime check to ensure key does not already exist in the table.
 
@@ -14,7 +15,7 @@ export async function dbPreferenceCreate(db: Database, input: PreferenceInputCre
   // Ensure that parsedInput.key exists in the preferenceKeySchema enum
   preferenceKeySchema.parse(parsedInput.key)
 
-  const { data, error } = await tryCatch(
+  const { error } = await tryCatch(
     db.preferences.add({
       ...parsedInput,
       createdAt: now,
@@ -26,5 +27,5 @@ export async function dbPreferenceCreate(db: Database, input: PreferenceInputCre
     console.log(error)
     throw new Error(`Error creating preference`)
   }
-  return data
+  return input.key
 }

--- a/packages/db/src/db-preference-find-unique-by-key.ts
+++ b/packages/db/src/db-preference-find-unique-by-key.ts
@@ -10,5 +10,5 @@ export async function dbPreferenceFindUniqueByKey(db: Database, key: PreferenceK
     console.log(error)
     throw new Error(`Error finding preference with key ${key}`)
   }
-  return data ? data : null
+  return data ?? null
 }

--- a/packages/db/test/db-account-create.test.ts
+++ b/packages/db/test/db-account-create.test.ts
@@ -2,11 +2,9 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AccountInputCreate } from '../src/dto/account-input-create'
-
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindMany } from '../src/db-account-find-many'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testAccountInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -19,12 +17,7 @@ describe('db-account-create', () => {
     it('should create an account', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'baz',
-        name: randomName('account'),
-        secret: 'bar',
-      }
+      const input = testAccountInputCreate()
 
       // ACT
       await dbAccountCreate(db, input)
@@ -47,7 +40,7 @@ describe('db-account-create', () => {
     it('should throw an error when creating an account fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: AccountInputCreate = { derivationPath: 'd', mnemonic: 'baz', name: 'test', secret: 'bar' }
+      const input = testAccountInputCreate()
       vi.spyOn(db.accounts, 'add').mockImplementationOnce(
         () => Promise.reject(new Error('Test error')) as PromiseExtended<string>,
       )

--- a/packages/db/test/db-account-delete.test.ts
+++ b/packages/db/test/db-account-delete.test.ts
@@ -2,12 +2,10 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AccountInputCreate } from '../src/dto/account-input-create'
-
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountDelete } from '../src/db-account-delete'
 import { dbAccountFindUnique } from '../src/db-account-find-unique'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testAccountInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -20,12 +18,7 @@ describe('db-account-delete', () => {
     it('should delete an account', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'baz',
-        name: randomName('account'),
-        secret: 'bar',
-      }
+      const input = testAccountInputCreate()
       const id = await dbAccountCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-account-find-many.test.ts
+++ b/packages/db/test/db-account-find-many.test.ts
@@ -2,12 +2,11 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AccountInputCreate } from '../src/dto/account-input-create'
 import type { Account } from '../src/entity/account'
 
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindMany } from '../src/db-account-find-many'
-import { createDbTest } from './test-helpers'
+import { createDbTest, testAccountInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -20,19 +19,9 @@ describe('db-account-find-many', () => {
     it('should find many accounts by a partial name', async () => {
       // ARRANGE
       expect.assertions(2)
-      const account1: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'm',
-        name: 'Test Account Alpha',
-        secret: 's',
-      }
-      const account2: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'm',
-        name: 'Test Account Beta',
-        secret: 's',
-      }
-      const account3: AccountInputCreate = { derivationPath: 'd', mnemonic: 'm', name: 'Another One', secret: 's' }
+      const account1 = testAccountInputCreate({ name: 'Test Account Alpha' })
+      const account2 = testAccountInputCreate({ name: 'Test Account Beta' })
+      const account3 = testAccountInputCreate({ name: 'Another One' })
       await dbAccountCreate(db, account1)
       await dbAccountCreate(db, account2)
       await dbAccountCreate(db, account3)
@@ -48,18 +37,8 @@ describe('db-account-find-many', () => {
     it('should find many accounts by id', async () => {
       // ARRANGE
       expect.assertions(2)
-      const account1: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'm',
-        name: 'Test Account Alpha',
-        secret: 's',
-      }
-      const account2: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'm',
-        name: 'Test Account Beta',
-        secret: 's',
-      }
+      const account1 = testAccountInputCreate({ name: 'Test Account Alpha' })
+      const account2 = testAccountInputCreate({ name: 'Test Account Beta' })
       const id1 = await dbAccountCreate(db, account1)
       await dbAccountCreate(db, account2)
 

--- a/packages/db/test/db-account-find-unique.test.ts
+++ b/packages/db/test/db-account-find-unique.test.ts
@@ -2,12 +2,11 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AccountInputCreate } from '../src/dto/account-input-create'
 import type { Account } from '../src/entity/account'
 
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindUnique } from '../src/db-account-find-unique'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testAccountInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -20,12 +19,7 @@ describe('db-account-find-unique', () => {
     it('should find a unique account', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'baz',
-        name: randomName('account'),
-        secret: 'bar',
-      }
+      const input = testAccountInputCreate()
       const id = await dbAccountCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-account-update.test.ts
+++ b/packages/db/test/db-account-update.test.ts
@@ -2,12 +2,10 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AccountInputCreate } from '../src/dto/account-input-create'
-
 import { dbAccountCreate } from '../src/db-account-create'
 import { dbAccountFindUnique } from '../src/db-account-find-unique'
 import { dbAccountUpdate } from '../src/db-account-update'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, randomName, testAccountInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -20,12 +18,7 @@ describe('db-account-update', () => {
     it('should update an account', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: AccountInputCreate = {
-        derivationPath: 'd',
-        mnemonic: 'baz',
-        name: randomName('account'),
-        secret: 'bar',
-      }
+      const input = testAccountInputCreate()
       const id = await dbAccountCreate(db, input)
       const newName = randomName('newName')
 

--- a/packages/db/test/db-cluster-create.test.ts
+++ b/packages/db/test/db-cluster-create.test.ts
@@ -2,11 +2,9 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
-
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindMany } from '../src/db-cluster-find-many'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testClusterInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -19,11 +17,7 @@ describe('db-cluster-create', () => {
     it('should create a cluster', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: ClusterInputCreate = {
-        endpoint: 'http://localhost:8899',
-        name: randomName('cluster'),
-        type: 'solana:devnet',
-      }
+      const input = testClusterInputCreate()
 
       // ACT
       await dbClusterCreate(db, input)
@@ -46,11 +40,7 @@ describe('db-cluster-create', () => {
     it('should throw an error when creating a cluster fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: ClusterInputCreate = {
-        endpoint: 'http://localhost:8899',
-        name: 'test',
-        type: 'solana:devnet',
-      }
+      const input = testClusterInputCreate()
       vi.spyOn(db.clusters, 'add').mockImplementationOnce(
         () => Promise.reject(new Error('Test error')) as PromiseExtended<string>,
       )
@@ -62,11 +52,7 @@ describe('db-cluster-create', () => {
     it('should throw an error with an invalid endpoint', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: ClusterInputCreate = {
-        endpoint: 'not-a-url',
-        name: randomName('cluster'),
-        type: 'solana:devnet',
-      }
+      const input = testClusterInputCreate({ endpoint: 'not-a-url' })
 
       // ACT & ASSERT
       await expect(dbClusterCreate(db, input)).rejects.toThrow()

--- a/packages/db/test/db-cluster-delete.test.ts
+++ b/packages/db/test/db-cluster-delete.test.ts
@@ -2,16 +2,14 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
-
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterDelete } from '../src/db-cluster-delete'
 import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testClusterInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
-describe('db-cluster', () => {
+describe('db-cluster-delete', () => {
   beforeEach(async () => {
     await db.clusters.clear()
   })
@@ -20,11 +18,7 @@ describe('db-cluster', () => {
     it('should delete a cluster', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: ClusterInputCreate = {
-        endpoint: 'http://localhost:8899',
-        name: randomName('cluster'),
-        type: 'solana:devnet',
-      }
+      const input = testClusterInputCreate()
       const id = await dbClusterCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-cluster-find-many.test.ts
+++ b/packages/db/test/db-cluster-find-many.test.ts
@@ -2,16 +2,15 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
 import type { Cluster } from '../src/entity/cluster'
 
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindMany } from '../src/db-cluster-find-many'
-import { createDbTest } from './test-helpers'
+import { createDbTest, testClusterInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
-describe('db-cluster', () => {
+describe('db-cluster-find-many', () => {
   beforeEach(async () => {
     await db.clusters.clear()
   })
@@ -20,9 +19,9 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial name', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
-      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
-      const cluster3: ClusterInputCreate = { endpoint: 'https://some.co', name: 'Another One', type: 'solana:devnet' }
+      const cluster1 = testClusterInputCreate({ name: 'Test Alpha' })
+      const cluster2 = testClusterInputCreate({ name: 'Test Beta' })
+      const cluster3 = testClusterInputCreate({ name: 'Another One' })
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
@@ -38,8 +37,8 @@ describe('db-cluster', () => {
     it('should find many clusters by id', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
-      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
+      const cluster1 = testClusterInputCreate()
+      const cluster2 = testClusterInputCreate()
       const id1 = await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
 
@@ -54,9 +53,9 @@ describe('db-cluster', () => {
     it('should find many clusters by type', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
-      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
-      const cluster3: ClusterInputCreate = { endpoint: 'https://test.co', name: 'Another One', type: 'solana:devnet' }
+      const cluster1 = testClusterInputCreate({ type: 'solana:devnet' })
+      const cluster2 = testClusterInputCreate({ type: 'solana:mainnet' })
+      const cluster3 = testClusterInputCreate({ type: 'solana:devnet' })
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
@@ -72,9 +71,9 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial endpoint', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
-      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
-      const cluster3: ClusterInputCreate = { endpoint: 'https://some.co', name: 'Another One', type: 'solana:devnet' }
+      const cluster1 = testClusterInputCreate({ endpoint: 'https://test.com' })
+      const cluster2 = testClusterInputCreate({ endpoint: 'https://test.com' })
+      const cluster3 = testClusterInputCreate({ endpoint: 'https://some.co' })
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)
@@ -90,9 +89,9 @@ describe('db-cluster', () => {
     it('should find many clusters by a partial name and type', async () => {
       // ARRANGE
       expect.assertions(2)
-      const cluster1: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Alpha', type: 'solana:devnet' }
-      const cluster2: ClusterInputCreate = { endpoint: 'https://test.com', name: 'Test Beta', type: 'solana:mainnet' }
-      const cluster3: ClusterInputCreate = { endpoint: 'https://some.co', name: 'Another One', type: 'solana:devnet' }
+      const cluster1 = testClusterInputCreate({ name: 'Test Alpha', type: 'solana:devnet' })
+      const cluster2 = testClusterInputCreate({ name: 'Test Beta', type: 'solana:mainnet' })
+      const cluster3 = testClusterInputCreate({ name: 'Another One', type: 'solana:devnet' })
       await dbClusterCreate(db, cluster1)
       await dbClusterCreate(db, cluster2)
       await dbClusterCreate(db, cluster3)

--- a/packages/db/test/db-cluster-find-unique.test.ts
+++ b/packages/db/test/db-cluster-find-unique.test.ts
@@ -2,16 +2,15 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
 import type { Cluster } from '../src/entity/cluster'
 
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testClusterInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
-describe('db-cluster', () => {
+describe('db-cluster-find-unique', () => {
   beforeEach(async () => {
     await db.clusters.clear()
   })
@@ -20,11 +19,7 @@ describe('db-cluster', () => {
     it('should find a unique cluster', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: ClusterInputCreate = {
-        endpoint: 'http://localhost:8899',
-        name: randomName('cluster'),
-        type: 'solana:devnet',
-      }
+      const input = testClusterInputCreate()
       const id = await dbClusterCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-cluster-update.test.ts
+++ b/packages/db/test/db-cluster-update.test.ts
@@ -2,16 +2,14 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
-
 import { dbClusterCreate } from '../src/db-cluster-create'
 import { dbClusterFindUnique } from '../src/db-cluster-find-unique'
 import { dbClusterUpdate } from '../src/db-cluster-update'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, randomName, testClusterInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
-describe('db-cluster', () => {
+describe('db-cluster-update', () => {
   beforeEach(async () => {
     await db.clusters.clear()
   })
@@ -20,11 +18,7 @@ describe('db-cluster', () => {
     it('should update a cluster', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: ClusterInputCreate = {
-        endpoint: 'http://localhost:8899',
-        name: randomName('cluster'),
-        type: 'solana:devnet',
-      }
+      const input = testClusterInputCreate()
       const id = await dbClusterCreate(db, input)
       const newName = randomName('newName')
 

--- a/packages/db/test/db-preference-create.test.ts
+++ b/packages/db/test/db-preference-create.test.ts
@@ -2,11 +2,9 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { PreferenceInputCreate } from '../src/dto/preference-input-create'
-
 import { dbPreferenceCreate } from '../src/db-preference-create'
 import { dbPreferenceFindUniqueByKey } from '../src/db-preference-find-unique-by-key'
-import { createDbTest } from './test-helpers'
+import { createDbTest, testPreferenceInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -19,10 +17,7 @@ describe('db-preference-create', () => {
     it('should create a preference', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: PreferenceInputCreate = {
-        key: 'activeClusterId',
-        value: 'test-cluster-id',
-      }
+      const input = testPreferenceInputCreate()
 
       // ACT
       await dbPreferenceCreate(db, input)
@@ -46,10 +41,7 @@ describe('db-preference-create', () => {
     it('should throw an error when creating a preference fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: PreferenceInputCreate = {
-        key: 'activeClusterId',
-        value: 'test-cluster-id',
-      }
+      const input = testPreferenceInputCreate()
       vi.spyOn(db.preferences, 'add').mockImplementationOnce(
         () => Promise.reject(new Error('Test error')) as PromiseExtended<string>,
       )
@@ -61,11 +53,10 @@ describe('db-preference-create', () => {
     it('should throw an error with an invalid key', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: PreferenceInputCreate = {
+      const input = testPreferenceInputCreate({
         // @ts-expect-error: Testing invalid input
         key: 'invalid-key',
-        value: 'some-value',
-      }
+      })
 
       // ACT & ASSERT
       await expect(dbPreferenceCreate(db, input)).rejects.toThrow()
@@ -74,10 +65,7 @@ describe('db-preference-create', () => {
     it('should throw an error when creating a preference with a key that already exists', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: PreferenceInputCreate = {
-        key: 'activeClusterId',
-        value: 'test-cluster-id-1',
-      }
+      const input = testPreferenceInputCreate()
       // Create the first preference
       await dbPreferenceCreate(db, input)
 

--- a/packages/db/test/db-preference-update-by-key.test.ts
+++ b/packages/db/test/db-preference-update-by-key.test.ts
@@ -2,21 +2,17 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { PreferenceInputCreate } from '../src/dto/preference-input-create'
 import type { PreferenceInputUpdate } from '../src/dto/preference-input-update'
 
 import { dbPreferenceCreate } from '../src/db-preference-create'
 import { dbPreferenceFindUniqueByKey } from '../src/db-preference-find-unique-by-key'
 import { dbPreferenceUpdateByKey } from '../src/db-preference-update-by-key'
-import { createDbTest } from './test-helpers'
+import { createDbTest, testPreferenceInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
 describe('db-preference-update-by-key', () => {
-  const initialInput: PreferenceInputCreate = {
-    key: 'activeClusterId',
-    value: 'test-cluster-id-1',
-  }
+  const initialInput = testPreferenceInputCreate()
 
   beforeEach(async () => {
     await db.preferences.clear()

--- a/packages/db/test/db-wallet-create.test.ts
+++ b/packages/db/test/db-wallet-create.test.ts
@@ -2,12 +2,10 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { WalletInputCreate } from '../src/dto/wallet-input-create'
-
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindMany } from '../src/db-wallet-find-many'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testWalletInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -21,12 +19,7 @@ describe('db-wallet-create', () => {
       // ARRANGE
       expect.assertions(1)
       const accountId = crypto.randomUUID()
-      const input: WalletInputCreate = {
-        accountId,
-        name: randomName('wallet'),
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
+      const input = testWalletInputCreate({ accountId })
 
       // ACT
       await dbWalletCreate(db, input)
@@ -40,12 +33,7 @@ describe('db-wallet-create', () => {
       // ARRANGE
       expect.assertions(1)
       const accountId = crypto.randomUUID()
-      const input: WalletInputCreate = {
-        accountId,
-        name: randomName('wallet'),
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
+      const input = testWalletInputCreate({ accountId })
 
       // ACT
       const result = await dbWalletCreate(db, input)
@@ -68,12 +56,7 @@ describe('db-wallet-create', () => {
     it('should throw an error when creating a wallet fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: WalletInputCreate = {
-        accountId: 'test-account',
-        name: 'test',
-        publicKey: 'test-pk',
-        type: 'Derived',
-      }
+      const input = testWalletInputCreate({ accountId: 'test-account' })
       vi.spyOn(db.wallets, 'add').mockImplementationOnce(
         () => Promise.reject(new Error('Test error')) as PromiseExtended<string>,
       )

--- a/packages/db/test/db-wallet-delete.test.ts
+++ b/packages/db/test/db-wallet-delete.test.ts
@@ -2,12 +2,10 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { WalletInputCreate } from '../src/dto/wallet-input-create'
-
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletDelete } from '../src/db-wallet-delete'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testWalletInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -20,12 +18,7 @@ describe('db-wallet-delete', () => {
     it('should delete a wallet', async () => {
       // ARRANGE
       expect.assertions(1)
-      const input: WalletInputCreate = {
-        accountId: crypto.randomUUID(),
-        name: randomName('wallet'),
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
+      const input = testWalletInputCreate({ accountId: crypto.randomUUID() })
       const id = await dbWalletCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-wallet-find-many.test.ts
+++ b/packages/db/test/db-wallet-find-many.test.ts
@@ -2,12 +2,11 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 import type { Wallet } from '../src/entity/wallet'
 
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindMany } from '../src/db-wallet-find-many'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testWalletInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -22,24 +21,9 @@ describe('db-wallet-find-many', () => {
       expect.assertions(2)
       const accountId1 = crypto.randomUUID()
       const accountId2 = crypto.randomUUID()
-      const wallet1: WalletInputCreate = {
-        accountId: accountId1,
-        name: randomName('wallet-1'),
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
-      const wallet2: WalletInputCreate = {
-        accountId: accountId1,
-        name: randomName('wallet-2'),
-        publicKey: crypto.randomUUID(),
-        type: 'Imported',
-      }
-      const wallet3: WalletInputCreate = {
-        accountId: accountId2,
-        name: randomName('wallet-3'),
-        publicKey: crypto.randomUUID(),
-        type: 'Watched',
-      }
+      const wallet1 = testWalletInputCreate({ accountId: accountId1 })
+      const wallet2 = testWalletInputCreate({ accountId: accountId1 })
+      const wallet3 = testWalletInputCreate({ accountId: accountId2 })
       await dbWalletCreate(db, wallet1)
       await dbWalletCreate(db, wallet2)
       await dbWalletCreate(db, wallet3)
@@ -56,24 +40,9 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: WalletInputCreate = {
-        accountId,
-        name: 'Trading Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
-      const wallet2: WalletInputCreate = {
-        accountId,
-        name: 'Staking Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Imported',
-      }
-      const wallet3: WalletInputCreate = {
-        accountId,
-        name: 'Savings',
-        publicKey: crypto.randomUUID(),
-        type: 'Watched',
-      }
+      const wallet1 = testWalletInputCreate({ accountId, name: 'Trading Wallet' })
+      const wallet2 = testWalletInputCreate({ accountId, name: 'Staking Wallet' })
+      const wallet3 = testWalletInputCreate({ accountId, name: 'Savings' })
       await dbWalletCreate(db, wallet1)
       await dbWalletCreate(db, wallet2)
       await dbWalletCreate(db, wallet3)
@@ -90,24 +59,9 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: WalletInputCreate = {
-        accountId,
-        name: 'Trading Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
-      const wallet2: WalletInputCreate = {
-        accountId,
-        name: 'Staking Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Imported',
-      }
-      const wallet3: WalletInputCreate = {
-        accountId,
-        name: 'Savings Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
+      const wallet1 = testWalletInputCreate({ accountId })
+      const wallet2 = testWalletInputCreate({ accountId, type: 'Imported' })
+      const wallet3 = testWalletInputCreate({ accountId })
       await dbWalletCreate(db, wallet1)
       await dbWalletCreate(db, wallet2)
       await dbWalletCreate(db, wallet3)
@@ -124,30 +78,10 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: WalletInputCreate = {
-        accountId,
-        name: 'Trading Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
-      const wallet2: WalletInputCreate = {
-        accountId,
-        name: 'Staking Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Imported',
-      }
-      const wallet3: WalletInputCreate = {
-        accountId,
-        name: 'Savings',
-        publicKey: crypto.randomUUID(),
-        type: 'Watched',
-      }
-      const wallet4: WalletInputCreate = {
-        accountId,
-        name: 'Another Trading Wallet',
-        publicKey: crypto.randomUUID(),
-        type: 'Imported',
-      }
+      const wallet1 = testWalletInputCreate({ accountId, name: 'Trading Wallet' })
+      const wallet2 = testWalletInputCreate({ accountId, name: 'Staking Wallet', type: 'Imported' })
+      const wallet3 = testWalletInputCreate({ accountId, name: 'Savings', type: 'Watched' })
+      const wallet4 = testWalletInputCreate({ accountId, name: 'Another Trading Wallet', type: 'Imported' })
       await dbWalletCreate(db, wallet1)
       await dbWalletCreate(db, wallet2)
       await dbWalletCreate(db, wallet3)
@@ -165,18 +99,8 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: WalletInputCreate = {
-        accountId,
-        name: 'Wallet 1',
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
-      const wallet2: WalletInputCreate = {
-        accountId,
-        name: 'Wallet 2',
-        publicKey: crypto.randomUUID(),
-        type: 'Imported',
-      }
+      const wallet1 = testWalletInputCreate({ accountId, name: 'Wallet 1' })
+      const wallet2 = testWalletInputCreate({ accountId, name: 'Wallet 2', type: 'Imported' })
       const id1 = await dbWalletCreate(db, wallet1)
       await dbWalletCreate(db, wallet2)
 
@@ -192,18 +116,8 @@ describe('db-wallet-find-many', () => {
       // ARRANGE
       expect.assertions(2)
       const accountId = crypto.randomUUID()
-      const wallet1: WalletInputCreate = {
-        accountId,
-        name: 'Wallet 1',
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
-      const wallet2: WalletInputCreate = {
-        accountId,
-        name: 'Wallet 2',
-        publicKey: crypto.randomUUID(),
-        type: 'Imported',
-      }
+      const wallet1 = testWalletInputCreate({ accountId, name: 'Wallet 1' })
+      const wallet2 = testWalletInputCreate({ accountId, name: 'Wallet 2', type: 'Imported' })
       await dbWalletCreate(db, wallet1)
       await dbWalletCreate(db, wallet2)
 

--- a/packages/db/test/db-wallet-find-unique.test.ts
+++ b/packages/db/test/db-wallet-find-unique.test.ts
@@ -2,12 +2,11 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 import type { Wallet } from '../src/entity/wallet'
 
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, testWalletInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -20,12 +19,7 @@ describe('db-wallet-find-unique', () => {
     it('should find a unique wallet', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: WalletInputCreate = {
-        accountId: crypto.randomUUID(),
-        name: randomName('wallet'),
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
+      const input = testWalletInputCreate({ accountId: crypto.randomUUID() })
       const id = await dbWalletCreate(db, input)
 
       // ACT

--- a/packages/db/test/db-wallet-update.test.ts
+++ b/packages/db/test/db-wallet-update.test.ts
@@ -2,12 +2,10 @@ import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { WalletInputCreate } from '../src/dto/wallet-input-create'
-
 import { dbWalletCreate } from '../src/db-wallet-create'
 import { dbWalletFindUnique } from '../src/db-wallet-find-unique'
 import { dbWalletUpdate } from '../src/db-wallet-update'
-import { createDbTest, randomName } from './test-helpers'
+import { createDbTest, randomName, testWalletInputCreate } from './test-helpers'
 
 const db = createDbTest()
 
@@ -20,12 +18,7 @@ describe('db-wallet-update', () => {
     it('should update a wallet', async () => {
       // ARRANGE
       expect.assertions(2)
-      const input: WalletInputCreate = {
-        accountId: crypto.randomUUID(),
-        name: randomName('wallet'),
-        publicKey: crypto.randomUUID(),
-        type: 'Derived',
-      }
+      const input = testWalletInputCreate({ accountId: crypto.randomUUID(), name: randomName('wallet') })
       const id = await dbWalletCreate(db, input)
       const newName = randomName('newName')
 

--- a/packages/db/test/test-helpers.ts
+++ b/packages/db/test/test-helpers.ts
@@ -1,6 +1,10 @@
 import 'fake-indexeddb/auto'
 
 import type { Database } from '../src/database'
+import type { AccountInputCreate } from '../src/dto/account-input-create'
+import type { ClusterInputCreate } from '../src/dto/cluster-input-create'
+import type { PreferenceInputCreate } from '../src/dto/preference-input-create'
+import type { WalletInputCreate } from '../src/dto/wallet-input-create'
 
 import { createDb } from '../src/create-db'
 
@@ -10,4 +14,40 @@ export function createDbTest(): Database {
 
 export function randomName(prefix: string): string {
   return `${prefix}-${Math.random().toString(36).substring(2, 9)}`
+}
+
+export function testAccountInputCreate(input: Partial<AccountInputCreate> = {}): AccountInputCreate {
+  return {
+    derivationPath: 'd',
+    mnemonic: 'baz',
+    name: randomName('account'),
+    secret: 'bar',
+    ...input,
+  }
+}
+
+export function testClusterInputCreate(input: Partial<ClusterInputCreate> = {}): ClusterInputCreate {
+  return {
+    endpoint: 'http://localhost:8899',
+    name: randomName('cluster'),
+    type: 'solana:localnet',
+    ...input,
+  }
+}
+
+export function testPreferenceInputCreate(input: Partial<PreferenceInputCreate> = {}): PreferenceInputCreate {
+  return {
+    key: 'activeClusterId',
+    value: randomName('preference'),
+    ...input,
+  }
+}
+
+export function testWalletInputCreate(input: { accountId: string } & Partial<WalletInputCreate>): WalletInputCreate {
+  return {
+    name: randomName('wallet'),
+    publicKey: crypto.randomUUID(),
+    type: 'Derived',
+    ...input,
+  }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactors tests to use helper functions for input data creation, enhancing code reuse and readability across multiple test files.
> 
>   - **Test Refactoring**:
>     - Replaces inline input object creation with helper functions `testAccountInputCreate`, `testClusterInputCreate`, and `testWalletInputCreate` in test files like `db-account-create.test.ts`, `db-cluster-create.test.ts`, and `db-wallet-create.test.ts`.
>     - Removes type imports for `AccountInputCreate`, `ClusterInputCreate`, and `WalletInputCreate` from test files.
>   - **Helper Functions**:
>     - Adds `testAccountInputCreate`, `testClusterInputCreate`, and `testWalletInputCreate` to `test-helpers.ts` for generating test input data with optional overrides.
>     - Adds `testPreferenceInputCreate` to `test-helpers.ts` for preference input data generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 7d6d998c6942f7b2ff6691e983ffb7819b615db9. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->