### PR TITLE
feat(extension): sign and send transaction

### DIFF
--- a/apps/extension/src/components/sign-and-send-transaction.tsx
+++ b/apps/extension/src/components/sign-and-send-transaction.tsx
@@ -1,0 +1,26 @@
+import type { SolanaSignAndSendTransactionInput } from '@solana/wallet-standard-features'
+
+import { getRequestService } from '@workspace/background/services/request'
+import { getSignService } from '@workspace/background/services/sign'
+import { Button } from '@workspace/ui/components/button'
+
+interface SignAndSendTransactionProps {
+  data: SolanaSignAndSendTransactionInput[]
+}
+
+export function SignAndSendTransaction({ data }: SignAndSendTransactionProps) {
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      <h1 className="text-2xl font-bold text-center">Sign and Send Transaction</h1>
+      <div className="flex flex-col gap-2">
+        <Button
+          onClick={async () => await getRequestService().resolve(await getSignService().signAndSendTransaction(data))}
+          variant="destructive"
+        >
+          Approve
+        </Button>
+        <Button onClick={async () => await getRequestService().reject()}>Reject</Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/extension/src/entrypoints/request/app.tsx
+++ b/apps/extension/src/entrypoints/request/app.tsx
@@ -19,6 +19,9 @@ export function App() {
     case 'connect':
       return <Connect />
 
+    case 'signAndSendTransaction':
+      return <SignAndSendTransaction data={data.data} />
+
     case 'signIn':
       return <SignIn data={data.data} />
 

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -58,7 +58,7 @@ export function App() {
                     return null
                   }
 
-                  return <SignAndSendTransaction key={feature} wallet={wallet} />
+                  return <SignAndSendTransaction key={feature} account={account} />
                 }
 
                 case SolanaSignTransaction: {

--- a/examples/basic/src/components/sign-transaction.tsx
+++ b/examples/basic/src/components/sign-transaction.tsx
@@ -21,14 +21,16 @@ interface SignTransactionProps {
   account: UiWalletAccount
 }
 
+const rpc = createSolanaRpc('https://api.devnet.solana.com')
+
+const rpcSubscriptions = createSolanaRpcSubscriptions('ws://api.devnet.solana.com')
+
 export function SignTransaction({ account }: SignTransactionProps) {
   const sender = useWalletAccountTransactionSigner(account, 'solana:devnet')
 
   return (
     <Button
       onClick={async () => {
-        const rpc = createSolanaRpc('https://api.devnet.solana.com')
-        const rpcSubscriptions = createSolanaRpcSubscriptions('ws://api.devnet.solana.com')
         const { value: latestBlockhash } = await rpc.getLatestBlockhash().send()
         const LAMPORTS_PER_SOL = 1_000_000_000n
         const transferAmount = lamports(LAMPORTS_PER_SOL / 100n) // 0.01 SOL

--- a/packages/background/src/actions/sign-and-send-transaction.ts
+++ b/packages/background/src/actions/sign-and-send-transaction.ts
@@ -3,10 +3,10 @@ import type {
   SolanaSignAndSendTransactionOutput,
 } from '@solana/wallet-standard-features'
 
+import { getRequestService } from '../services/request'
+
 export async function signAndSendTransaction(
   inputs: SolanaSignAndSendTransactionInput[],
 ): Promise<SolanaSignAndSendTransactionOutput[]> {
-  console.log('Sign and Send Transaction', inputs)
-
-  return Promise.resolve([])
+  return await getRequestService().create('signAndSendTransaction', inputs)
 }

--- a/packages/background/src/services/db.ts
+++ b/packages/background/src/services/db.ts
@@ -54,7 +54,7 @@ export const [registerDbService, getDbService] = defineProxyService('DbService',
           {
             address: wallet.publicKey,
             chains: ['solana:devnet'],
-            features: ['solana:signTransaction'],
+            features: ['solana:signTransaction', 'solana:signAndSendTransaction'],
             // icon: '',
             label: wallet.name,
             publicKey: getAddressEncoder().encode(address(wallet.publicKey)),

--- a/packages/background/src/services/request.ts
+++ b/packages/background/src/services/request.ts
@@ -1,4 +1,6 @@
 import type {
+  SolanaSignAndSendTransactionInput,
+  SolanaSignAndSendTransactionOutput,
   SolanaSignInInput,
   SolanaSignInOutput,
   SolanaSignMessageInput,
@@ -16,6 +18,13 @@ import { browser } from 'wxt/browser'
 type DataType<T extends Requests['type']> = Extract<Requests, { type: T }>['data']
 
 type Requests =
+  | {
+      data: SolanaSignAndSendTransactionInput[]
+      id: number
+      reject: (reason?: Error) => void
+      resolve: (data: SolanaSignAndSendTransactionOutput[]) => void
+      type: 'signAndSendTransaction'
+    }
   | {
       data: SolanaSignInInput[]
       id: number
@@ -105,7 +114,12 @@ class RequestService {
   }
 
   resolve(
-    data: SolanaSignInOutput[] | SolanaSignMessageOutput[] | SolanaSignTransactionOutput[] | StandardConnectOutput,
+    data:
+      | SolanaSignAndSendTransactionOutput[]
+      | SolanaSignInOutput[]
+      | SolanaSignMessageOutput[]
+      | SolanaSignTransactionOutput[]
+      | StandardConnectOutput,
   ) {
     if (!this.request) {
       throw new Error('No request to resolve')
@@ -120,6 +134,8 @@ class RequestService {
       this.request.resolve(data as SolanaSignInOutput[])
     } else if (this.request.type === 'signTransaction') {
       this.request.resolve(data as SolanaSignTransactionOutput[])
+    } else if (this.request.type === 'signAndSendTransaction') {
+      this.request.resolve(data as SolanaSignAndSendTransactionOutput[])
     }
 
     this.request = undefined

--- a/packages/wallet-standard/src/features/sign-and-send-transaction.ts
+++ b/packages/wallet-standard/src/features/sign-and-send-transaction.ts
@@ -4,12 +4,15 @@ import type {
 } from '@solana/wallet-standard-features'
 
 import { sendMessage } from '@workspace/background/window'
+import { ensureUint8Array } from '@workspace/keypair/ensure-uint8array'
 
 export async function signAndSendTransaction(
   ...inputs: SolanaSignAndSendTransactionInput[]
 ): Promise<SolanaSignAndSendTransactionOutput[]> {
   const response = await sendMessage('signAndSendTransaction', inputs)
-  console.log('Sign and Send Transaction', response)
 
-  return response
+  return response.map((output) => ({
+    ...output,
+    signature: ensureUint8Array(output.signature),
+  }))
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add feature to sign and send Solana transactions with new component and service integration.
> 
>   - **Components**:
>     - Add `SignAndSendTransaction` component in `apps/extension/src/components/sign-and-send-transaction.tsx` to handle transaction signing and sending.
>     - Update `App` in `apps/extension/src/entrypoints/request/app.tsx` to include `signAndSendTransaction` case.
>     - Modify `SignAndSendTransaction` in `examples/basic/src/components/sign-and-send-transaction.tsx` to use `useWalletAccountTransactionSendingSigner` and handle transaction logic.
>   - **Services**:
>     - Implement `signAndSendTransaction` in `sign.ts` to sign transactions and send them using Solana RPC.
>     - Update `RequestService` in `request.ts` to handle `signAndSendTransaction` requests.
>     - Extend `DbService` in `db.ts` to include `solana:signAndSendTransaction` feature.
>   - **Actions**:
>     - Create `signAndSendTransaction` action in `sign-and-send-transaction.ts` to initiate transaction requests.
>   - **Misc**:
>     - Update `sign-and-send-transaction.ts` in `wallet-standard` to map and ensure signature format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 265b0cb123d7f824e0a7d727a6bffa4878d4a5de. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->