### PR TITLE
fix: ensure cluster endpoint can be updated

### DIFF
--- a/packages/settings/src/ui/settings-ui-cluster-form-update.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-form-update.tsx
@@ -41,10 +41,7 @@ export function SettingsUiClusterFormUpdate({
               <FormLabel>Endpoint * </FormLabel>
               <FormControl>
                 <Input
-                  onChange={(e) => {
-                    const val = e.target.value
-                    field.onChange(+val)
-                  }}
+                  onChange={(e) => field.onChange(e.target.value)}
                   placeholder="Cluster Endpoint"
                   type="url"
                   value={field.value}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `onChange` handler in `SettingsUiClusterFormUpdate` to update endpoint as a string, ensuring correct cluster endpoint updates.
> 
>   - **Behavior**:
>     - Fixes `onChange` handler in `SettingsUiClusterFormUpdate` to update endpoint as a string instead of a number.
>     - Ensures cluster endpoint can be updated correctly in the form.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for e86f2a4189897faa7282fe32a6bd72f0c69e60ad. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->