### PR TITLE
feat(env): enable clusters provisioning through .env file

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,1 +1,12 @@
+# Set the active cluster during db provisioning
+#VITE_ACTIVE_CLUSTER_ID='clusterDevnet'
+# Define the endpoint for the API
 VITE_API_ENDPOINT=http://localhost:8787
+# Set the cluster url for Devnet during db provisioning. Set the value to an empty string to disable the cluster.
+#VITE_CLUSTER_DEVNET=''
+# Set the cluster url for Localnet during db provisioning. Set the value to an empty string to disable the cluster.
+#VITE_CLUSTER_LOCALNET=''
+# Set the cluster url for Mainnet during db provisioning. Set the value to an empty string to disable the cluster.
+#VITE_CLUSTER_MAINNET=''
+# Set the cluster url for Testnet during db provisioning. Set the value to an empty string to disable the cluster.
+#VITE_CLUSTER_TESTNET=''

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -1,3 +1,10 @@
 import { setEnv } from '@workspace/env/env'
 
-setEnv({ apiEndpoint: import.meta.env.VITE_API_ENDPOINT })
+setEnv({
+  activeClusterId: import.meta.env.VITE_ACTIVE_CLUSTER_ID,
+  apiEndpoint: import.meta.env.VITE_API_ENDPOINT,
+  clusterDevnet: import.meta.env.VITE_CLUSTER_DEVNET,
+  clusterLocalnet: import.meta.env.VITE_CLUSTER_LOCALNET,
+  clusterMainnet: import.meta.env.VITE_CLUSTER_MAINNET,
+  clusterTestnet: import.meta.env.VITE_CLUSTER_TESTNET,
+})

--- a/packages/db/src/db-populate.ts
+++ b/packages/db/src/db-populate.ts
@@ -2,49 +2,13 @@ import { env } from '@workspace/env/env'
 
 import type { Database } from './database'
 
+import { getDefaultClusters } from './get-default-clusters'
+
 export async function dbPopulate(db: Database) {
   const now = new Date()
-  const activeClusterId = crypto.randomUUID()
-  await db.clusters.bulkAdd([
-    {
-      createdAt: now,
-      endpoint: 'http://localhost:8899',
-      id: crypto.randomUUID(),
-      name: 'Localnet',
-      type: 'solana:localnet',
-      updatedAt: now,
-    },
-    {
-      createdAt: now,
-      endpoint: 'https://api.devnet.solana.com',
-      id: activeClusterId,
-      name: 'Devnet',
-      type: 'solana:devnet',
-      updatedAt: now,
-    },
-    {
-      createdAt: now,
-      endpoint: 'https://api.testnet.solana.com',
-      id: crypto.randomUUID(),
-      name: 'Testnet',
-      type: 'solana:testnet',
-      updatedAt: now,
-    },
-  ])
+  await db.clusters.bulkAdd(getDefaultClusters())
   await db.preferences.bulkAdd([
-    {
-      createdAt: now,
-      id: crypto.randomUUID(),
-      key: 'activeClusterId',
-      updatedAt: now,
-      value: activeClusterId,
-    },
-    {
-      createdAt: now,
-      id: crypto.randomUUID(),
-      key: 'apiEndpoint',
-      updatedAt: now,
-      value: env('apiEndpoint'),
-    },
+    { createdAt: now, id: crypto.randomUUID(), key: 'activeClusterId', updatedAt: now, value: env('activeClusterId') },
+    { createdAt: now, id: crypto.randomUUID(), key: 'apiEndpoint', updatedAt: now, value: env('apiEndpoint') },
   ])
 }

--- a/packages/db/src/get-default-clusters.ts
+++ b/packages/db/src/get-default-clusters.ts
@@ -1,0 +1,38 @@
+import type { Env } from '@workspace/env/env'
+
+import { env } from '@workspace/env/env'
+
+import type { Cluster } from './entity/cluster'
+import type { ClusterType } from './entity/cluster-type'
+
+const clusterEnvVars: (keyof Env)[] = ['clusterDevnet', 'clusterLocalnet', 'clusterMainnet', 'clusterTestnet']
+
+export function getDefaultClusters(): Cluster[] {
+  const now = new Date()
+  return clusterEnvVars
+    .map((key) => ({ endpoint: env(key), key }))
+    .filter((item) => !!item.endpoint.length)
+    .map(({ endpoint, key }) => ({
+      createdAt: now,
+      endpoint,
+      id: key,
+      name: key.replace('cluster', ''),
+      type: getClusterTypeFromEnv(key),
+      updatedAt: now,
+    }))
+}
+
+function getClusterTypeFromEnv(env: keyof Env): ClusterType {
+  switch (env) {
+    case 'clusterDevnet':
+      return 'solana:devnet'
+    case 'clusterLocalnet':
+      return 'solana:localnet'
+    case 'clusterMainnet':
+      return 'solana:mainnet'
+    case 'clusterTestnet':
+      return 'solana:testnet'
+    default:
+      throw new Error(`Cannot get cluster type from ${env}`)
+  }
+}

--- a/packages/env/src/env.ts
+++ b/packages/env/src/env.ts
@@ -1,7 +1,14 @@
 import { z } from 'zod'
 
 export const envSchema = z.object({
+  activeClusterId: z
+    .enum(['clusterDevnet', 'clusterLocalnet', 'clusterMainnet', 'clusterTestnet'])
+    .default('clusterDevnet'),
   apiEndpoint: z.url().default('https://api.samui.build'),
+  clusterDevnet: z.url().or(z.literal('')).default('https://api.devnet.solana.com'),
+  clusterLocalnet: z.url().or(z.literal('')).default('http://localhost:8899'),
+  clusterMainnet: z.url().or(z.literal('')).default(''),
+  clusterTestnet: z.url().or(z.literal('')).default('https://api.testnet.solana.com'),
 })
 
 export type Env = z.infer<typeof envSchema>


### PR DESCRIPTION
This PR add support for provisioning the default clusters through the `.env` file.

If no variables are specified it'll keep the current ones: `Devnet` (default), `Localnet` and `Testnet`.

You can override the URL for each of these clusters or enable Mainnet. In addition, you can control which cluster is activated by default.

This way, you can set up your dev environment in such a way that it will load a specific cluster with a custom endpoint.    
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable cluster provisioning through `.env` file, allowing custom cluster configurations and default selection.
> 
>   - **Behavior**:
>     - Supports cluster provisioning via `.env` file, allowing URL overrides for `Devnet`, `Localnet`, `Mainnet`, and `Testnet`.
>     - Default cluster can be set using `VITE_ACTIVE_CLUSTER_ID`.
>   - **Environment**:
>     - Updates `env.ts` to include new environment variables for cluster URLs and active cluster ID.
>     - Modifies `envSchema` in `env.ts` to validate new cluster-related variables.
>   - **Database**:
>     - Replaces hardcoded cluster data in `db-populate.ts` with `getDefaultClusters()` function.
>     - Adds `get-default-clusters.ts` to generate default cluster configurations based on `.env` settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 8a09c24279a3249dfd3e94caab4d4d8760b9b050. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->