### PR TITLE
chore: set pkg-pr-new option --packageManager=pnpm

### DIFF
--- a/.github/workflows/publish-pkg-pr-new.yml
+++ b/.github/workflows/publish-pkg-pr-new.yml
@@ -24,4 +24,4 @@ jobs:
         run: pnpm build
 
       - name: Publish to pkg.pr.new
-        run: pnpm pkg-pr-new publish './packages/*'
+        run: pnpm pkg-pr-new publish --pnpm --packageManager=pnpm './packages/*'


### PR DESCRIPTION
Without these parameters set, the packages don't allow installing as they refer to the pnpm `catalog:`

```
pnpm i https://pkg.pr.new/samui-build/samui-wallet/@workspace/solana-client@fdf3adb 
 ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER  @solana-program/token@catalog: isn't supported by any available resolver.

This error happened while installing the dependencies of @workspace/solana-client@0.0.0

An external package outside of the pnpm workspace declared a dependency using
the catalog protocol. This is likely a bug in that external package. Only
packages within the pnpm workspace may use catalogs. Usages of the catalog
protocol are replaced with real specifiers on 'pnpm publish'.

This is likely a bug in the publishing automation of this package. Consider filing
a bug with the authors of:

  @workspace/solana-client@0.0.0

Progress: resolved 350, reused 325, downloaded 1, added 0
```
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `--packageManager=pnpm` option to `pnpm pkg-pr-new publish` command in `publish-pkg-pr-new.yml`.
> 
>   - **Workflow Update**:
>     - In `publish-pkg-pr-new.yml`, added `--packageManager=pnpm` option to `pnpm pkg-pr-new publish` command.
>     - Ensures packages are published using `pnpm` package manager.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b3be2fee1c6a7869fbf28a6ad2151eb48dc81915. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->