### PR TITLE
feat(settings): add an 'experimental software' warning to cluster add/edit form

### DIFF
--- a/packages/db/src/schema/cluster-schema-update.ts
+++ b/packages/db/src/schema/cluster-schema-update.ts
@@ -1,3 +1,5 @@
 import { clusterSchema } from './cluster-schema'
 
-export const clusterSchemaUpdate = clusterSchema.omit({ createdAt: true, id: true, updatedAt: true }).partial()
+export const clusterSchemaUpdate = clusterSchema
+  .omit({ createdAt: true, id: true, type: true, updatedAt: true })
+  .partial()

--- a/packages/settings/src/ui/settings-ui-cluster-form-create.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-form-create.tsx
@@ -17,14 +17,45 @@ import { Input } from '@workspace/ui/components/input'
 import { ToggleGroup, ToggleGroupItem } from '@workspace/ui/components/toggle-group'
 import { useForm } from 'react-hook-form'
 
+import { SettingsUiClusterWarningMainnet } from './settings-ui-cluster-warning-mainnet.js'
+
 export function SettingsUiClusterFormCreate({ submit }: { submit: (input: ClusterInputCreate) => Promise<void> }) {
   const form = useForm<ClusterInputCreate>({
     resolver: standardSchemaResolver(clusterSchemaCreate),
   })
 
+  const watchType = form.watch('type')
+
   return (
     <Form {...form}>
       <form className="flex flex-col gap-6" onSubmit={form.handleSubmit((input) => submit(input))}>
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem className="flex flex-col gap-2 w-full py-1">
+              <FormLabel>Cluster *</FormLabel>
+              <FormControl>
+                <ToggleGroup
+                  className="flex justify-start items-center flex-wrap"
+                  onValueChange={field.onChange}
+                  type="single"
+                  value={field.value}
+                  variant="outline"
+                >
+                  {dbClusterTypeOptions.map(({ label, value }) => (
+                    <ToggleGroupItem className="flex items-center gap-x-2" key={value} value={value}>
+                      {label.replace('Solana ', '')}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              </FormControl>
+              <FormDescription>Select the type of cluster</FormDescription>
+              <FormMessage />
+              <SettingsUiClusterWarningMainnet type={watchType} />
+            </FormItem>
+          )}
+        />
         <FormField
           control={form.control}
           name="endpoint"
@@ -44,32 +75,6 @@ export function SettingsUiClusterFormCreate({ submit }: { submit: (input: Cluste
             </FormItem>
           )}
           rules={{ required: true }}
-        />
-        <FormField
-          control={form.control}
-          name="type"
-          render={({ field }) => (
-            <FormItem className="flex flex-col gap-2 w-full py-1">
-              <FormLabel>Cluster *</FormLabel>
-              <FormControl>
-                <ToggleGroup
-                  className="flex justify-start items-center flex-wrap"
-                  onValueChange={field.onChange}
-                  type="single"
-                  value={field.value}
-                  variant="outline"
-                >
-                  {dbClusterTypeOptions.map(({ label, value }) => (
-                    <ToggleGroupItem className="flex items-center gap-x-2" key={value} value={value}>
-                      {label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
-              </FormControl>
-              <FormDescription>Select the type of cluster</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
         />
         <FormField
           control={form.control}

--- a/packages/settings/src/ui/settings-ui-cluster-form-update.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-form-update.tsx
@@ -18,6 +18,8 @@ import { Input } from '@workspace/ui/components/input'
 import { ToggleGroup, ToggleGroupItem } from '@workspace/ui/components/toggle-group'
 import { useForm } from 'react-hook-form'
 
+import { SettingsUiClusterWarningMainnet } from './settings-ui-cluster-warning-mainnet.js'
+
 export function SettingsUiClusterFormUpdate({
   item,
   submit,
@@ -33,6 +35,27 @@ export function SettingsUiClusterFormUpdate({
   return (
     <Form {...form}>
       <form className="flex flex-col gap-6" onSubmit={form.handleSubmit((input) => submit(input))}>
+        <FormItem className="flex flex-col gap-2 w-full py-1">
+          <FormLabel>Cluster</FormLabel>
+          <FormControl>
+            <ToggleGroup
+              className="flex justify-start items-center flex-wrap"
+              defaultValue={item.type}
+              disabled
+              type="single"
+              variant="outline"
+            >
+              {dbClusterTypeOptions.map(({ label, value }) => (
+                <ToggleGroupItem className="flex items-center gap-x-2" key={value} value={value}>
+                  {label.replace('Solana ', '')}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          </FormControl>
+          <FormDescription>You can&#39;t change the type of cluster after you created it.</FormDescription>
+          <FormMessage />
+          <SettingsUiClusterWarningMainnet type={item.type} />
+        </FormItem>
         <FormField
           control={form.control}
           name="endpoint"
@@ -52,32 +75,6 @@ export function SettingsUiClusterFormUpdate({
             </FormItem>
           )}
           rules={{ required: true }}
-        />
-        <FormField
-          control={form.control}
-          name="type"
-          render={({ field }) => (
-            <FormItem className="flex flex-col gap-2 w-full py-1">
-              <FormLabel>Cluster *</FormLabel>
-              <FormControl>
-                <ToggleGroup
-                  className="flex justify-start items-center flex-wrap"
-                  onValueChange={field.onChange}
-                  type="single"
-                  value={field.value}
-                  variant="outline"
-                >
-                  {dbClusterTypeOptions.map(({ label, value }) => (
-                    <ToggleGroupItem className="flex items-center gap-x-2" key={value} value={value}>
-                      {label}
-                    </ToggleGroupItem>
-                  ))}
-                </ToggleGroup>
-              </FormControl>
-              <FormDescription>Select the type of cluster</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
         />
         <FormField
           control={form.control}

--- a/packages/settings/src/ui/settings-ui-cluster-warning-mainnet.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-warning-mainnet.tsx
@@ -1,0 +1,20 @@
+import type { ClusterType } from '@workspace/db/entity/cluster-type'
+
+import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert'
+import { AlertTriangleIcon } from 'lucide-react'
+
+export function SettingsUiClusterWarningMainnet({ type }: { type?: ClusterType }) {
+  if (!type || type !== 'solana:mainnet') {
+    return null
+  }
+
+  return (
+    <Alert variant="warning">
+      <AlertTriangleIcon />
+      <AlertTitle>This is experimental software.</AlertTitle>
+      <AlertDescription>
+        Use Mainnet at your own risk. This code is unaudited and unsupported. Do not use any real funds.
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/packages/ui/src/components/alert.tsx
+++ b/packages/ui/src/components/alert.tsx
@@ -13,6 +13,8 @@ const alertVariants = cva(
         default: 'bg-card text-card-foreground',
         destructive:
           'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+        warning:
+          'border-yellow-500 text-yellow-500 bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-yellow-500/90',
       },
     },
   },


### PR DESCRIPTION


<img width="662" height="304" alt="image" src="https://github.com/user-attachments/assets/b94e09b3-8c5d-428f-9fe5-3eb7911870b1" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add experimental software warning for Solana mainnet clusters in cluster add/edit forms and update schema and alert components accordingly.
> 
>   - **UI Changes**:
>     - Add `SettingsUiClusterWarningMainnet` component to display a warning for 'solana:mainnet' clusters in `settings-ui-cluster-form-create.tsx` and `settings-ui-cluster-form-update.tsx`.
>     - Move 'type' field in `settings-ui-cluster-form-create.tsx` to display warning below it.
>     - Remove 'type' field from `settings-ui-cluster-form-update.tsx` as it is now disabled and unchangeable.
>   - **Schema Changes**:
>     - Omit 'type' field in `clusterSchemaUpdate` in `cluster-schema-update.ts`.
>   - **Alert Component**:
>     - Add 'warning' variant to `alert.tsx` for displaying warning messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for cab2039494b89429eb0e5de4924dbfc4693ba9c8. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->