### PR TITLE
feat: add loader to portfolio route with redirect

### DIFF
--- a/packages/features/src/core/core-routes.tsx
+++ b/packages/features/src/core/core-routes.tsx
@@ -4,6 +4,7 @@ import { createHashRouter, Navigate, RouterProvider } from 'react-router'
 
 import type { CoreLayoutLink } from './ui/core-layout.js'
 
+import { loaderPortfolio } from './data-access/loader-portfolio.js'
 import { CoreLayout } from './ui/core-layout.js'
 
 const DevRoutes = lazy(() => import('../dev/dev-routes.js'))
@@ -19,7 +20,12 @@ const router = createHashRouter([
   {
     children: [
       { element: <Navigate replace to="/portfolio" />, index: true },
-      { element: <PortfolioRoutes />, path: 'portfolio/*' },
+      {
+        element: <PortfolioRoutes />,
+        id: 'portfolio',
+        loader: loaderPortfolio,
+        path: 'portfolio/*',
+      },
       { element: <DevRoutes />, path: 'dev/*' },
       { element: <SettingsRoutes />, path: 'settings/*' },
     ],

--- a/packages/features/src/core/data-access/loader-portfolio.tsx
+++ b/packages/features/src/core/data-access/loader-portfolio.tsx
@@ -1,0 +1,15 @@
+import { db } from '@workspace/db/db'
+import { dbAccountFindMany } from '@workspace/db/db-account-find-many'
+import { dbClusterFindMany } from '@workspace/db/db-cluster-find-many'
+import { redirect } from 'react-router'
+
+export async function loaderPortfolio() {
+  const [accounts, clusters] = await Promise.all([dbAccountFindMany(db), dbClusterFindMany(db)])
+  if (!accounts.length) {
+    return redirect('/settings/accounts')
+  }
+  if (!clusters.length) {
+    return redirect('/settings/clusters')
+  }
+  return null
+}


### PR DESCRIPTION
Add a loader to the portfolio route that redirects a user to `/settings/accounts` or `/settings/clusters` if they don't have any accounts/clusters configured.

In the future we'll redirect to `/onboarding` to get a proper onboarding for accounts/wallets and we'll find a way to make sure we always have the initial clusters configured.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `loaderPortfolio` to redirect users without accounts or clusters to appropriate settings pages in `core-routes.tsx`.
> 
>   - **Behavior**:
>     - Adds `loaderPortfolio` function in `loader-portfolio.tsx` to check for accounts and clusters.
>     - Redirects to `/settings/accounts` if no accounts are found.
>     - Redirects to `/settings/clusters` if no clusters are found.
>   - **Routing**:
>     - Integrates `loaderPortfolio` into the portfolio route in `core-routes.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 391931d0655a5885fe6d460757c607ccb2dfac37. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->