### PR TITLE
feat(extension): add sign message support

### DIFF
--- a/apps/extension/entrypoints/request/app.tsx
+++ b/apps/extension/entrypoints/request/app.tsx
@@ -1,8 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { getDbService } from '@workspace/background/services/db'
 import { getRequestService } from '@workspace/background/services/request'
+import { getSignService } from '@workspace/background/services/sign'
 import { Button } from '@workspace/ui/components/button'
 
+// TODO: Refactor each type into its own component
 export function App() {
   const { data, isLoading } = useQuery({
     queryFn: async () => await getRequestService().get(),
@@ -20,12 +22,28 @@ export function App() {
           <h1 className="text-2xl font-bold text-center">Connect</h1>
           <div className="flex flex-col gap-2">
             <Button
-              onClick={async () => getRequestService().resolve(await getDbService().wallet.walletAccounts())}
+              onClick={async () => await getRequestService().resolve(await getDbService().wallet.walletAccounts())}
               variant="destructive"
             >
               Approve
             </Button>
-            <Button onClick={async () => getRequestService().reject()}>Reject</Button>
+            <Button onClick={async () => await getRequestService().reject()}>Reject</Button>
+          </div>
+        </div>
+      )
+
+    case 'signMessage':
+      return (
+        <div className="p-4 flex flex-col gap-4">
+          <h1 className="text-2xl font-bold text-center">Sign Message</h1>
+          <div className="flex flex-col gap-2">
+            <Button
+              onClick={async () => await getRequestService().resolve(await getSignService().signMessage(data.data))}
+              variant="destructive"
+            >
+              Approve
+            </Button>
+            <Button onClick={async () => await getRequestService().reject()}>Reject</Button>
           </div>
         </div>
       )

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -22,6 +22,14 @@ import {
   getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
   getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
 } from '@wallet-standard/ui-registry'
+import {
+  address,
+  getBase58Decoder,
+  getPublicKeyFromAddress,
+  getUtf8Encoder,
+  signatureBytes,
+  verifySignature,
+} from '@solana/kit'
 
 export function App() {
   const wallets = useWallets()
@@ -135,7 +143,24 @@ export function App() {
                   ) as SolanaSignMessageFeature[typeof SolanaSignMessage]
 
                   return (
-                    <Button key={feature} onClick={() => signMessage()}>
+                    <Button
+                      key={feature}
+                      onClick={async () => {
+                        const message = new Uint8Array(getUtf8Encoder().encode('Hello, World!'))
+                        const [response] = await signMessage({
+                          account,
+                          message,
+                        })
+                        console.log('Signed Message:', response)
+
+                        const decoded = getBase58Decoder().decode(response.signature)
+                        console.log('Signature:', decoded)
+
+                        const key = await getPublicKeyFromAddress(address(account.address))
+                        const verified = await verifySignature(key, signatureBytes(response.signature), message)
+                        console.log('Verified:', verified)
+                      }}
+                    >
                       Sign Message
                     </Button>
                   )

--- a/packages/background/src/actions/connect.ts
+++ b/packages/background/src/actions/connect.ts
@@ -3,7 +3,5 @@ import type { StandardConnectInput, StandardConnectOutput } from '@wallet-standa
 import { getRequestService } from '../services/request'
 
 export async function connect(input?: StandardConnectInput): Promise<StandardConnectOutput> {
-  console.log('Connect', input)
-
   return await getRequestService().create('connect', input)
 }

--- a/packages/background/src/actions/sign-message.ts
+++ b/packages/background/src/actions/sign-message.ts
@@ -1,7 +1,7 @@
 import type { SolanaSignMessageInput, SolanaSignMessageOutput } from '@solana/wallet-standard-features'
 
-export async function signMessage(inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> {
-  console.log('Sign Message', inputs)
+import { getRequestService } from '../services/request'
 
-  return Promise.resolve([])
+export async function signMessage(inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> {
+  return await getRequestService().create('signMessage', inputs)
 }

--- a/packages/background/src/services.ts
+++ b/packages/background/src/services.ts
@@ -1,7 +1,9 @@
 import { registerDbService } from './services/db'
 import { registerRequestService } from './services/request'
+import { registerSignService } from './services/sign'
 
 export function services() {
   registerDbService()
   registerRequestService()
+  registerSignService()
 }

--- a/packages/background/src/services/sign.ts
+++ b/packages/background/src/services/sign.ts
@@ -1,0 +1,35 @@
+import type { SolanaSignMessageInput, SolanaSignMessageOutput } from '@solana/wallet-standard-features'
+
+import { createKeyPairFromBytes, signBytes } from '@solana/kit'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- https://github.com/aklinker1/webext-core/pull/117
+import { defineProxyService } from '@webext-core/proxy-service'
+
+import { getDbService } from './db'
+
+export const [registerSignService, getSignService] = defineProxyService('SignService', () => ({
+  // TODO: What security measures should be in place here?
+  signMessage: async (inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> => {
+    const results: SolanaSignMessageOutput[] = []
+    const active = await getDbService().wallet.active()
+    if (!active.secretKey) {
+      throw new Error('Active wallet has no secret key')
+    }
+
+    const bytes = new Uint8Array(JSON.parse(active.secretKey))
+    const { privateKey } = await createKeyPairFromBytes(bytes)
+
+    for (const input of inputs) {
+      const messageBytes = new Uint8Array(Object.values(input.message))
+      const signedBytes = await signBytes(privateKey, messageBytes)
+
+      results.push({
+        signature: signedBytes,
+        signatureType: 'ed25519',
+        signedMessage: messageBytes,
+      })
+    }
+
+    return results
+  },
+}))

--- a/packages/wallet-standard/src/features/sign-message.ts
+++ b/packages/wallet-standard/src/features/sign-message.ts
@@ -3,8 +3,11 @@ import type { SolanaSignMessageInput, SolanaSignMessageOutput } from '@solana/wa
 import { sendMessage } from '@workspace/background/window'
 
 export async function signMessage(...inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> {
-  const response = await sendMessage('signMessage', inputs)
-  console.log('Sign Message', response)
+  const outputs = await sendMessage('signMessage', inputs)
 
-  return response
+  return outputs.map((output) => ({
+    signature: new Uint8Array(Object.values(output.signature)),
+    signatureType: output.signatureType,
+    signedMessage: new Uint8Array(Object.values(output.signedMessage)),
+  }))
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for signing messages in Solana wallet extension, including new services and request handling updates.
> 
>   - **Behavior**:
>     - Adds 'signMessage' case in `App` component in `app.tsx` to handle message signing requests.
>     - Implements `signMessage` function in `sign-message.ts` to create 'signMessage' requests.
>     - Updates `RequestService` in `request.ts` to handle 'signMessage' type.
>   - **Services**:
>     - Introduces `sign.ts` to define `SignService` for signing messages using Solana keys.
>     - Registers `SignService` in `services.ts`.
>   - **Examples**:
>     - Updates `examples/basic/src/app.tsx` to demonstrate message signing and verification using Solana features.
>   - **Misc**:
>     - Removes console log from `connect.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 1713f08007ab410bfe1ad4a11decb365e09336c5. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->