### PR TITLE
feat(portfolio): send SOL transaction

### DIFF
--- a/packages/portfolio/package.json
+++ b/packages/portfolio/package.json
@@ -7,6 +7,7 @@
     "@workspace/core": "workspace:*",
     "@workspace/db": "workspace:*",
     "@workspace/db-react": "workspace:*",
+    "@workspace/keypair": "workspace:*",
     "@workspace/solana-client": "workspace:*",
     "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",

--- a/packages/portfolio/src/data-access/use-get-token-metadata.ts
+++ b/packages/portfolio/src/data-access/use-get-token-metadata.ts
@@ -29,8 +29,6 @@ export interface TokenMetadata {
 }
 
 export function useGetTokenBalances(props: { cluster: Cluster; wallet: Wallet }) {
-  //
-
   const { data: dataBalance, isLoading: isLoadingBalance } = useGetBalance(props)
   const { data: dataTokenAccounts, isLoading: isLoadingTokenAccounts } = useGetTokenAccounts(props)
 

--- a/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
@@ -1,3 +1,5 @@
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { useMemo } from 'react'
 
 import type { ClusterWallet } from './portfolio-routes-loaded.js'
@@ -5,9 +7,12 @@ import type { ClusterWallet } from './portfolio-routes-loaded.js'
 import { useGetTokenBalances } from './data-access/use-get-token-metadata.js'
 import { PortfolioUiTokenBalances } from './ui/portfolio-ui-token-balances.js'
 import { PortfolioUiWalletButtons } from './ui/portfolio-ui-wallet-buttons.js'
+import { useCreateAndSendSolTransaction } from './use-create-and-send-sol-transaction.js'
 
 export function PortfolioFeatureTabTokens(props: ClusterWallet) {
   const balances = useGetTokenBalances(props)
+
+  const sendSolMutation = useCreateAndSendSolTransaction(props)
 
   const totalBalance = useMemo(() => {
     const balance = balances.reduce((acc, item) => {
@@ -27,7 +32,18 @@ export function PortfolioFeatureTabTokens(props: ClusterWallet) {
   return (
     <div className="p-4 space-y-6">
       <div className="text-4xl font-bold text-center">$ {totalBalance}</div>
-      <PortfolioUiWalletButtons {...props} />
+      <PortfolioUiWalletButtons
+        balances={balances}
+        {...props}
+        send={async (input) => {
+          const done = await sendSolMutation.mutateAsync({ ...input, wallet: props.wallet })
+          if (done) {
+            toastSuccess('Sol has been sent!')
+          } else {
+            toastError(`Error sending SOL`)
+          }
+        }}
+      />
       <PortfolioUiTokenBalances items={balances} />
     </div>
   )

--- a/packages/portfolio/src/ui/portfolio-ui-cluster-guard.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-cluster-guard.tsx
@@ -1,8 +1,11 @@
 import type { Cluster } from '@workspace/db/entity/cluster'
+import type { Wallet } from '@workspace/db/entity/wallet'
 
 import { useDbClusterLive } from '@workspace/db-react/use-db-cluster-live'
 import { useDbPreference } from '@workspace/db-react/use-db-preference'
 import React, { useMemo } from 'react'
+
+import { PortfolioUiWalletGuard } from './portfolio-ui-wallet-guard.js'
 
 export interface PortfolioUiClusterGuardProps {
   fallback?: React.ReactNode
@@ -18,4 +21,16 @@ export function PortfolioUiClusterGuard({
   const cluster = useMemo(() => clusterLive.find((item) => item.id === activeId), [activeId, clusterLive])
 
   return cluster ? render({ cluster }) : fallback
+}
+
+export function PortfolioUiClusterWalletGuard({
+  render,
+}: {
+  render: (props: { cluster: Cluster; wallet: Wallet }) => React.ReactNode
+}) {
+  return (
+    <PortfolioUiClusterGuard
+      render={({ cluster }) => <PortfolioUiWalletGuard render={({ wallet }) => render({ cluster, wallet })} />}
+    />
+  )
 }

--- a/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
@@ -1,0 +1,31 @@
+import { UiAvatar } from '@workspace/ui/components/ui-avatar'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+
+import type { TokenBalance } from '../data-access/use-get-token-metadata.js'
+
+export function PortfolioUiTokenBalanceItem({ item }: { item: TokenBalance }) {
+  const name = item.metadata?.name ?? ellipsify(item.mint)
+  const symbol = item.metadata?.symbol ?? ellipsify(item.mint, 2, '').toLocaleUpperCase()
+  const icon = item.metadata?.icon
+  return (
+    <div className="flex justify-between items-center w-full" key={item.mint}>
+      <div className="flex items-center gap-2">
+        <div className="flex justify-center items-center size-14">
+          {icon ? (
+            <UiAvatar className="size-12" label={name} src={icon} />
+          ) : (
+            <UiAvatar className="size-12" label={symbol} />
+          )}
+        </div>
+        <div className="flex flex-col items-start mr-6">
+          <div className="font-bold">{name}</div>
+          <div className="text-muted-foreground">{symbol}</div>
+        </div>
+      </div>
+      <div className="flex flex-col items-end" style={{ flexGrow: 1 }}>
+        <div>$ {item.balanceUsd}</div>
+        <div className="text-muted-foreground text-sm">{item.balanceToken}</div>
+      </div>
+    </div>
+  )
+}

--- a/packages/portfolio/src/ui/portfolio-ui-token-balances.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balances.tsx
@@ -1,38 +1,7 @@
-import { UiAvatar } from '@workspace/ui/components/ui-avatar'
-import { ellipsify } from '@workspace/ui/lib/ellipsify'
-
 import type { TokenBalance } from '../data-access/use-get-token-metadata.js'
 
-export function PortfolioUiTokenBalances({ items }: { items: TokenBalance[] }) {
-  return (
-    <div>
-      {items.map((item) => {
-        const name = item.metadata?.name ?? ellipsify(item.mint)
-        const symbol = item.metadata?.symbol ?? ellipsify(item.mint, 2, '').toLocaleUpperCase()
-        const icon = item.metadata?.icon
+import { PortfolioUiTokenBalanceItem } from './portfolio-ui-token-balance-item.js'
 
-        return (
-          <div className="flex justify-between items-center" key={item.mint}>
-            <div className="flex items-center gap-2">
-              <div className="flex justify-center items-center size-14">
-                {icon ? (
-                  <img alt={name} className="size-12" src={icon} />
-                ) : (
-                  <UiAvatar className="size-12" label={symbol} />
-                )}
-              </div>
-              <div style={{ flexGrow: 1 }}>
-                <div>{name}</div>
-                <div className="font-bold text-muted-foreground">{symbol}</div>
-              </div>
-            </div>
-            <div className="flex flex-col items-end" style={{ flexGrow: 1 }}>
-              <div>$ {item.balanceUsd}</div>
-              <div className="text-muted-foreground text-sm">{item.balanceToken}</div>
-            </div>
-          </div>
-        )
-      })}
-    </div>
-  )
+export function PortfolioUiTokenBalances({ items }: { items: TokenBalance[] }) {
+  return items.map((item) => <PortfolioUiTokenBalanceItem item={item} key={item.mint} />)
 }

--- a/packages/portfolio/src/ui/portfolio-ui-wallet-buttons.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-wallet-buttons.tsx
@@ -1,13 +1,21 @@
+import type { TokenBalance } from '../data-access/use-get-token-metadata.js'
 import type { ClusterWallet } from '../portfolio-routes-loaded.js'
 
 import { PortfolioUiWalletSheetReceive } from './portfolio-ui-wallet-sheet-receive.js'
 import { PortfolioUiWalletSheetSend } from './portfolio-ui-wallet-sheet-send.js'
 
-export function PortfolioUiWalletButtons({ wallet }: ClusterWallet) {
+export function PortfolioUiWalletButtons({
+  balances,
+  send,
+  wallet,
+}: {
+  balances: TokenBalance[]
+  send: (input: { amount: string; destination: string; mint: TokenBalance }) => Promise<void>
+} & ClusterWallet) {
   return wallet ? (
     <div className="gap-2 flex justify-center">
       <PortfolioUiWalletSheetReceive wallet={wallet} />
-      <PortfolioUiWalletSheetSend />
+      <PortfolioUiWalletSheetSend balances={balances} send={send} />
     </div>
   ) : null
 }

--- a/packages/portfolio/src/ui/portfolio-ui-wallet-form-send.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-wallet-form-send.tsx
@@ -1,0 +1,81 @@
+import { Button } from '@workspace/ui/components/button'
+import { Field, FieldGroup, FieldLabel, FieldSet } from '@workspace/ui/components/field'
+import { Input } from '@workspace/ui/components/input'
+import { useMemo, useState } from 'react'
+
+import type { TokenBalance } from '../data-access/use-get-token-metadata.js'
+
+import { PortfolioUiWalletFormTokenDropdown } from './portfolio-ui-wallet-form-token-dropdown.js'
+
+export function PortfolioUiWalletFormSend({
+  balances,
+  send,
+}: {
+  balances: TokenBalance[]
+  send: (input: { amount: string; destination: string; mint: TokenBalance }) => Promise<void>
+}) {
+  const [mintAddress, setMintAddress] = useState('So11111111111111111111111111111111111111112')
+  const [amount, setAmount] = useState('0')
+  const [destination, setDestination] = useState('')
+  const mint = useMemo(() => {
+    return balances.find((item) => item.mint === mintAddress)
+  }, [balances, mintAddress])
+
+  return (
+    <div className="w-full max-w-md md:px-4">
+      <form>
+        <FieldGroup>
+          <FieldSet>
+            <PortfolioUiWalletFormTokenDropdown
+              mint={mint}
+              mintAddress={mintAddress}
+              setMintAddress={setMintAddress}
+              tokens={balances}
+            />
+
+            <FieldGroup>
+              <Field>
+                <FieldLabel htmlFor="destination">Destination</FieldLabel>
+                <Input
+                  id="destination"
+                  onChange={(e) => setDestination(e.target.value)}
+                  placeholder="Destination"
+                  type="text"
+                  value={destination}
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor="amount">Amount</FieldLabel>
+                <Input
+                  id="amount"
+                  min="1"
+                  onChange={(e) => setAmount(e.target.value)}
+                  placeholder="Amount"
+                  required
+                  step="any"
+                  type="number"
+                  value={amount}
+                />
+              </Field>
+            </FieldGroup>
+          </FieldSet>
+          <Field className="flex justify-end" orientation="horizontal">
+            <Button
+              disabled={!mint || !amount || !destination}
+              onClick={async (e) => {
+                e.preventDefault()
+                if (!mint) {
+                  return
+                }
+                await send({ amount, destination, mint })
+              }}
+              type="button"
+            >
+              Submit
+            </Button>
+          </Field>
+        </FieldGroup>
+      </form>
+    </div>
+  )
+}

--- a/packages/portfolio/src/ui/portfolio-ui-wallet-form-token-dropdown.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-wallet-form-token-dropdown.tsx
@@ -1,0 +1,67 @@
+import { Button } from '@workspace/ui/components/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@workspace/ui/components/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@workspace/ui/components/popover'
+import { cn } from '@workspace/ui/lib/utils'
+import { ChevronsUpDown } from 'lucide-react'
+import { useState } from 'react'
+
+import type { TokenBalance } from '../data-access/use-get-token-metadata.js'
+
+import { PortfolioUiTokenBalanceItem } from './portfolio-ui-token-balance-item.js'
+
+export function PortfolioUiWalletFormTokenDropdown({
+  mint,
+  mintAddress,
+  setMintAddress,
+  tokens,
+}: {
+  mint: TokenBalance | undefined
+  mintAddress: string
+  setMintAddress: (mintAddress: string) => void
+  tokens: TokenBalance[]
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>
+        <Button aria-expanded={open} className="w-full h-[60px] justify-between" role="combobox" variant="outline">
+          {mint ? <PortfolioUiTokenBalanceItem item={mint} /> : 'Select token...'}
+          <ChevronsUpDown className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-full p-0">
+        <Command>
+          <CommandInput className="h-9" placeholder="Search token..." />
+          <CommandList>
+            <CommandEmpty>No token found.</CommandEmpty>
+            <CommandGroup>
+              {tokens.map((item) => (
+                <CommandItem
+                  className={cn({
+                    'bg-muted': mintAddress === item.mint,
+                  })}
+                  key={item.mint}
+                  onSelect={(currentValue) => {
+                    setMintAddress(currentValue === mintAddress ? '' : currentValue)
+                    setOpen(false)
+                  }}
+                  value={item.mint}
+                >
+                  <PortfolioUiTokenBalanceItem item={item} />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/portfolio/src/ui/portfolio-ui-wallet-sheet-send.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-wallet-sheet-send.tsx
@@ -2,7 +2,17 @@ import { Button } from '@workspace/ui/components/button'
 import { UiBottomSheet } from '@workspace/ui/components/ui-bottom-sheet'
 import { LucideArrowUp } from 'lucide-react'
 
-export function PortfolioUiWalletSheetSend() {
+import type { TokenBalance } from '../data-access/use-get-token-metadata.js'
+
+import { PortfolioUiWalletFormSend } from './portfolio-ui-wallet-form-send.js'
+
+export function PortfolioUiWalletSheetSend({
+  balances,
+  send,
+}: {
+  balances: TokenBalance[]
+  send: (input: { amount: string; destination: string; mint: TokenBalance }) => Promise<void>
+}) {
   return (
     <UiBottomSheet
       description="Selecting the token, enter the destination public key and the amount."
@@ -13,7 +23,7 @@ export function PortfolioUiWalletSheetSend() {
         </Button>
       }
     >
-      <div>Placeholder for Send Form</div>
+      <PortfolioUiWalletFormSend balances={balances} send={send} />
     </UiBottomSheet>
   )
 }

--- a/packages/portfolio/src/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/use-create-and-send-sol-transaction.tsx
@@ -1,0 +1,23 @@
+import type { Wallet } from '@workspace/db/entity/wallet'
+
+import { useMutation } from '@tanstack/react-query'
+import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
+import { useSolanaClient } from '@workspace/solana-client-react/use-solana-client'
+import { createAndSendSolTransaction } from '@workspace/solana-client/create-and-send-sol-transaction'
+
+import type { ClusterWallet } from './portfolio-routes-loaded.js'
+
+export function useCreateAndSendSolTransaction(props: ClusterWallet) {
+  const client = useSolanaClient({ cluster: props.cluster })
+
+  return useMutation({
+    mutationFn: async ({ amount, destination, wallet }: { amount: string; destination: string; wallet: Wallet }) => {
+      if (!wallet.secretKey) {
+        throw new Error(`No secret key for this wallet`)
+      }
+      const sender = await createKeyPairSignerFromJson({ json: wallet.secretKey })
+
+      return createAndSendSolTransaction(client, { amount, destination, sender })
+    },
+  })
+}

--- a/packages/solana-client/package.json
+++ b/packages/solana-client/package.json
@@ -2,6 +2,7 @@
   "name": "@workspace/solana-client",
   "version": "0.0.0",
   "dependencies": {
+    "@solana-program/system": "catalog:",
     "@solana-program/token": "catalog:",
     "@solana-program/token-2022": "catalog:",
     "@solana/kit": "catalog:",

--- a/packages/solana-client/src/create-and-send-sol-transaction.ts
+++ b/packages/solana-client/src/create-and-send-sol-transaction.ts
@@ -1,0 +1,40 @@
+import type { KeyPairSigner } from '@solana/kit'
+
+import type { SolanaClient } from './solana-client'
+
+import { createSolTransferTransaction } from './create-sol-transfer-transaction'
+import {
+  getSignatureFromTransaction,
+  sendAndConfirmTransactionFactory,
+  signTransactionMessageWithSigners,
+} from './index'
+
+export async function createAndSendSolTransaction(
+  client: SolanaClient,
+  {
+    amount,
+    destination,
+    sender,
+  }: {
+    amount: string
+    destination: string
+    sender: KeyPairSigner
+  },
+): Promise<string> {
+  const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
+  const transactionMessage = createSolTransferTransaction({
+    amount,
+    destination,
+    latestBlockhash,
+    sender,
+  })
+
+  const signedTransaction = await signTransactionMessageWithSigners(transactionMessage)
+  // @ts-expect-error rpc clients are scoped to their cluster, we need to figure out how to handle this
+  await sendAndConfirmTransactionFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions })(
+    // @ts-expect-error TODO: Figure out "Property lastValidBlockHeight is missing in type TransactionDurableNonceLifetime but required in type"
+    signedTransaction,
+    { commitment: 'confirmed' },
+  )
+  return getSignatureFromTransaction(signedTransaction)
+}

--- a/packages/solana-client/src/create-sol-transfer-transaction.ts
+++ b/packages/solana-client/src/create-sol-transfer-transaction.ts
@@ -1,0 +1,52 @@
+import type { Address, Blockhash, TransactionSigner } from '@solana/kit'
+
+import { getTransferSolInstruction } from '@solana-program/system'
+import {
+  address,
+  appendTransactionMessageInstructions,
+  assertIsAddress,
+  assertIsKeyPairSigner,
+  createTransactionMessage,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit'
+
+import { solToLamports } from './sol-to-lamports'
+
+export interface LatestBlockhash {
+  blockhash: Blockhash
+  lastValidBlockHeight: bigint
+}
+
+export function createSolTransferTransaction({
+  amount,
+  destination,
+  latestBlockhash,
+  sender,
+  source,
+}: {
+  amount: string
+  destination: Address | string
+  latestBlockhash: LatestBlockhash
+  sender: TransactionSigner
+  source?: TransactionSigner
+}) {
+  assertIsAddress(destination)
+  assertIsKeyPairSigner(sender)
+  if (source) {
+    assertIsKeyPairSigner(source)
+  }
+  const transferInstruction = getTransferSolInstruction({
+    amount: solToLamports(amount),
+    destination: address(destination),
+    source: source ?? sender,
+  })
+
+  return pipe(
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(sender, tx),
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    (tx) => appendTransactionMessageInstructions([transferInstruction], tx),
+  )
+}

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { Label } from '@workspace/ui/components/label'
+import { Separator } from '@workspace/ui/components/separator'
+import { cn } from '@workspace/ui/lib/utils'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { useMemo } from 'react'
+
+function FieldGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4',
+        className,
+      )}
+      data-slot="field-group"
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = 'legend',
+  ...props
+}: { variant?: 'label' | 'legend' } & React.ComponentProps<'legend'>) {
+  return (
+    <legend
+      className={cn('mb-3 font-medium', 'data-[variant=legend]:text-base', 'data-[variant=label]:text-sm', className)}
+      data-slot="field-legend"
+      data-variant={variant}
+      {...props}
+    />
+  )
+}
+
+function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
+  return (
+    <fieldset
+      className={cn(
+        'flex flex-col gap-6',
+        'has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3',
+        className,
+      )}
+      data-slot="field-set"
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva('group/field flex w-full gap-3 data-[invalid=true]:text-destructive', {
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+  variants: {
+    orientation: {
+      horizontal: [
+        'flex-row items-center',
+        '[&>[data-slot=field-label]]:flex-auto',
+        'has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+      ],
+      responsive: [
+        'flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto',
+        '@md/field-group:[&>[data-slot=field-label]]:flex-auto',
+        '@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+      ],
+      vertical: ['flex-col [&>*]:w-full [&>.sr-only]:w-auto'],
+    },
+  },
+})
+
+function Field({
+  className,
+  orientation = 'vertical',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      className={cn(fieldVariants({ orientation }), className)}
+      data-orientation={orientation}
+      data-slot="field"
+      role="group"
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('group/field-content flex flex-1 flex-col gap-1.5 leading-snug', className)}
+      data-slot="field-content"
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <p
+      className={cn(
+        'text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance',
+        'last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5',
+        '[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
+        className,
+      )}
+      data-slot="field-description"
+      {...props}
+    />
+  )
+}
+
+function FieldError({
+  children,
+  className,
+  errors,
+  ...props
+}: {
+  errors?: Array<{ message?: string } | undefined>
+} & React.ComponentProps<'div'>) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn('text-destructive text-sm font-normal', className)}
+      data-slot="field-error"
+      role="alert"
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      className={cn(
+        'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50',
+        'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4',
+        'has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10',
+        className,
+      )}
+      data-slot="field-label"
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: {
+  children?: React.ReactNode
+} & React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn('relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2', className)}
+      data-content={!!children}
+      data-slot="field-separator"
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={cn(
+        'flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50',
+        className,
+      )}
+      data-slot="field-label"
+      {...props}
+    />
+  )
+}
+
+export {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+}

--- a/packages/ui/src/components/ui-bottom-sheet.tsx
+++ b/packages/ui/src/components/ui-bottom-sheet.tsx
@@ -21,7 +21,7 @@ export function UiBottomSheet({
           <SheetTitle>{title}</SheetTitle>
           <SheetDescription>{description}</SheetDescription>
         </SheetHeader>
-        <div className="flex flex-col gap-6 pb-10 items-center aspect-square">{children}</div>
+        <div className="flex flex-col gap-6 pb-10 items-center md:aspect-square">{children}</div>
       </SheetContent>
     </Sheet>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@hookform/resolvers':
       specifier: ^5.2.2
       version: 5.2.2
+    '@solana-program/system':
+      specifier: 0.9.0
+      version: 0.9.0
     '@solana-program/token':
       specifier: 0.7.0
       version: 0.7.0
@@ -687,6 +690,9 @@ importers:
       '@workspace/db-react':
         specifier: workspace:*
         version: link:../db-react
+      '@workspace/keypair':
+        specifier: workspace:*
+        version: link:../keypair
       '@workspace/solana-client':
         specifier: workspace:*
         version: link:../solana-client
@@ -864,6 +870,9 @@ importers:
 
   packages/solana-client:
     dependencies:
+      '@solana-program/system':
+        specifier: 'catalog:'
+        version: 0.9.0(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3))
       '@solana-program/token':
         specifier: 'catalog:'
         version: 0.7.0(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3))
@@ -3709,6 +3718,11 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@solana-program/system@0.9.0':
+    resolution: {integrity: sha512-yu+i0SZ+c+0E9Cy+btoMiCbxRnP/FLQuv/Ba8l2klZApAiOX1Ja/2IGkctFV36fglsI7PwD9czkSkHm8og+QeA==}
+    peerDependencies:
+      '@solana/kit': ^4.0
 
   '@solana-program/token-2022@0.6.0':
     resolution: {integrity: sha512-PHBkmAvzt4NKFSZB0toFkQ4iQE0KZIaOIDpDLfBbD0TaePA1LqG8i8Rb2zsav42g/xzL35dAw0kLzwB45O1alQ==}
@@ -13052,6 +13066,10 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@solana-program/system@0.9.0(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3))':
+    dependencies:
+      '@solana/kit': 4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3)
 
   '@solana-program/token-2022@0.6.0(@solana/kit@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3))(@solana/sysvars@4.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 catalog:
   '@eslint/js': 9.38.0
   '@hookform/resolvers': ^5.2.2
+  '@solana-program/system': 0.9.0
   '@solana-program/token': 0.7.0
   '@solana-program/token-2022': 0.6.0
   '@solana/kit': 4.0.0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add SOL transaction sending feature with UI components and Solana client integration in the portfolio package.
> 
>   - **Behavior**:
>     - Adds `useCreateAndSendSolTransaction` hook in `use-create-and-send-sol-transaction.tsx` to handle SOL transactions.
>     - Integrates SOL transaction sending in `PortfolioFeatureTabTokens` with success and error toasts.
>   - **UI Components**:
>     - Adds `PortfolioUiWalletFormSend` and `PortfolioUiWalletFormTokenDropdown` for transaction form and token selection.
>     - Updates `PortfolioUiWalletButtons` and `PortfolioUiWalletSheetSend` to include send functionality.
>     - Refactors `PortfolioUiTokenBalances` to use `PortfolioUiTokenBalanceItem` for individual token display.
>   - **Solana Client**:
>     - Adds `createAndSendSolTransaction` and `createSolTransferTransaction` functions for transaction creation and sending.
>     - Updates `package.json` to include `@solana-program/system` dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f38b73f3d3b1b7d0297b8621fabfb3c38c3a88e8. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->