### PR TITLE
feat: add not-found catch all route to root routes

### DIFF
--- a/packages/features/src/core/core-routes.tsx
+++ b/packages/features/src/core/core-routes.tsx
@@ -1,3 +1,4 @@
+import { UiNotFound } from '@workspace/ui/components/ui-not-found.js'
 import { LucidePieChart, LucideSettings } from 'lucide-react'
 import { lazy } from 'react'
 import { createHashRouter, Navigate, RouterProvider } from 'react-router'
@@ -28,6 +29,7 @@ const router = createHashRouter([
       },
       { element: <DevRoutes />, path: 'dev/*' },
       { element: <SettingsRoutes />, path: 'settings/*' },
+      { element: <UiNotFound />, path: '*' },
     ],
     element: <CoreLayout links={links} />,
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a catch-all route in `core-routes.tsx` using `UiNotFound` for unmatched paths.
> 
>   - **Behavior**:
>     - Adds a catch-all route in `core-routes.tsx` using `UiNotFound` component for unmatched paths.
>   - **Imports**:
>     - Imports `UiNotFound` from `@workspace/ui/components/ui-not-found.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 5e0633683c0b6cac4041d4cb1b8761eb852115a5. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->