### PR TITLE
feat(extension): hide buttons until connected

### DIFF
--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -47,6 +47,10 @@ export function App() {
             {wallet.features.map((feature) => {
               switch (feature) {
                 case StandardConnect: {
+                  if (account) {
+                    return null
+                  }
+
                   const { connect } = getWalletFeature(
                     wallet,
                     StandardConnect,
@@ -72,6 +76,10 @@ export function App() {
                 }
 
                 case StandardDisconnect: {
+                  if (!account) {
+                    return null
+                  }
+
                   const { disconnect } = getWalletFeature(
                     wallet,
                     StandardDisconnect,
@@ -84,20 +92,11 @@ export function App() {
                   )
                 }
 
-                case StandardEvents: {
-                  const { on } = getWalletFeature(
-                    wallet,
-                    StandardEvents,
-                  ) as StandardEventsFeature[typeof StandardEvents]
-
-                  return (
-                    <Button key={feature} onClick={() => on('change', console.log)}>
-                      On
-                    </Button>
-                  )
-                }
-
                 case SolanaSignAndSendTransaction: {
+                  if (!account) {
+                    return null
+                  }
+
                   const { signAndSendTransaction } = getWalletFeature(
                     wallet,
                     SolanaSignAndSendTransaction,
@@ -111,6 +110,10 @@ export function App() {
                 }
 
                 case SolanaSignTransaction: {
+                  if (!account) {
+                    return null
+                  }
+
                   const { signTransaction } = getWalletFeature(
                     wallet,
                     SolanaSignTransaction,
@@ -124,6 +127,10 @@ export function App() {
                 }
 
                 case SolanaSignMessage: {
+                  if (!account) {
+                    return null
+                  }
+
                   const { signMessage } = getWalletFeature(
                     wallet,
                     SolanaSignMessage,
@@ -137,6 +144,10 @@ export function App() {
                 }
 
                 case SolanaSignIn: {
+                  if (!account) {
+                    return null
+                  }
+
                   const { signIn } = getWalletFeature(wallet, SolanaSignIn) as SolanaSignInFeature[typeof SolanaSignIn]
 
                   return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `app.tsx`, conditionally render wallet feature buttons based on connection status, hiding them when not applicable.
> 
>   - **Behavior**:
>     - In `App` component in `app.tsx`, buttons for `StandardConnect` are hidden if `account` is defined.
>     - Buttons for `StandardDisconnect`, `SolanaSignAndSendTransaction`, `SolanaSignTransaction`, `SolanaSignMessage`, and `SolanaSignIn` are hidden if `account` is not defined.
>   - **Misc**:
>     - Removed `StandardEvents` case from the feature switch statement in `app.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f37ddb0e180b55334a71510ecbabe91ba1387bae. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->