### PR TITLE
feat: move navigation to bottom tabs

### DIFF
--- a/packages/features/src/core/core-routes.tsx
+++ b/packages/features/src/core/core-routes.tsx
@@ -1,5 +1,8 @@
+import { LucidePieChart, LucideSettings } from 'lucide-react'
 import { lazy } from 'react'
 import { Navigate, useRoutes } from 'react-router'
+
+import type { CoreLayoutLink } from './ui/core-layout.js'
 
 import { CoreLayout } from './ui/core-layout.js'
 
@@ -7,10 +10,9 @@ const DevRoutes = lazy(() => import('../dev/dev-routes.js'))
 const PortfolioRoutes = lazy(() => import('../portfolio/portfolio-routes.js'))
 const SettingsRoutes = lazy(() => import('@workspace/settings/settings-routes'))
 
-const links = [
-  { label: 'Portfolio', to: '/portfolio' },
-  { label: 'Dev', to: '/dev' },
-  { label: 'Settings', to: '/settings' },
+const links: CoreLayoutLink[] = [
+  { icon: LucidePieChart, label: 'Portfolio', to: '/portfolio' },
+  { icon: LucideSettings, label: 'Settings', to: '/settings' },
 ]
 
 export function CoreRoutes() {

--- a/packages/features/src/core/ui/core-layout.tsx
+++ b/packages/features/src/core/ui/core-layout.tsx
@@ -1,27 +1,47 @@
+import type { UiIconLucide } from '@workspace/ui/components/ui-icon.js'
+
 import { SettingsFeatureAccountDropdown } from '@workspace/settings/settings-feature-account-dropdown'
 import { SettingsFeatureClusterDropdown } from '@workspace/settings/settings-feature-cluster-dropdown'
 import { SettingsFeatureWalletDropdown } from '@workspace/settings/settings-feature-wallet-dropdown'
 import { Toaster } from '@workspace/ui/components/sonner'
+import { cn } from '@workspace/ui/lib/utils.js'
 import { NavLink, Outlet } from 'react-router'
 
-export function CoreLayout({ links }: { links: { label: string; to: string }[] }) {
+export interface CoreLayoutLink {
+  icon: UiIconLucide
+  label: string
+  to: string
+}
+
+export function CoreLayout({ links }: { links: CoreLayoutLink[] }) {
   return (
     <div className="h-full flex flex-col justify-between items-stretch">
       <header className="bg-secondary/50 px-4 py-2 flex justify-between items-center">
         <div className="flex items-center gap-2">
           <SettingsFeatureAccountDropdown />
           <SettingsFeatureWalletDropdown />
-          {links.map((link) => (
-            <NavLink className={({ isActive }) => (isActive ? 'font-bold' : '')} key={link.to} to={link.to}>
-              {link.label}
-            </NavLink>
-          ))}
         </div>
         <SettingsFeatureClusterDropdown />
       </header>
       <main className="flex-1 overflow-y-auto p-2 lg:p-4">
         <Outlet />
       </main>
+      <footer className="bg-secondary/50 flex justify-between items-center">
+        {links.map(({ icon: Icon, label, to }) => (
+          <NavLink
+            className={({ isActive }) =>
+              cn('items-center gap-2 py-2 flex flex-col flex-1', {
+                'font-bold bg-secondary/60': isActive,
+              })
+            }
+            key={to}
+            to={to}
+          >
+            <Icon />
+            {label}
+          </NavLink>
+        ))}
+      </footer>
       <Toaster richColors />
     </div>
   )

--- a/packages/settings/src/ui/settings-ui-cluster-dropdown.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-dropdown.tsx
@@ -23,7 +23,7 @@ export function SettingsUiClusterDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="sm" variant="outline">
+        <Button variant="outline">
           <LucideNetwork /> {activeCluster?.name ?? 'Select Cluster'}
         </Button>
       </DropdownMenuTrigger>

--- a/packages/settings/src/ui/settings-ui-wallet-dropdown.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-dropdown.tsx
@@ -26,9 +26,7 @@ export function SettingsUiWalletDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button size="sm" variant="outline">
-          {activeWallet.name}
-        </Button>
+        <Button variant="outline">{activeWallet.name}</Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56">
         {items.map((item) => (


### PR DESCRIPTION
<img width="767" height="653" alt="image" src="https://github.com/user-attachments/assets/427050a3-ea2d-46d7-8750-2cc3be5d40ea" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move navigation to bottom tabs with icons in `CoreLayout` and update related components.
> 
>   - **Navigation Update**:
>     - Move navigation to bottom tabs in `CoreLayout` in `core-layout.tsx`.
>     - Add icons to navigation links in `core-routes.tsx` using `LucidePieChart` and `LucideSettings`.
>   - **Type Changes**:
>     - Define `CoreLayoutLink` interface in `core-layout.tsx` to include `icon`.
>   - **UI Adjustments**:
>     - Remove `size="sm"` from `Button` in `settings-ui-cluster-dropdown.tsx` and `settings-ui-wallet-dropdown.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 74824253b6cb7093f94eb30ed3d280c504215b08. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->