### PR TITLE
feat: add scratch-pad route to dev feature

### DIFF
--- a/packages/dev/src/dev-feature-scratch-pad.tsx
+++ b/packages/dev/src/dev-feature-scratch-pad.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@workspace/ui/components/button'
+import { UiCard } from '@workspace/ui/components/ui-card'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+
+export default function DevFeatureScratchPad() {
+  return (
+    <UiCard
+      action={
+        <Button
+          onClick={() => {
+            toastSuccess('Success')
+          }}
+          variant="outline"
+        >
+          Click
+        </Button>
+      }
+      description="Your place to quickly test some UI components"
+      title="Scratch Pad"
+    >
+      <div className="space-y-6">Start here</div>
+    </UiCard>
+  )
+}

--- a/packages/dev/src/dev-routes.tsx
+++ b/packages/dev/src/dev-routes.tsx
@@ -2,6 +2,7 @@ import { UiTabRoutes } from '@workspace/ui/components/ui-tab-routes'
 import { lazy } from 'react'
 
 const DevFeatureDb = lazy(() => import('./dev-feature-db.js'))
+const DevFeatureScratchPad = lazy(() => import('./dev-feature-scratch-pad.js'))
 const DevFeatureSolana = lazy(() => import('./dev-feature-solana.js'))
 const DevFeatureUi = lazy(() => import('./dev-feature-ui.js'))
 
@@ -11,6 +12,7 @@ export default function DevRoutes() {
       basePath="/dev"
       className="mt-2 mb-4 lg:mb-6"
       tabs={[
+        { element: <DevFeatureScratchPad />, label: 'Scratch Pad', path: 'scratch-pad' },
         { element: <DevFeatureDb />, label: 'DB', path: 'db' },
         { element: <DevFeatureSolana />, label: 'Solana', path: 'solana' },
         { element: <DevFeatureUi />, label: 'UI', path: 'ui' },


### PR DESCRIPTION
I often find myself needing a place in the UI to quickly try things or sketch out new components. This PR adds such a place. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `DevFeatureScratchPad` component and route for quick UI component testing.
> 
>   - **Feature Addition**:
>     - Adds `DevFeatureScratchPad` component in `dev-feature-scratch-pad.tsx` for testing UI components.
>     - Includes a button that triggers a success toast message.
>   - **Routing**:
>     - Updates `dev-routes.tsx` to include a new route for `Scratch Pad` under `/dev` path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ed35b5e6b7ccf174012ff1b434f756f4533232fa. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->