### PR TITLE
fix: make accountId param required in usDbWalletLive function

### DIFF
--- a/packages/db-react/src/use-db-wallet-live.tsx
+++ b/packages/db-react/src/use-db-wallet-live.tsx
@@ -3,10 +3,7 @@ import type { Wallet } from '@workspace/db/entity/wallet'
 import { db } from '@workspace/db/db'
 import { useLiveQuery } from 'dexie-react-hooks'
 
-import { useDbPreference } from './use-db-preference'
-
-export function useDbWalletLive() {
-  const [accountId] = useDbPreference('activeAccountId')
+export function useDbWalletLive({ accountId }: { accountId: null | string }) {
   return useLiveQuery<Wallet[], Wallet[]>(
     () =>
       db.wallets

--- a/packages/portfolio/src/ui/portfolio-ui-wallet-guard.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-wallet-guard.tsx
@@ -13,10 +13,11 @@ export function PortfolioUiWalletGuard({
   fallback = <div>Wallet not selected</div>,
   render,
 }: PortfolioUiWalletGuardProps) {
-  const walletLive = useDbWalletLive()
-  const [activeId] = useDbPreference('activeWalletId')
+  const [walletId] = useDbPreference('activeWalletId')
+  const [accountId] = useDbPreference('activeAccountId')
+  const walletLive = useDbWalletLive({ accountId: accountId })
 
-  const wallet = useMemo(() => walletLive.find((item) => item.id === activeId), [activeId, walletLive])
+  const wallet = useMemo(() => walletLive.find((item) => item.id === walletId), [walletId, walletLive])
 
   return wallet ? render({ wallet }) : fallback
 }

--- a/packages/settings/src/data-access/use-active-wallet.tsx
+++ b/packages/settings/src/data-access/use-active-wallet.tsx
@@ -4,10 +4,11 @@ import { useDbWalletSetActive } from '@workspace/db-react/use-db-wallet-set-acti
 import { useMemo } from 'react'
 
 export function useActiveWallet() {
-  const wallets = useDbWalletLive()
-  const [activeId] = useDbPreference('activeWalletId')
+  const [walletId] = useDbPreference('activeWalletId')
+  const [accountId] = useDbPreference('activeAccountId')
+  const wallets = useDbWalletLive({ accountId: accountId })
   const { mutateAsync } = useDbWalletSetActive()
-  const active = useMemo(() => wallets.find((c) => c.id === activeId) ?? null, [wallets, activeId])
+  const active = useMemo(() => wallets.find((c) => c.id === walletId) ?? null, [wallets, walletId])
 
   return {
     active,

--- a/packages/settings/src/settings-feature-account-details.tsx
+++ b/packages/settings/src/settings-feature-account-details.tsx
@@ -1,4 +1,5 @@
 import { useDbAccountFindUnique } from '@workspace/db-react/use-db-account-find-unique'
+import { useDbWalletLive } from '@workspace/db-react/use-db-wallet-live'
 import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { UiError } from '@workspace/ui/components/ui-error'
@@ -14,7 +15,8 @@ import { SettingsUiWalletTable } from './ui/settings-ui-wallet-table.js'
 export function SettingsFeatureAccountDetails() {
   const { accountId } = useParams() as { accountId: string }
   const { data: item, error, isError, isLoading } = useDbAccountFindUnique({ id: accountId })
-  const { active, setActive, wallets } = useActiveWallet()
+  const { active, setActive } = useActiveWallet()
+  const wallets = useDbWalletLive({ accountId })
   const deriveWallet = useDeriveAndCreateWallet()
 
   if (isLoading) {


### PR DESCRIPTION
This PR fixes an issue I introduced earlier where the account detail list showed the wallets from the *active* account instead of from the account we're looking at.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `useDbWalletLive` to require `accountId` and updates components to ensure correct account's wallets are displayed.
> 
>   - **Behavior**:
>     - `useDbWalletLive` now requires an `accountId` parameter to fetch wallets for the specified account.
>     - Fixes issue where wallets from the active account were shown instead of the specified account.
>   - **Components**:
>     - `PortfolioUiWalletGuard` now passes `accountId` to `useDbWalletLive` and uses `walletId` for wallet selection.
>     - `useActiveWallet` in `use-active-wallet.tsx` updated to pass `accountId` to `useDbWalletLive` and use `walletId` for active wallet.
>     - `SettingsFeatureAccountDetails` now directly calls `useDbWalletLive` with `accountId` from `useParams`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 794244410b6bebf7293eab4264015af83bc0ea81. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->