### PR TITLE
feat: import/watch wallets

### DIFF
--- a/packages/keypair/src/convert-key-pair-to-public-key-secret-key.ts
+++ b/packages/keypair/src/convert-key-pair-to-public-key-secret-key.ts
@@ -1,0 +1,15 @@
+import { getAddressFromPublicKey } from '@solana/kit'
+
+import { convertKeyPairToJson } from './convert-key-pair-to-json'
+
+export interface PublicKeySecretKey {
+  publicKey: string
+  secretKey: string
+}
+
+export async function convertKeyPairToPublicKeySecretKey(keyPair: CryptoKeyPair): Promise<PublicKeySecretKey> {
+  const publicKey = await getAddressFromPublicKey(keyPair.publicKey)
+  const secretKey = await convertKeyPairToJson(keyPair)
+
+  return { publicKey, secretKey }
+}

--- a/packages/keypair/src/create-key-pair-from-base58.ts
+++ b/packages/keypair/src/create-key-pair-from-base58.ts
@@ -1,0 +1,5 @@
+import { createKeyPairFromBytes, getBase58Encoder } from '@solana/kit'
+
+export async function createKeyPairFromBase58(input: string, extractable = false): Promise<CryptoKeyPair> {
+  return createKeyPairFromBytes(getBase58Encoder().encode(input), extractable)
+}

--- a/packages/keypair/src/import-key-pair-to-public-key-secret-key.ts
+++ b/packages/keypair/src/import-key-pair-to-public-key-secret-key.ts
@@ -1,0 +1,11 @@
+import type { PublicKeySecretKey } from './convert-key-pair-to-public-key-secret-key'
+
+import { convertKeyPairToPublicKeySecretKey } from './convert-key-pair-to-public-key-secret-key'
+import { importKeyPair } from './import-key-pair'
+
+export async function importKeyPairToPublicKeySecretKey(
+  input: string,
+  extractable = false,
+): Promise<PublicKeySecretKey> {
+  return convertKeyPairToPublicKeySecretKey(await importKeyPair(input, extractable))
+}

--- a/packages/keypair/src/import-key-pair.spec.ts
+++ b/packages/keypair/src/import-key-pair.spec.ts
@@ -1,0 +1,60 @@
+import { getAddressFromPublicKey } from '@solana/kit'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { convertKeyPairToJson } from './convert-key-pair-to-json'
+import { importKeyPair } from './import-key-pair'
+
+describe('import-key-pair', () => {
+  const inputByteArray =
+    '[158,162,68,53,7,160,11,228,121,212,9,20,153,66,181,218,221,151,133,191,47,200,42,248,9,193,87,242,138,52,78,247,62,126,231,24,61,119,89,115,57,124,71,221,150,117,118,44,234,134,91,100,152,80,11,142,29,0,122,146,140,107,174,196]'
+  const inputBase58 = '4AxFzQaPR6N9dWP5K3GdZRLuWJcdgPznM4h42ASqByP3c6vywVLKs32rwPPsuvsJh1E6fLjkAbe8dzhTj3w173Ky'
+  const expected = '5CxWcsm9h3NfCM8WPM6eaw8LnnSmnYyEHf8BQQ56YJGK'
+  describe('expected behavior', () => {
+    it('should import a key pair from a byte array', async () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      const result = await importKeyPair(inputByteArray, true)
+
+      // ASSERT
+      const publicKey = await getAddressFromPublicKey(result.publicKey)
+      const secretKey = await convertKeyPairToJson(result)
+      expect(publicKey).toBe(expected)
+      expect(secretKey).toBe(inputByteArray)
+    })
+
+    it('should import a key pair from a base58', async () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      const result = await importKeyPair(inputBase58, true)
+
+      // ASSERT
+      const publicKey = await getAddressFromPublicKey(result.publicKey)
+      const secretKey = await convertKeyPairToJson(result)
+      expect(publicKey).toBe(expected)
+      expect(secretKey).toBe(inputByteArray)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error for an invalid input', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const invalidInput = 'this is not a valid key'
+
+      // ACT & ASSERT
+      await expect(importKeyPair(invalidInput, true)).rejects.toThrow()
+    })
+  })
+})

--- a/packages/keypair/src/import-key-pair.ts
+++ b/packages/keypair/src/import-key-pair.ts
@@ -1,0 +1,12 @@
+import { createKeyPairFromBytes } from '@solana/kit'
+
+import { convertJsonToByteArray } from './convert-json-to-byte-array'
+import { createKeyPairFromBase58 } from './create-key-pair-from-base58'
+
+export async function importKeyPair(input: string, extractable = false): Promise<CryptoKeyPair> {
+  try {
+    return createKeyPairFromBytes(convertJsonToByteArray(input), extractable)
+  } catch {
+    return createKeyPairFromBase58(input, extractable)
+  }
+}

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -8,6 +8,7 @@
     "@workspace/db": "workspace:*",
     "@workspace/db-react": "workspace:*",
     "@workspace/keypair": "workspace:*",
