### PR TITLE
feat: add option to delete the database to start from scratch

### DIFF
--- a/packages/db-react/src/use-db-reset.tsx
+++ b/packages/db-react/src/use-db-reset.tsx
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query'
+import { db } from '@workspace/db/db'
+import { dbReset } from '@workspace/db/db-reset'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+
+export function useDbReset() {
+  return useMutation({
+    mutationFn: async () => {
+      await dbReset(db)
+      toastSuccess('Database reset successfully')
+    },
+  })
+}

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -5,6 +5,8 @@ import type { Cluster } from './entity/cluster'
 import type { Preference } from './entity/preference'
 import type { Wallet } from './entity/wallet'
 
+import { dbPopulate } from './db-populate'
+
 export interface DatabaseConfig {
   name: string
 }
@@ -25,47 +27,7 @@ export class Database extends Dexie {
     })
 
     this.on('populate', async () => {
-      await this.populate()
+      await dbPopulate(this)
     })
-  }
-
-  async populate() {
-    const now = new Date()
-    const activeClusterId = crypto.randomUUID()
-    await this.clusters.bulkAdd([
-      {
-        createdAt: now,
-        endpoint: 'http://localhost:8899',
-        id: crypto.randomUUID(),
-        name: 'Localnet',
-        type: 'solana:localnet',
-        updatedAt: now,
-      },
-      {
-        createdAt: now,
-        endpoint: 'https://api.devnet.solana.com',
-        id: activeClusterId,
-        name: 'Devnet',
-        type: 'solana:devnet',
-        updatedAt: now,
-      },
-      {
-        createdAt: now,
-        endpoint: 'https://api.testnet.solana.com',
-        id: crypto.randomUUID(),
-        name: 'Testnet',
-        type: 'solana:testnet',
-        updatedAt: now,
-      },
-    ])
-    await this.preferences.bulkAdd([
-      {
-        createdAt: now,
-        id: crypto.randomUUID(),
-        key: 'activeClusterId',
-        updatedAt: now,
-        value: activeClusterId,
-      },
-    ])
   }
 }

--- a/packages/db/src/db-populate.ts
+++ b/packages/db/src/db-populate.ts
@@ -1,0 +1,41 @@
+import type { Database } from './database'
+
+export async function dbPopulate(db: Database) {
+  const now = new Date()
+  const activeClusterId = crypto.randomUUID()
+  await db.clusters.bulkAdd([
+    {
+      createdAt: now,
+      endpoint: 'http://localhost:8899',
+      id: crypto.randomUUID(),
+      name: 'Localnet',
+      type: 'solana:localnet',
+      updatedAt: now,
+    },
+    {
+      createdAt: now,
+      endpoint: 'https://api.devnet.solana.com',
+      id: activeClusterId,
+      name: 'Devnet',
+      type: 'solana:devnet',
+      updatedAt: now,
+    },
+    {
+      createdAt: now,
+      endpoint: 'https://api.testnet.solana.com',
+      id: crypto.randomUUID(),
+      name: 'Testnet',
+      type: 'solana:testnet',
+      updatedAt: now,
+    },
+  ])
+  await db.preferences.bulkAdd([
+    {
+      createdAt: now,
+      id: crypto.randomUUID(),
+      key: 'activeClusterId',
+      updatedAt: now,
+      value: activeClusterId,
+    },
+  ])
+}

--- a/packages/db/src/db-reset.ts
+++ b/packages/db/src/db-reset.ts
@@ -1,0 +1,8 @@
+import type { Database } from './database'
+
+import { dbPopulate } from './db-populate'
+
+export async function dbReset(db: Database) {
+  await Promise.all(db.tables.map((table) => table.clear()))
+  await dbPopulate(db)
+}

--- a/packages/settings/src/settings-feature-general-danger-delete-database.tsx
+++ b/packages/settings/src/settings-feature-general-danger-delete-database.tsx
@@ -1,0 +1,28 @@
+import { useDbReset } from '@workspace/db-react/use-db-reset'
+import { Button } from '@workspace/ui/components/button'
+import { Label } from '@workspace/ui/components/label'
+
+export function SettingsFeatureGeneralDangerDeleteDatabase() {
+  const mutation = useDbReset()
+  return (
+    <div className="flex items-center justify-between space-x-2">
+      <Label>Delete the database</Label>
+      <Button
+        onClick={async () => {
+          if (!window.confirm('Are you sure? This action can not be reversed.')) {
+            return
+          }
+          if (!window.confirm('Any mnemonic stored in the database will be lost. Do you want to continue?')) {
+            return
+          }
+          await mutation.mutateAsync()
+
+          window.location.replace('/')
+        }}
+        variant="destructive"
+      >
+        Delete Database
+      </Button>
+    </div>
+  )
+}

--- a/packages/settings/src/settings-feature-general.tsx
+++ b/packages/settings/src/settings-feature-general.tsx
@@ -5,6 +5,7 @@ import { useDbPreferenceFindUnique } from '@workspace/db-react/use-db-preference
 import { useDbPreferenceUpdateByKey } from '@workspace/db-react/use-db-preference-update-by-key'
 
 import { useSettingsPage } from './data-access/use-settings-page.js'
+import { SettingsFeatureGeneralDangerDeleteDatabase } from './settings-feature-general-danger-delete-database.js'
 import { SettingsFeatureGeneralWarningAcceptExperimental } from './settings-feature-general-warning-accept-experimental.js'
 import { SettingsUiPageCard } from './ui/settings-ui-page-card.js'
 
@@ -13,6 +14,9 @@ export function SettingsFeatureGeneral() {
   return (
     <SettingsUiPageCard page={page}>
       <SettingsFeatureGeneralWarningAcceptExperimental />
+      <div className="border border-red-500 rounded-md p-4">
+        <SettingsFeatureGeneralDangerDeleteDatabase />
+      </div>
     </SettingsUiPageCard>
   )
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a feature to reset the database with confirmation dialogs in the settings UI, including logic to clear and repopulate the database.
> 
>   - **Feature**:
>     - Adds `useDbReset` hook in `use-db-reset.tsx` to reset the database using `dbReset` and show a success toast.
>     - Implements `dbReset` function in `db-reset.ts` to clear all tables and repopulate the database.
>     - Extracts database population logic to `dbPopulate` in `db-populate.ts`.
>   - **UI**:
>     - Adds `SettingsFeatureGeneralDangerDeleteDatabase` component in `settings-feature-general-danger-delete-database.tsx` with a button to trigger database reset.
>     - Integrates the delete database feature into `SettingsFeatureGeneral` in `settings-feature-general.tsx` with confirmation dialogs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ec37b6da6b3b48d3ba5b68a2ca70c48e6b3c0557. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->