### PR TITLE
feat: add get-solana-cluster-from-genesis-hash function + hook

### DIFF
--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -8,6 +8,7 @@
     "@workspace/db-react": "workspace:*",
     "@workspace/portfolio": "workspace:*",
     "@workspace/settings": "workspace:*",
+    "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
     "effect": "^3.18.4",
     "lucide-react": "catalog:",

--- a/packages/features/src/dev/dev-routes.tsx
+++ b/packages/features/src/dev/dev-routes.tsx
@@ -3,7 +3,11 @@ import type { ClusterType } from '@workspace/db/entity/cluster-type'
 
 import { useDbClusterFindMany } from '@workspace/db-react/use-db-cluster-find-many'
 import { db } from '@workspace/db/db'
+import { useGetSolanaClusterFromGenesisHash } from '@workspace/solana-client-react/use-get-solana-cluster-from-genesis-hash'
+import { Button } from '@workspace/ui/components/button.js'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@workspace/ui/components/card.js'
+import { Input } from '@workspace/ui/components/input.js'
+import { Label } from '@workspace/ui/components/label.js'
 import {
   Select,
   SelectContent,
@@ -22,6 +26,7 @@ export default function DevRoutes() {
     <div className="space-y-6">
       <DevUiAvatars />
       <DevUiColors />
+      <DevGenesisHash />
       <DevDbTables />
       <DevDbClusterFindMany />
     </div>
@@ -80,6 +85,69 @@ function DevDbTables() {
       </CardHeader>
       <CardContent>
         <pre>{JSON.stringify(tables, null, 2)}</pre>
+      </CardContent>
+    </Card>
+  )
+}
+function DevGenesisHash() {
+  const mutation = useGetSolanaClusterFromGenesisHash()
+  const [endpoint, setEndpoint] = useState<string>('')
+
+  const options = [
+    'https://api.devnet.solana.com',
+    'http://localhost:8899',
+    'https://api.mainnet-beta.solana.com',
+    'https://api.testnet.solana.com',
+  ]
+
+  async function submit() {
+    if (!endpoint.length) {
+      return
+    }
+    await mutation.mutateAsync(endpoint)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>get cluster from genesis hash</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          <div className="space-x-2 space-y-2">
+            {options.map((option) => (
+              <Button key={option} onClick={() => setEndpoint(option)} variant="outline">
+                {option}
+              </Button>
+            ))}
+          </div>
+          <div>
+            <Label htmlFor="endpoint">Endpoint</Label>
+            <Input
+              disabled={mutation.isPending}
+              id="endpoint"
+              onChange={(e) => {
+                setEndpoint(e.target.value)
+              }}
+              type="url"
+              value={endpoint}
+            />
+            <Button onClick={submit}>Submit</Button>
+          </div>
+        </div>
+        <pre>
+          {JSON.stringify(
+            {
+              //
+              data: mutation.data,
+              error: mutation.error?.message,
+              isError: mutation.isError,
+              isPending: mutation.isPending,
+            },
+            null,
+            2,
+          )}
+        </pre>
       </CardContent>
     </Card>
   )

--- a/packages/solana-client-react/src/use-get-solana-cluster-from-genesis-hash.tsx
+++ b/packages/solana-client-react/src/use-get-solana-cluster-from-genesis-hash.tsx
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query'
+import { createSolanaClient } from '@workspace/solana-client/create-solana-client'
+import { getSolanaClusterFromGenesisHash } from '@workspace/solana-client/get-solana-cluster-from-genesis-hash'
+
+export function useGetSolanaClusterFromGenesisHash() {
+  return useMutation({
+    mutationFn: async (endpoint: string) => {
+      const client = createSolanaClient({ url: endpoint })
+      const hash = await client.rpc.getGenesisHash().send()
+      return getSolanaClusterFromGenesisHash(hash)
+    },
+  })
+}

--- a/packages/solana-client/src/get-explorer-url.ts
+++ b/packages/solana-client/src/get-explorer-url.ts
@@ -1,11 +1,11 @@
-export type ClusterType = 'solana:devnet' | 'solana:localnet' | 'solana:mainnet' | 'solana:testnet'
+import type { SolanaCluster } from './solana-cluster'
 
 export type ExplorerProvider = 'orb' | 'solana' | 'solscan'
 export const explorerProviders: ExplorerProvider[] = ['solana', 'solscan', 'orb'] as const
 
 export interface GetClusterSuffixProps {
   endpoint: string
-  type: ClusterType
+  type: SolanaCluster
 }
 
 export interface GetExplorerUrlProps {

--- a/packages/solana-client/src/get-solana-cluster-from-genesis-hash.ts
+++ b/packages/solana-client/src/get-solana-cluster-from-genesis-hash.ts
@@ -1,0 +1,27 @@
+/*
+ * From https://github.com/gillsdk/gill and adapted for Samui Wallet
+ * MIT License
+ * Copyright (c) 2023 Solana Foundation
+ */
+import type { SolanaCluster } from './solana-cluster'
+
+export const GENESIS_HASH = {
+  devnet: 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG',
+  mainnet: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+  testnet: '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY',
+}
+/**
+ * Determine the Solana Cluster from its genesis hash
+ */
+export function getSolanaClusterFromGenesisHash(hash: string): SolanaCluster {
+  switch (hash) {
+    case GENESIS_HASH.devnet:
+      return 'solana:devnet'
+    case GENESIS_HASH.mainnet:
+      return 'solana:mainnet'
+    case GENESIS_HASH.testnet:
+      return 'solana:testnet'
+    default:
+      return 'solana:localnet'
+  }
+}

--- a/packages/solana-client/src/solana-cluster.ts
+++ b/packages/solana-client/src/solana-cluster.ts
@@ -1,0 +1,1 @@
+export type SolanaCluster = 'solana:devnet' | 'solana:localnet' | 'solana:mainnet' | 'solana:testnet'

--- a/packages/solana-client/test/get-solana-cluster-from-genesis-hash.test.ts
+++ b/packages/solana-client/test/get-solana-cluster-from-genesis-hash.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { GENESIS_HASH, getSolanaClusterFromGenesisHash } from '../src/get-solana-cluster-from-genesis-hash'
+
+describe('get-solana-cluster-from-genesis-hash', () => {
+  describe('expected behavior', () => {
+    it('should return solana:devnet for devnet genesis hash', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const hash = GENESIS_HASH.devnet
+
+      // ACT
+      const result = getSolanaClusterFromGenesisHash(hash)
+
+      // ASSERT
+      expect(result).toBe('solana:devnet')
+    })
+
+    it('should return solana:mainnet for mainnet genesis hash', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const hash = GENESIS_HASH.mainnet
+
+      // ACT
+      const result = getSolanaClusterFromGenesisHash(hash)
+
+      // ASSERT
+      expect(result).toBe('solana:mainnet')
+    })
+
+    it('should return solana:testnet for testnet genesis hash', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const hash = GENESIS_HASH.testnet
+
+      // ACT
+      const result = getSolanaClusterFromGenesisHash(hash)
+
+      // ASSERT
+      expect(result).toBe('solana:testnet')
+    })
+
+    it('should return solana:localnet for unknown genesis hash', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const hash = 'UnknownGenesisHashThatDoesNotExist123456789'
+
+      // ACT
+      const result = getSolanaClusterFromGenesisHash(hash)
+
+      // ASSERT
+      expect(result).toBe('solana:localnet')
+    })
+
+    it('should return solana:localnet for empty string', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const hash = ''
+
+      // ACT
+      const result = getSolanaClusterFromGenesisHash(hash)
+
+      // ASSERT
+      expect(result).toBe('solana:localnet')
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,6 +516,9 @@ importers:
       '@workspace/settings':
         specifier: workspace:*
         version: link:../settings
+      '@workspace/solana-client-react':
+        specifier: workspace:*
+        version: link:../solana-client-react
       '@workspace/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
Helper function we'll use to enhance the Settings -> Cluster -> Add screen, where we can auto-detect the cluster based on the endpoint that's passed in.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `getSolanaClusterFromGenesisHash` function and hook for auto-detecting Solana clusters from genesis hash, with UI integration and tests.
> 
>   - **New Functionality**:
>     - Adds `getSolanaClusterFromGenesisHash()` in `get-solana-cluster-from-genesis-hash.ts` to determine Solana cluster from genesis hash.
>     - Introduces `useGetSolanaClusterFromGenesisHash()` hook in `use-get-solana-cluster-from-genesis-hash.tsx` for mutation handling.
>   - **UI Integration**:
>     - Adds `DevGenesisHash` component in `dev-routes.tsx` to auto-detect cluster from endpoint.
>   - **Types and Constants**:
>     - Defines `SolanaCluster` type in `solana-cluster.ts`.
>     - Updates `ClusterType` to `SolanaCluster` in `get-explorer-url.ts`.
>   - **Testing**:
>     - Adds tests in `get-solana-cluster-from-genesis-hash.test.ts` for `getSolanaClusterFromGenesisHash()` function.
>   - **Dependencies**:
>     - Adds `@workspace/solana-client-react` to `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 7aacf2a3e21f315371282540c1f4e40bbf6165ac. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->