### PR TITLE
chore: remove pnpm audit on pre-push

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,9 +1,3 @@
-pre-push:
-  parallel: true
-  jobs:
-    - name: packages audit
-      run: pnpm audit --audit-level high
-
 pre-commit:
   parallel: true
   jobs:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `pre-push` hook running `pnpm audit` from `lefthook.yaml`.
> 
>   - **Hooks**:
>     - Remove `pre-push` hook from `lefthook.yaml` that ran `pnpm audit --audit-level high`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 69049567f7ddee6849b42c77387f7919f9dab9dd. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->