### PR TITLE
feat: add tabs to portfolio page

### DIFF
--- a/packages/portfolio/src/portfolio-feature-index.tsx
+++ b/packages/portfolio/src/portfolio-feature-index.tsx
@@ -1,15 +1,19 @@
+import { UiTabRoutes } from '@workspace/ui/components/ui-tab-routes'
+
 import type { ClusterWallet } from './portfolio-routes-loaded.js'
 
-import { PortfolioFeatureGetActivity } from './portfolio-feature-get-activity.js'
-import { PortfolioFeatureGetSolBalance } from './portfolio-feature-get-sol-balance.js'
-import { PortfolioFeatureGetTokenAccounts } from './portfolio-feature-get-token-accounts.js'
+import { PortfolioFeatureTabActivity } from './portfolio-feature-tab-activity.js'
+import { PortfolioFeatureTabTokens } from './portfolio-feature-tab-tokens.js'
 
 export function PortfolioFeatureIndex(props: ClusterWallet) {
   return (
-    <div className="p-4 space-y-6">
-      <PortfolioFeatureGetSolBalance {...props} />
-      <PortfolioFeatureGetTokenAccounts {...props} />
-      <PortfolioFeatureGetActivity {...props} />
-    </div>
+    <UiTabRoutes
+      basePath="/portfolio"
+      className="items-center my-6"
+      tabs={[
+        { element: <PortfolioFeatureTabTokens {...props} />, label: 'Tokens', path: 'tokens' },
+        { element: <PortfolioFeatureTabActivity {...props} />, label: 'Activity', path: 'activity' },
+      ]}
+    />
   )
 }

--- a/packages/portfolio/src/portfolio-feature-tab-activity.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-activity.tsx
@@ -1,0 +1,11 @@
+import type { ClusterWallet } from './portfolio-routes-loaded.js'
+
+import { PortfolioFeatureGetActivity } from './portfolio-feature-get-activity.js'
+
+export function PortfolioFeatureTabActivity(props: ClusterWallet) {
+  return (
+    <div className="p-4 space-y-6">
+      <PortfolioFeatureGetActivity {...props} />
+    </div>
+  )
+}

--- a/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
@@ -1,0 +1,13 @@
+import type { ClusterWallet } from './portfolio-routes-loaded.js'
+
+import { PortfolioFeatureGetSolBalance } from './portfolio-feature-get-sol-balance.js'
+import { PortfolioFeatureGetTokenAccounts } from './portfolio-feature-get-token-accounts.js'
+
+export function PortfolioFeatureTabTokens(props: ClusterWallet) {
+  return (
+    <div className="p-4 space-y-6">
+      <PortfolioFeatureGetSolBalance {...props} />
+      <PortfolioFeatureGetTokenAccounts {...props} />
+    </div>
+  )
+}

--- a/packages/portfolio/src/portfolio-routes-loaded.tsx
+++ b/packages/portfolio/src/portfolio-routes-loaded.tsx
@@ -12,7 +12,7 @@ export interface ClusterWallet {
 
 export function PortfolioRoutesLoaded(props: ClusterWallet) {
   return useRoutes([
-    { element: <PortfolioFeatureIndex {...props} />, index: true },
-    { element: <div>Page not found :(</div>, path: '*' },
+    { element: <PortfolioFeatureIndex {...props} />, path: '*' },
+    // { element: <div>Page not found :(</div>, path: '*' },
   ])
 }

--- a/packages/ui/src/components/ui-tab-routes.tsx
+++ b/packages/ui/src/components/ui-tab-routes.tsx
@@ -1,0 +1,57 @@
+import type { ComponentProps, ReactElement, ReactNode } from 'react'
+
+import { Suspense } from 'react'
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router'
+
+import { Tabs, TabsList, TabsTrigger } from './tabs.js'
+import { UiLoader } from './ui-loader.js'
+
+export interface UiTabRoute {
+  element: ReactNode
+  label: ReactElement | string
+  path: string
+}
+
+export function UiTabRoutes({
+  basePath,
+  tabs,
+  ...props
+}: {
+  basePath: string
+  tabs: UiTabRoute[]
+} & Omit<ComponentProps<typeof Tabs>, 'activationMode' | 'children' | 'onValueChange' | 'value'>) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  // Set the active tab based on matching the location pathname with the tab path
+  const activeTab = tabs.find((tab) => location.pathname.startsWith(`${basePath}/${tab.path}`))?.path
+  // Set default redirect route to the first tab
+  const redirect = tabs[0]?.path !== '' ? tabs[0]?.path : undefined
+
+  return (
+    <>
+      <Tabs
+        activationMode="manual"
+        onValueChange={(value) => navigate(`${basePath}/${value}`)}
+        value={activeTab}
+        {...props}
+      >
+        <TabsList>
+          {tabs.map((tab) => (
+            <TabsTrigger key={tab.path} value={tab.path}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+      <Suspense fallback={<UiLoader />}>
+        <Routes>
+          {redirect ? <Route element={<Navigate replace to={`./${redirect}`} />} index /> : null}
+          {tabs.map((tab) => (
+            <Route element={tab.element} key={tab.path} path={`${tab.path}/*`} />
+          ))}
+          <Route element={<Navigate replace to={`./${redirect}`} />} path="*" />
+        </Routes>
+      </Suspense>
+    </>
+  )
+}


### PR DESCRIPTION

<img width="234" height="506" alt="localhost_5173_(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/07ffbbd3-5c30-458d-b8ae-92bda619f814" />
<img width="234" height="506" alt="localhost_5173_(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/13e4de86-034d-4b80-931e-7066624d0e53" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds tabbed navigation to the portfolio page with 'Tokens' and 'Activity' tabs using a new `UiTabRoutes` component.
> 
>   - **Behavior**:
>     - Adds `UiTabRoutes` to `portfolio-feature-index.tsx` for tabbed navigation between 'Tokens' and 'Activity'.
>     - Replaces direct rendering of balance and activity components with tab components.
>   - **Components**:
>     - New `PortfolioFeatureTabActivity` component in `portfolio-feature-tab-activity.tsx` for 'Activity' tab.
>     - New `PortfolioFeatureTabTokens` component in `portfolio-feature-tab-tokens.tsx` for 'Tokens' tab.
>     - New `UiTabRoutes` component in `ui-tab-routes.tsx` for handling tab navigation.
>   - **Routing**:
>     - Updates `PortfolioRoutesLoaded` in `portfolio-routes-loaded.tsx` to use `PortfolioFeatureIndex` for all paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 9ec7f7d57ba52d7af458c3d639c34524b3280e4c. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->