### PR TITLE
feat: add banner with warning about experimental software

### DIFF
--- a/packages/db-react/src/db-preference-options.tsx
+++ b/packages/db-react/src/db-preference-options.tsx
@@ -8,7 +8,6 @@ import { dbPreferenceCreate } from '@workspace/db/db-preference-create'
 import { dbPreferenceFindUniqueByKey } from '@workspace/db/db-preference-find-unique-by-key'
 import { dbPreferenceUpdateByKey } from '@workspace/db/db-preference-update-by-key'
 import { toastError } from '@workspace/ui/lib/toast-error'
-import { toastSuccess } from '@workspace/ui/lib/toast-success'
 
 export type DbPreferenceCreateMutateOptions = MutateOptions<string, Error, { input: PreferenceInputCreate }>
 export type DbPreferenceUpdateMutateOptions = MutateOptions<number, Error, { input: PreferenceInputUpdate }>
@@ -18,7 +17,6 @@ export const dbPreferenceOptions = {
     mutationOptions({
       mutationFn: ({ input }: { input: PreferenceInputCreate }) => dbPreferenceCreate(db, input),
       onError: () => toastError('Error creating preference'),
-      onSuccess: () => toastSuccess('Preference created'),
       ...props,
     }),
   findUniqueByKey: (key: PreferenceKey) =>
@@ -30,7 +28,6 @@ export const dbPreferenceOptions = {
     mutationOptions({
       mutationFn: ({ input }: { input: PreferenceInputUpdate }) => dbPreferenceUpdateByKey(db, key, input),
       onError: () => toastError('Error updating preference'),
-      onSuccess: () => toastSuccess('Preference updated'),
       ...props,
     }),
 }

--- a/packages/db/src/schema/preference-key-schema.ts
+++ b/packages/db/src/schema/preference-key-schema.ts
@@ -1,3 +1,8 @@
 import { z } from 'zod'
 
-export const preferenceKeySchema = z.enum(['activeAccountId', 'activeClusterId', 'activeWalletId'])
+export const preferenceKeySchema = z.enum([
+  'activeAccountId',
+  'activeClusterId',
+  'activeWalletId',
+  'warningAcceptExperimental',
+])

--- a/packages/features/src/core/ui/core-layout.tsx
+++ b/packages/features/src/core/ui/core-layout.tsx
@@ -7,6 +7,8 @@ import { Toaster } from '@workspace/ui/components/sonner'
 import { cn } from '@workspace/ui/lib/utils.js'
 import { NavLink, Outlet } from 'react-router'
 
+import { CoreUiWarningExperimental } from './core-ui-warning-experimental.js'
+
 export interface CoreLayoutLink {
   icon: UiIconLucide
   label: string
@@ -16,6 +18,7 @@ export interface CoreLayoutLink {
 export function CoreLayout({ links }: { links: CoreLayoutLink[] }) {
   return (
     <div className="h-full flex flex-col justify-between items-stretch">
+      <CoreUiWarningExperimental />
       <header className="bg-secondary/50 px-4 py-2 flex justify-between items-center">
         <div className="flex items-center gap-2">
           <SettingsFeatureAccountDropdown />

--- a/packages/features/src/core/ui/core-ui-warning-experimental.tsx
+++ b/packages/features/src/core/ui/core-ui-warning-experimental.tsx
@@ -1,0 +1,18 @@
+import { usePreference } from '@workspace/settings/settings-feature-general'
+import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert.js'
+import { Button } from '@workspace/ui/components/button.js'
+import { AlertTriangle, LucideX } from 'lucide-react'
+
+export function CoreUiWarningExperimental() {
+  const { update, value } = usePreference('warningAcceptExperimental')
+  return value !== 'true' ? (
+    <Alert className="rounded-none border-1 border-yellow-500 bg-yellow-500/10 text-yellow-500">
+      <AlertTriangle />
+      <AlertTitle>This is experimental software.</AlertTitle>
+      <AlertDescription>Use this wallet at your own risk. Do not use any real funds.</AlertDescription>
+      <Button className="absolute top-2 right-2" onClick={() => update('true')} size="icon" variant="ghost">
+        <LucideX />
+      </Button>
+    </Alert>
+  ) : null
+}

--- a/packages/settings/src/data-access/use-settings-pages.tsx
+++ b/packages/settings/src/data-access/use-settings-pages.tsx
@@ -1,9 +1,15 @@
-import { LucideNetwork, LucideWallet2 } from 'lucide-react'
+import { LucideNetwork, LucideSettings, LucideWallet2 } from 'lucide-react'
 
 import type { SettingsPage } from './settings-page.js'
 
 export function useSettingsPages(): SettingsPage[] {
   return [
+    {
+      description: 'General settings for the wallet',
+      icon: LucideSettings,
+      id: 'general',
+      name: 'General',
+    },
     {
       description: 'Manage accounts and wallets',
       icon: LucideWallet2,

--- a/packages/settings/src/settings-feature-general-warning-accept-experimental.tsx
+++ b/packages/settings/src/settings-feature-general-warning-accept-experimental.tsx
@@ -1,0 +1,19 @@
+import { Label } from '@workspace/ui/components/label'
+import { Switch } from '@workspace/ui/components/switch'
+
+import { usePreference } from './settings-feature-general.js'
+
+export function SettingsFeatureGeneralWarningAcceptExperimental() {
+  const { update, value } = usePreference('warningAcceptExperimental')
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Switch
+        checked={value !== 'true'}
+        id="warning-accept-experimental"
+        onCheckedChange={(checked) => update(checked ? 'false' : 'true')}
+      />
+      <Label htmlFor="warning-accept-experimental">Show warning about experimental software</Label>
+    </div>
+  )
+}

--- a/packages/settings/src/settings-feature-general.tsx
+++ b/packages/settings/src/settings-feature-general.tsx
@@ -1,0 +1,37 @@
+import type { PreferenceKey } from '@workspace/db/entity/preference-key'
+
+import { useDbPreferenceCreate } from '@workspace/db-react/use-db-preference-create'
+import { useDbPreferenceFindUnique } from '@workspace/db-react/use-db-preference-find-unique-by-key'
+import { useDbPreferenceUpdateByKey } from '@workspace/db-react/use-db-preference-update-by-key'
+
+import { useSettingsPage } from './data-access/use-settings-page.js'
+import { SettingsFeatureGeneralWarningAcceptExperimental } from './settings-feature-general-warning-accept-experimental.js'
+import { SettingsUiPageCard } from './ui/settings-ui-page-card.js'
+
+export function SettingsFeatureGeneral() {
+  const page = useSettingsPage({ pageId: 'general' })
+  return (
+    <SettingsUiPageCard page={page}>
+      <SettingsFeatureGeneralWarningAcceptExperimental />
+    </SettingsUiPageCard>
+  )
+}
+
+export function usePreference(key: PreferenceKey) {
+  const { data, refetch } = useDbPreferenceFindUnique({ key: key })
+  const mutationCreate = useDbPreferenceCreate()
+  const mutationUpdate = useDbPreferenceUpdateByKey(key)
+
+  return {
+    update: async (value: string) => {
+      if (!data) {
+        await mutationCreate.mutateAsync({ input: { key, value } })
+        await refetch()
+        return
+      }
+      await mutationUpdate.mutateAsync({ input: { value } })
+      await refetch()
+    },
+    value: data?.value,
+  }
+}

--- a/packages/settings/src/settings-routes.tsx
+++ b/packages/settings/src/settings-routes.tsx
@@ -9,13 +9,14 @@ import { SettingsFeatureAccountUpdate } from './settings-feature-account-update.
 import { SettingsFeatureClusterCreate } from './settings-feature-cluster-create.js'
 import { SettingsFeatureClusterList } from './settings-feature-cluster-list.js'
 import { SettingsFeatureClusterUpdate } from './settings-feature-cluster-update.js'
+import { SettingsFeatureGeneral } from './settings-feature-general.js'
 import { SettingsUiLayout } from './ui/settings-ui-layout.js'
 
 export default function SettingsRoutes() {
   return useRoutes([
     {
       children: [
-        { element: <Navigate replace to="accounts" />, index: true },
+        { element: <Navigate replace to="general" />, index: true },
         {
           children: [
             { element: <SettingsFeatureAccountList />, index: true },
@@ -34,6 +35,10 @@ export default function SettingsRoutes() {
             { element: <SettingsFeatureClusterUpdate />, path: ':clusterId' },
           ],
           path: 'clusters',
+        },
+        {
+          children: [{ element: <SettingsFeatureGeneral />, index: true }],
+          path: 'general',
         },
       ],
       element: <SettingsUiLayout />,


### PR DESCRIPTION
Add the warning on top of the layout with an option to close it (stored in the preferences table).

Add a General settings screen where this preference can be toggled.

<img width="1724" height="1674" alt="image" src="https://github.com/user-attachments/assets/079b1655-4bcb-4840-b23b-b21c346ac65e" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning banner for experimental software and a general settings screen to manage its visibility, updating the preference schema and UI components accordingly.
> 
>   - **UI Changes**:
>     - Adds `CoreUiWarningExperimental` component in `core-ui-warning-experimental.tsx` to display a warning banner about experimental software.
>     - Integrates the warning banner into `CoreLayout` in `core-layout.tsx`.
>   - **Settings**:
>     - Adds `SettingsFeatureGeneral` and `SettingsFeatureGeneralWarningAcceptExperimental` components to manage the warning preference in `settings-feature-general.tsx` and `settings-feature-general-warning-accept-experimental.tsx`.
>     - Updates `useSettingsPages` in `use-settings-pages.tsx` to include a new 'General' settings page.
>     - Modifies `settings-routes.tsx` to add routing for the new 'General' settings page.
>   - **Preferences**:
>     - Adds `warningAcceptExperimental` to `preferenceKeySchema` in `preference-key-schema.ts`.
>     - Removes success toasts from `db-preference-options.tsx` for preference creation and update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 17a17950a7383b5ae8e9bc2030366e591132e630. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->