### PR TITLE
feat: make settings-ui-wallet-table responsive

### DIFF
--- a/packages/settings/src/ui/settings-ui-wallet-table.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-table.tsx
@@ -1,6 +1,7 @@
 import type { Wallet } from '@workspace/db/entity/wallet'
 
 import { Button } from '@workspace/ui/components/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@workspace/ui/components/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
 import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
 import { LucideCheck, LucidePlus } from 'lucide-react'
@@ -17,37 +18,83 @@ export function SettingsUiWalletTable({
   setActive: (id: string) => Promise<void>
 }) {
   return (
-    <Table>
-      <TableHeader>
-        <TableRow className="hover:bg-transparent">
-          <TableHead className="w-[20px]">#</TableHead>
-          <TableHead>Name</TableHead>
-          <TableHead>PublicKey</TableHead>
-          <TableHead className="flex justify-end">
-            <Button onClick={deriveWallet} size="icon" variant="outline">
-              <LucidePlus />
-            </Button>
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {items.map((item) => (
-          <TableRow key={item.id}>
-            <TableCell>{item.derivationIndex}</TableCell>
-            <TableCell>{item.name}</TableCell>
-            <TableCell className="font-mono text-xs">{item.publicKey}</TableCell>
-            <TableCell>
-              {active?.id === item.id ? null : (
-                <UiTooltip content="Set as active">
-                  <Button onClick={() => setActive(item.id)} size="icon" variant="outline">
-                    <LucideCheck className="text-green-500 size-4" />
-                  </Button>
-                </UiTooltip>
-              )}
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+    <div>
+      {/* Mobile View */}
+      <div className="md:hidden">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Wallets</h2>
+          <Button onClick={deriveWallet} size="icon" variant="outline">
+            <LucidePlus />
+          </Button>
+        </div>
+        <div className="space-y-4">
+          {items.map((item) => (
+            <Card key={item.id}>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>{item.name}</span>
+                  {active?.id === item.id ? (
+                    <UiTooltip content="Active wallet">
+                      <Button size="icon" variant="secondary">
+                        <LucideCheck className="text-green-500 size-4" />
+                      </Button>
+                    </UiTooltip>
+                  ) : (
+                    <UiTooltip content="Set as active">
+                      <Button onClick={() => setActive(item.id)} size="icon" variant="outline">
+                        <LucideCheck className="size-4" />
+                      </Button>
+                    </UiTooltip>
+                  )}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="font-mono text-xs break-all">{item.publicKey}</div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      {/* Desktop View */}
+      <div className="hidden md:block">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead>Name</TableHead>
+              <TableHead>Public Key</TableHead>
+              <TableHead className="flex justify-end">
+                <Button onClick={deriveWallet} size="icon" variant="outline">
+                  <LucidePlus />
+                </Button>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.name}</TableCell>
+                <TableCell className="font-mono text-xs">{item.publicKey}</TableCell>
+                <TableCell className="text-right">
+                  {active?.id === item.id ? (
+                    <UiTooltip content="Active wallet">
+                      <Button size="icon" variant="secondary">
+                        <LucideCheck className="text-green-500 size-4" />
+                      </Button>
+                    </UiTooltip>
+                  ) : (
+                    <UiTooltip content="Set as active">
+                      <Button onClick={() => setActive(item.id)} size="icon" variant="outline">
+                        <LucideCheck className="size-4" />
+                      </Button>
+                    </UiTooltip>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `SettingsUiWalletTable` is updated to be responsive with distinct mobile and desktop layouts using cards and tables, respectively.
> 
>   - **Responsive Design**:
>     - `SettingsUiWalletTable` now supports responsive design with separate mobile and desktop views.
>     - Mobile view uses `Card`, `CardContent`, `CardHeader`, and `CardTitle` for wallet items.
>     - Desktop view retains `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, and `TableRow` for wallet items.
>   - **UI Components**:
>     - Adds `Card`, `CardContent`, `CardHeader`, and `CardTitle` imports for mobile view.
>     - Adjusts button placement and tooltip usage for both views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 34fec3c7381677bca1b858ec2cf95f138d203ff9. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->