### PR TITLE
feat: add account dropdown to header

### DIFF
--- a/packages/features/src/core/ui/core-layout.tsx
+++ b/packages/features/src/core/ui/core-layout.tsx
@@ -1,3 +1,4 @@
+import { SettingsFeatureAccountDropdown } from '@workspace/settings/settings-feature-account-dropdown'
 import { SettingsFeatureClusterDropdown } from '@workspace/settings/settings-feature-cluster-dropdown'
 import { Toaster } from '@workspace/ui/components/sonner'
 import { NavLink, Outlet } from 'react-router'
@@ -7,6 +8,7 @@ export function CoreLayout({ links }: { links: { label: string; to: string }[] }
     <div className="h-full flex flex-col justify-between items-stretch">
       <header className="bg-secondary/50 px-4 py-2 flex justify-between items-center">
         <div className="flex items-center gap-2">
+          <SettingsFeatureAccountDropdown />
           {links.map((link) => (
             <NavLink className={({ isActive }) => (isActive ? 'font-bold' : '')} key={link.to} to={link.to}>
               {link.label}

--- a/packages/settings/src/settings-feature-account-dropdown.tsx
+++ b/packages/settings/src/settings-feature-account-dropdown.tsx
@@ -1,0 +1,25 @@
+import { useDbAccountLive } from '@workspace/db-react/use-db-account-live'
+import { useDbPreferenceFindUniqueByKeyLive } from '@workspace/db-react/use-db-preference-find-unique-by-key-live'
+import { useDbPreferenceUpdateByKey } from '@workspace/db-react/use-db-preference-update-by-key'
+import { useMemo } from 'react'
+
+import { SettingsUiAccountDropdown } from './ui/settings-ui-account-dropdown.js'
+
+export function SettingsFeatureAccountDropdown() {
+  const items = useDbAccountLive()
+  const data = useDbPreferenceFindUniqueByKeyLive({ key: 'activeAccountId' })
+  const { mutateAsync } = useDbPreferenceUpdateByKey('activeAccountId')
+  const activeAccount = useMemo(() => items.find((c) => c.id === data?.value), [items, data])
+  return (
+    <SettingsUiAccountDropdown
+      activeAccount={activeAccount}
+      items={items}
+      setActive={async (item) => {
+        if (!data?.id) {
+          return
+        }
+        await mutateAsync({ input: { value: item.id } })
+      }}
+    />
+  )
+}

--- a/packages/settings/src/ui/settings-ui-account-dropdown.tsx
+++ b/packages/settings/src/ui/settings-ui-account-dropdown.tsx
@@ -1,0 +1,58 @@
+import type { Account } from '@workspace/db/entity/account'
+
+import { Button } from '@workspace/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@workspace/ui/components/dropdown-menu'
+import { UiAvatar } from '@workspace/ui/components/ui-avatar'
+import { LucideWallet2 } from 'lucide-react'
+import { Link } from 'react-router'
+
+import { SettingsUiAccountItem } from './settings-ui-account-item.js'
+
+export function SettingsUiAccountDropdown({
+  activeAccount,
+  items,
+  setActive,
+}: {
+  activeAccount: Account | undefined
+  items: Account[]
+  setActive: (item: Account) => Promise<void>
+}) {
+  if (!activeAccount) {
+    return null
+  }
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="icon" variant="ghost">
+          <UiAvatar label={activeAccount.name} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        {items.map((item) => (
+          <DropdownMenuItem
+            disabled={item.id === activeAccount?.id}
+            key={item.id}
+            onClick={async () => {
+              await setActive(item)
+            }}
+          >
+            <SettingsUiAccountItem item={item} />
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/settings/accounts">
+            <LucideWallet2 />
+            Account settings
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds an account dropdown to the header for account selection and management using new components `SettingsFeatureAccountDropdown` and `SettingsUiAccountDropdown`.
> 
>   - **Feature Addition**:
>     - Adds `SettingsFeatureAccountDropdown` to `core-layout.tsx` header for account selection.
>   - **Components**:
>     - `SettingsFeatureAccountDropdown` fetches accounts using `useDbAccountLive` and manages active account state with `useDbPreferenceFindUnique` and `useDbPreferenceUpdateByKey`.
>     - `SettingsUiAccountDropdown` displays accounts in a dropdown menu, allows selection, and links to account settings.
>   - **UI**:
>     - Uses `DropdownMenu`, `Button`, and `UiAvatar` for dropdown interface in `settings-ui-account-dropdown.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 77f23ecb6c81a2a24cef381cf8800f38a5d63ff3. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->