### PR TITLE
fix(docs): correct GitHub repo URL

### DIFF
--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -25,7 +25,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components'
       Follow us on X to stay up to date with the project!
     </Card>
   </a>
-  <a href="https://x.com/SamuiBuild" target="_blank" style={{ textDecoration: 'none' }}>
+  <a href="https://github.com/samui-build/samui-wallet" target="_blank" style={{ textDecoration: 'none' }}>
     <Card title="Star our repo on GitHub" icon="github">
       Star our repo on GitHub or fork it and start contributing!
     </Card>


### PR DESCRIPTION
Not much😁
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects GitHub repository URL in `index.mdx` to ensure accurate link to the project.
> 
>   - **Docs**:
>     - Corrects GitHub repository URL in `index.mdx` from `https://x.com/SamuiBuild` to `https://github.com/samui-build/samui-wallet`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ac6c15acf1f4b31dffc0785d26bbc479f2f0724b. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->