+    "@workspace/solana-client": "workspace:*",
     "@workspace/ui": "workspace:*",
     "lucide-react": "catalog:",
     "react": "catalog:",

--- a/packages/settings/src/data-access/use-active-wallet.tsx
+++ b/packages/settings/src/data-access/use-active-wallet.tsx
@@ -3,16 +3,19 @@ import { useDbWalletLive } from '@workspace/db-react/use-db-wallet-live'
 import { useDbWalletSetActive } from '@workspace/db-react/use-db-wallet-set-active'
 import { useMemo } from 'react'
 
+import { useSortWallets } from './use-sort-wallets.js'
+
 export function useActiveWallet() {
   const [walletId] = useDbPreference('activeWalletId')
   const [accountId] = useDbPreference('activeAccountId')
-  const wallets = useDbWalletLive({ accountId: accountId })
   const { mutateAsync } = useDbWalletSetActive()
+  const wallets = useDbWalletLive({ accountId: accountId })
+  const sorted = useSortWallets(wallets)
   const active = useMemo(() => wallets.find((c) => c.id === walletId) ?? null, [wallets, walletId])
 
   return {
     active,
     setActive: (id: string) => mutateAsync({ id }),
-    wallets,
+    wallets: sorted,
   }
 }

--- a/packages/settings/src/data-access/use-sort-wallets.tsx
+++ b/packages/settings/src/data-access/use-sort-wallets.tsx
@@ -1,0 +1,10 @@
+import type { Wallet } from '@workspace/db/entity/wallet'
+
+import { useMemo } from 'react'
+
+export function useSortWallets(wallets: Wallet[]) {
+  return useMemo(
+    () => [...wallets].sort((a, b) => a.type.localeCompare(b.type) || a.name.localeCompare(b.name)),
+    [wallets],
+  )
+}

