### PR TITLE
refactor: switch react-router to data mode

### DIFF
--- a/packages/features/src/core/core-feature.tsx
+++ b/packages/features/src/core/core-feature.tsx
@@ -1,14 +1,10 @@
-import { HashRouter } from 'react-router'
-
 import { CoreRoutes } from './core-routes.js'
 import { CoreProviders } from './data-access/core-providers.js'
 
 export function CoreFeature() {
   return (
     <CoreProviders>
-      <HashRouter>
-        <CoreRoutes />
-      </HashRouter>
+      <CoreRoutes />
     </CoreProviders>
   )
 }

--- a/packages/features/src/core/core-routes.tsx
+++ b/packages/features/src/core/core-routes.tsx
@@ -1,6 +1,6 @@
 import { LucidePieChart, LucideSettings } from 'lucide-react'
 import { lazy } from 'react'
-import { Navigate, useRoutes } from 'react-router'
+import { createHashRouter, Navigate, RouterProvider } from 'react-router'
 
 import type { CoreLayoutLink } from './ui/core-layout.js'
 
@@ -15,16 +15,18 @@ const links: CoreLayoutLink[] = [
   { icon: LucideSettings, label: 'Settings', to: '/settings' },
 ]
 
+const router = createHashRouter([
+  {
+    children: [
+      { element: <Navigate replace to="/portfolio" />, index: true },
+      { element: <PortfolioRoutes />, path: 'portfolio/*' },
+      { element: <DevRoutes />, path: 'dev/*' },
+      { element: <SettingsRoutes />, path: 'settings/*' },
+    ],
+    element: <CoreLayout links={links} />,
+  },
+])
+
 export function CoreRoutes() {
-  return useRoutes([
-    {
-      children: [
-        { element: <Navigate replace to="/portfolio" />, index: true },
-        { element: <PortfolioRoutes />, path: 'portfolio/*' },
-        { element: <DevRoutes />, path: 'dev/*' },
-        { element: <SettingsRoutes />, path: 'settings/*' },
-      ],
-      element: <CoreLayout links={links} />,
-    },
-  ])
+  return <RouterProvider router={router} />
 }


### PR DESCRIPTION
Switch to [data mode](https://reactrouter.com/start/modes#data) from declarative mode so we can use things like loaders, actions, pending state in the router.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor routing in `core-feature.tsx` and `core-routes.tsx` to use `react-router` data mode.
> 
>   - **Routing Refactor**:
>     - Switch from `HashRouter` to `createHashRouter` in `core-routes.tsx`.
>     - Replace `useRoutes` with `RouterProvider` in `core-routes.tsx`.
>     - Remove `HashRouter` wrapper in `core-feature.tsx`.
>   - **Behavior**:
>     - Enables use of loaders, actions, and pending state in the router.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ddde3ce128d6fa669c3d2dae8e92f92c908be065. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->