### PR TITLE
feat: implement db-account-set-active, db-wallet-set-active functions

### DIFF
--- a/packages/db-react/src/db-account-options.tsx
+++ b/packages/db-react/src/db-account-options.tsx
@@ -8,10 +8,12 @@ import { dbAccountCreate } from '@workspace/db/db-account-create'
 import { dbAccountDelete } from '@workspace/db/db-account-delete'
 import { dbAccountFindMany } from '@workspace/db/db-account-find-many'
 import { dbAccountFindUnique } from '@workspace/db/db-account-find-unique'
+import { dbAccountSetActive } from '@workspace/db/db-account-set-active'
 import { dbAccountUpdate } from '@workspace/db/db-account-update'
 
 export type DbAccountCreateMutateOptions = MutateOptions<string, Error, { input: AccountInputCreate }>
 export type DbAccountDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
+export type DbAccountSetActiveMutateOptions = MutateOptions<void, Error, { id: string }>
 export type DbAccountUpdateMutateOptions = MutateOptions<number, Error, { input: AccountInputUpdate }>
 
 export const dbAccountOptions = {
@@ -34,6 +36,11 @@ export const dbAccountOptions = {
     queryOptions({
       queryFn: () => dbAccountFindUnique(db, id),
       queryKey: ['dbAccountFindUnique', id],
+    }),
+  setActive: (props: DbAccountSetActiveMutateOptions = {}) =>
+    mutationOptions({
+      mutationFn: ({ id }: { id: string }) => dbAccountSetActive(db, id),
+      ...props,
     }),
   update: (props: DbAccountUpdateMutateOptions = {}) =>
     mutationOptions({

--- a/packages/db-react/src/db-wallet-options.tsx
+++ b/packages/db-react/src/db-wallet-options.tsx
@@ -8,10 +8,12 @@ import { dbWalletCreate } from '@workspace/db/db-wallet-create'
 import { dbWalletDelete } from '@workspace/db/db-wallet-delete'
 import { dbWalletFindMany } from '@workspace/db/db-wallet-find-many'
 import { dbWalletFindUnique } from '@workspace/db/db-wallet-find-unique'
+import { dbWalletSetActive } from '@workspace/db/db-wallet-set-active'
 import { dbWalletUpdate } from '@workspace/db/db-wallet-update'
 
 export type DbWalletCreateMutateOptions = MutateOptions<string, Error, { input: WalletInputCreate }>
 export type DbWalletDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
+export type DbWalletSetActiveMutateOptions = MutateOptions<void, Error, { id: string }>
 export type DbWalletUpdateMutateOptions = MutateOptions<number, Error, { input: WalletInputUpdate }>
 
 export const dbWalletOptions = {
@@ -34,6 +36,11 @@ export const dbWalletOptions = {
     queryOptions({
       queryFn: () => dbWalletFindUnique(db, id),
       queryKey: ['dbWalletFindUnique', id],
+    }),
+  setActive: (props: DbWalletSetActiveMutateOptions = {}) =>
+    mutationOptions({
+      mutationFn: ({ id }: { id: string }) => dbWalletSetActive(db, id),
+      ...props,
     }),
   update: (props: DbWalletUpdateMutateOptions = {}) =>
     mutationOptions({

--- a/packages/db-react/src/use-db-account-set-active.tsx
+++ b/packages/db-react/src/use-db-account-set-active.tsx
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query'
+
+import type { DbAccountSetActiveMutateOptions } from './db-account-options'
+
+import { dbAccountOptions } from './db-account-options'
+
+export function useDbAccountSetActive(props: DbAccountSetActiveMutateOptions = {}) {
+  return useMutation(dbAccountOptions.setActive(props))
+}

--- a/packages/db-react/src/use-db-wallet-set-active.tsx
+++ b/packages/db-react/src/use-db-wallet-set-active.tsx
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query'
+
+import type { DbWalletSetActiveMutateOptions } from './db-wallet-options'
+
+import { dbWalletOptions } from './db-wallet-options'
+
+export function useDbWalletSetActive(props: DbWalletSetActiveMutateOptions = {}) {
+  return useMutation(dbWalletOptions.setActive(props))
+}

--- a/packages/db/src/db-account-set-active.ts
+++ b/packages/db/src/db-account-set-active.ts
@@ -1,0 +1,29 @@
+import type { Database } from './database'
+
+import { dbAccountFindUnique } from './db-account-find-unique'
+import { dbPreferenceSetValue } from './db-preference-set-value'
+import { dbWalletFindMany } from './db-wallet-find-many'
+
+export async function dbAccountSetActive(db: Database, id: string) {
+  return db.transaction('rw', db.accounts, db.preferences, db.wallets, async () => {
+    const found = await dbAccountFindUnique(db, id)
+    if (!found) {
+      // TODO: Use Effect
+      throw new Error(`Account with id ${id} not found`)
+    }
+    const accountId = found.id
+
+    // set the `activeAccountId` preference to the new value
+    await dbPreferenceSetValue(db, 'activeAccountId', accountId)
+
+    // get the list of wallets for `activeAccountId`
+    const wallets = await dbWalletFindMany(db, { accountId })
+    const first = wallets[0]
+    if (!first) {
+      console.warn(`There are no wallets in account ${accountId}`)
+      return
+    }
+    // set the `activeWalletId` preference to the first one of the list of wallets
+    await dbPreferenceSetValue(db, 'activeWalletId', first.id)
+  })
+}

--- a/packages/db/src/db-wallet-set-active.ts
+++ b/packages/db/src/db-wallet-set-active.ts
@@ -1,0 +1,31 @@
+import type { Database } from './database'
+import type { PreferenceKey } from './entity/preference-key'
+
+import { dbPreferenceFindUniqueByKey } from './db-preference-find-unique-by-key'
+import { dbPreferenceSetValue } from './db-preference-set-value'
+import { dbWalletFindUnique } from './db-wallet-find-unique'
+
+export async function dbWalletSetActive(db: Database, id: string) {
+  return db.transaction('rw', db.accounts, db.preferences, db.wallets, async () => {
+    // get the requested wallet from the database
+    const found = await dbWalletFindUnique(db, id)
+    if (!found) {
+      // TODO: Use Effect
+      throw new Error(`Wallet with id ${id} not found`)
+    }
+    const walletId = found.id
+
+    // // set the `activeWalletId` preference to the new value
+    const keyAccount: PreferenceKey = 'activeAccountId'
+    const keyWallet: PreferenceKey = 'activeWalletId'
+    // get the `activeAccountId` preference
+    const activeAccount = await dbPreferenceFindUniqueByKey(db, keyAccount)
+
+    // ensure that the request `Wallet.accountId` is equal to `activeAccountId`
+    if (found.accountId !== activeAccount?.value) {
+      await dbPreferenceSetValue(db, keyAccount, found.accountId)
+    }
+
+    await dbPreferenceSetValue(db, keyWallet, walletId)
+  })
+}

--- a/packages/db/test/db-account-set-active.test.ts
+++ b/packages/db/test/db-account-set-active.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { dbAccountCreate } from '../src/db-account-create'
+import { dbAccountSetActive } from '../src/db-account-set-active'
+import { dbPreferenceFindUniqueByKey } from '../src/db-preference-find-unique-by-key'
+import { dbWalletCreate } from '../src/db-wallet-create'
+import { createDbTest, testAccountInputCreate, testWalletInputCreate } from './test-helpers'
+
+const db = createDbTest()
+
+describe('db-account-set-active', () => {
+  beforeEach(async () => {
+    await db.accounts.clear()
+    await db.wallets.clear()
+    await db.preferences.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should set an account and its first wallet to active', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const inputAccount1 = testAccountInputCreate()
+      const inputAccount2 = testAccountInputCreate()
+      const idAccount1 = await dbAccountCreate(db, inputAccount1)
+      const idAccount2 = await dbAccountCreate(db, inputAccount2)
+
+      const inputWallet1 = testWalletInputCreate({ accountId: idAccount1 })
+      const inputWallet2 = testWalletInputCreate({ accountId: idAccount2 })
+      const idWallet1 = await dbWalletCreate(db, inputWallet1)
+      const idWallet2 = await dbWalletCreate(db, inputWallet2)
+
+      // ACT
+      const activeAccountIdBeforeSetActive = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+      const activeWalletIdBeforeSetActive = await dbPreferenceFindUniqueByKey(db, 'activeWalletId')
+
+      await dbAccountSetActive(db, idAccount2)
+      const activeAccountIdAfterSetActive = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+      const activeWalletIdAfterSetActive = await dbPreferenceFindUniqueByKey(db, 'activeWalletId')
+
+      // ASSERT
+      expect(activeAccountIdBeforeSetActive?.value).toBe(idAccount1)
+      expect(activeWalletIdBeforeSetActive?.value).toBe(idWallet1)
+      expect(activeAccountIdAfterSetActive?.value).toBe(idAccount2)
+      expect(activeWalletIdAfterSetActive?.value).toBe(idWallet2)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when account does not exist', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const nonExistentId = 'non-existent-account-id'
+
+      // ACT & ASSERT
+      await expect(dbAccountSetActive(db, nonExistentId)).rejects.toThrow(`Account with id ${nonExistentId} not found`)
+    })
+
+    it('should handle account with no wallets gracefully', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const inputAccount = testAccountInputCreate()
+      const idAccount = await dbAccountCreate(db, inputAccount)
+
+      // ACT
+      await dbAccountSetActive(db, idAccount)
+      const activeAccountIdAfterSetActive = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+      const activeWalletIdAfterSetActive = await dbPreferenceFindUniqueByKey(db, 'activeWalletId')
+
+      // ASSERT
+      expect(activeAccountIdAfterSetActive?.value).toBe(idAccount)
+      expect(activeWalletIdAfterSetActive?.value).toBeUndefined()
+      expect(console.warn).toHaveBeenCalledWith(`There are no wallets in account ${idAccount}`)
+    })
+  })
+})

--- a/packages/db/test/db-wallet-set-active.test.ts
+++ b/packages/db/test/db-wallet-set-active.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { dbAccountCreate } from '../src/db-account-create'
+import { dbPreferenceFindUniqueByKey } from '../src/db-preference-find-unique-by-key'
+import { dbWalletCreate } from '../src/db-wallet-create'
+import { dbWalletSetActive } from '../src/db-wallet-set-active'
+import { createDbTest, testAccountInputCreate, testWalletInputCreate } from './test-helpers'
+
+const db = createDbTest()
+
+describe('db-wallet-set-active', () => {
+  beforeEach(async () => {
+    await db.accounts.clear()
+    await db.wallets.clear()
+    await db.preferences.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should set an wallet and its related account to active', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const inputAccount1 = testAccountInputCreate()
+      const inputAccount2 = testAccountInputCreate()
+      const idAccount1 = await dbAccountCreate(db, inputAccount1)
+      const idAccount2 = await dbAccountCreate(db, inputAccount2)
+
+      const inputWallet1 = testWalletInputCreate({ accountId: idAccount1 })
+      const inputWallet2 = testWalletInputCreate({ accountId: idAccount2 })
+      const idWallet1 = await dbWalletCreate(db, inputWallet1)
+      const idWallet2 = await dbWalletCreate(db, inputWallet2)
+
+      // ACT
+      const activeAccountIdBefore = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+      const activeWalletIdBefore = await dbPreferenceFindUniqueByKey(db, 'activeWalletId')
+
+      await dbWalletSetActive(db, idWallet2)
+      const activeAccountIdAfter = await dbPreferenceFindUniqueByKey(db, 'activeAccountId')
+      const activeWalletIdAfter = await dbPreferenceFindUniqueByKey(db, 'activeWalletId')
+
+      // ASSERT
+      expect(activeAccountIdBefore?.value).toBe(idAccount1)
+      expect(activeWalletIdBefore?.value).toBe(idWallet1)
+      expect(activeAccountIdAfter?.value).toBe(idAccount2)
+      expect(activeWalletIdAfter?.value).toBe(idWallet2)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    it('should throw an error when wallet does not exist', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const nonExistentId = 'non-existent-wallet-id'
+
+      // ACT & ASSERT
+      await expect(dbWalletSetActive(db, nonExistentId)).rejects.toThrow(`Wallet with id ${nonExistentId} not found`)
+    })
+  })
+})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Implement `dbAccountSetActive` and `dbWalletSetActive` functions with React Query hooks and tests.
> 
>   - **Functions**:
>     - Add `dbAccountSetActive` in `db-account-set-active.ts` to set an account and its first wallet as active.
>     - Add `dbWalletSetActive` in `db-wallet-set-active.ts` to set a wallet and its related account as active.
>   - **Options**:
>     - Add `setActive` to `dbAccountOptions` in `db-account-options.tsx`.
>     - Add `setActive` to `dbWalletOptions` in `db-wallet-options.tsx`.
>   - **Hooks**:
>     - Add `useDbAccountSetActive` in `use-db-account-set-active.tsx` for account activation.
>     - Add `useDbWalletSetActive` in `use-db-wallet-set-active.tsx` for wallet activation.
>   - **Tests**:
>     - Add tests for `dbAccountSetActive` in `db-account-set-active.test.ts`.
>     - Add tests for `dbWalletSetActive` in `db-wallet-set-active.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 92feea2e6ccabd418e9604e04794a8ed2e726c8e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->