--- a/packages/settings/src/ui/settings-ui-wallet-dropdown.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-dropdown.tsx
@@ -11,6 +11,8 @@ import {
 import { LucideWallet2 } from 'lucide-react'
 import { Link } from 'react-router'
 
+import { WalletUiItem } from './wallet-ui-item.js'
+
 export function SettingsUiWalletDropdown({
   active,
   items,
@@ -26,7 +28,9 @@ export function SettingsUiWalletDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline">{active.name}</Button>
+        <Button variant="outline">
+          <WalletUiItem wallet={active} />
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56">
         {items.map((item) => (
@@ -37,7 +41,7 @@ export function SettingsUiWalletDropdown({
               await setActive(item.id)
             }}
           >
-            {item.name}
+            <WalletUiItem wallet={item} />
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />

--- a/packages/settings/src/ui/settings-ui-wallet-table.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-table.tsx
@@ -4,18 +4,25 @@ import { Button } from '@workspace/ui/components/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@workspace/ui/components/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
 import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
-import { LucideCheck, LucidePlus } from 'lucide-react'
+import { LucideCheck } from 'lucide-react'
+
+import { WalletUiIcon } from './wallet-ui-icon.js'
+import { WalletUiItem } from './wallet-ui-item.js'
 
 export function SettingsUiWalletTable({
   active,
   deriveWallet,
+  importWallet,
   items,
   setActive,
+  watchWallet,
 }: {
   active: null | Wallet
   deriveWallet: () => void
+  importWallet: () => void
   items: Wallet[]
   setActive: (id: string) => Promise<void>
+  watchWallet: () => void
 }) {
   return (
     <div>
@@ -23,16 +30,24 @@ export function SettingsUiWalletTable({
       <div className="md:hidden">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold">Wallets</h2>
-          <Button onClick={deriveWallet} size="icon" variant="outline">
-            <LucidePlus />
-          </Button>
+          <div className="flex gap-2">
+            <Button onClick={importWallet} size="icon" variant="outline">
+              <WalletUiIcon type="Imported" />
+            </Button>
+            <Button onClick={watchWallet} size="icon" variant="outline">
+              <WalletUiIcon type="Watched" />
+            </Button>
+            <Button onClick={deriveWallet} size="icon" variant="outline">
+              <WalletUiIcon type="Derived" />
+            </Button>
+          </div>
         </div>
         <div className="space-y-4">
           {items.map((item) => (
             <Card key={item.id}>
               <CardHeader>
                 <CardTitle className="flex items-center justify-between">
-                  <span>{item.name}</span>
+                  <WalletUiItem wallet={item} />
                   {active?.id === item.id ? (
                     <UiTooltip content="Active wallet">
                       <Button size="icon" variant="secondary">
@@ -63,17 +78,31 @@ export function SettingsUiWalletTable({
             <TableRow className="hover:bg-transparent">
               <TableHead>Name</TableHead>
               <TableHead>Public Key</TableHead>
-              <TableHead className="flex justify-end">
-                <Button onClick={deriveWallet} size="icon" variant="outline">
-                  <LucidePlus />
-                </Button>
+              <TableHead className="flex gap-2 justify-end">
+                <UiTooltip content="Import wallet">
+                  <Button onClick={importWallet} size="icon" variant="outline">
+                    <WalletUiIcon type="Imported" />
+                  </Button>
+                </UiTooltip>
+                <UiTooltip content="Watch wallet">
+                  <Button onClick={watchWallet} size="icon" variant="outline">
+                    <WalletUiIcon type="Watched" />
+                  </Button>
+                </UiTooltip>
+                <UiTooltip content="Derive wallet">
+                  <Button onClick={deriveWallet} size="icon" variant="outline">
+                    <WalletUiIcon type="Derived" />
+                  </Button>
+                </UiTooltip>
               </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {items.map((item) => (
               <TableRow key={item.id}>
-                <TableCell>{item.name}</TableCell>
+                <TableCell>
+                  <WalletUiItem wallet={item} />
+                </TableCell>
                 <TableCell className="font-mono text-xs">{item.publicKey}</TableCell>
                 <TableCell className="text-right">
                   {active?.id === item.id ? (

--- a/packages/settings/src/ui/wallet-ui-icon.tsx
+++ b/packages/settings/src/ui/wallet-ui-icon.tsx
@@ -1,0 +1,19 @@
+import type { WalletType } from '@workspace/db/entity/wallet-type'
+import type { UiIconLucide } from '@workspace/ui/components/ui-icon'
+
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+import { LucideEye, LucideImport, LucideLetterText } from 'lucide-react'
+
+export function WalletUiIcon({ type }: { type: WalletType }) {
+  return <UiIcon className="size-4" icon={getWalletUiIcon(type)} />
+}
+function getWalletUiIcon(type: WalletType): UiIconLucide {
+  switch (type) {
+    case 'Derived':
+      return LucideLetterText
+    case 'Imported':
+      return LucideImport
+    case 'Watched':
+      return LucideEye
+  }
+}

--- a/packages/settings/src/ui/wallet-ui-item.tsx
+++ b/packages/settings/src/ui/wallet-ui-item.tsx
@@ -1,0 +1,12 @@
+import type { Wallet } from '@workspace/db/entity/wallet'
+
+import { WalletUiIcon } from './wallet-ui-icon.js'
+
+export function WalletUiItem({ wallet }: { wallet: Wallet }) {
+  return (
+    <span className="flex items-center gap-2">
+      <WalletUiIcon type={wallet.type} />
+      <span className="font-mono">{wallet.name}</span>
+    </span>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,6 +693,9 @@ importers:
       '@workspace/keypair':
         specifier: workspace:*
         version: link:../keypair
+      '@workspace/solana-client':
+        specifier: workspace:*
+        version: link:../solana-client
       '@workspace/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functionality to import and watch wallets, with key pair conversion and UI updates in `keypair` and `settings` packages.
> 
>   - **Keypair Package**:
>     - Add `convertKeyPairToPublicKeySecretKey()` in `convert-key-pair-to-public-key-secret-key.ts` to convert `CryptoKeyPair` to `PublicKeySecretKey`.
>     - Add `createKeyPairFromBase58()` in `create-key-pair-from-base58.ts` to create key pairs from Base58 strings.
>     - Add `importKeyPairToPublicKeySecretKey()` in `import-key-pair-to-public-key-secret-key.ts` to import key pairs and convert them to `PublicKeySecretKey`.
>     - Add `importKeyPair()` in `import-key-pair.ts` to handle key pair import from JSON or Base58.
>     - Add tests in `import-key-pair.spec.ts` for `importKeyPair()`.
>   - **Settings Package**:
>     - Update `useActiveWallet()` in `use-active-wallet.tsx` to sort wallets.
>     - Add `useSortWallets()` in `use-sort-wallets.tsx` to sort wallets by type and name.
>     - Update `SettingsFeatureAccountDetails` in `settings-feature-account-details.tsx` to support importing and watching wallets.
>     - Update `SettingsUiWalletTable` and `SettingsUiWalletDropdown` to display wallet icons and handle new wallet actions.
>     - Add `WalletUiIcon` and `WalletUiItem` components for wallet display in UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 4b8f86d69ab92d976d5099f37ca41500045df69b. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->