### PR TITLE
feat(site): add discord link and /go/* redirects

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -14,14 +14,19 @@ export default defineConfig({
       },
       social: [
         {
+          icon: 'discord',
+          label: 'Discord',
+          href: 'https://samui.build/go/discord',
+        },
+        {
           icon: 'x.com',
           label: 'X / Twitter',
-          href: 'https://x.com/SamuiBuild',
+          href: 'https://samui.build/go/x',
         },
         {
           icon: 'github',
           label: 'GitHub',
-          href: 'https://github.com/samui-build/samui-wallet',
+          href: 'https://samui.build/go/github',
         },
       ],
 

--- a/apps/site/public/_redirects
+++ b/apps/site/public/_redirects
@@ -1,0 +1,3 @@
+/go/discord https://discord.gg/Zf2mc27HZA 302
+/go/github https://github.com/samui-build/samui-wallet 302
+/go/x https://x.com/SamuiBuild 302

--- a/apps/site/src/content/docs/index.mdx
+++ b/apps/site/src/content/docs/index.mdx
@@ -20,14 +20,19 @@ hero:
 import { Card, CardGrid } from '@astrojs/starlight/components'
 
 <CardGrid>
-  <a href="https://x.com/SamuiBuild" target="_blank" style={{ textDecoration: 'none' }}>
-    <Card title="Follow us on X" icon="x.com">
-      Follow us on X to stay up to date with the project!
+  <a href="/go/github" target="_blank" style={{ textDecoration: 'none' }}>
+    <Card title="Star our repo on GitHub" icon="github">
+      Star and fork our repo on GitHub and start contributing!
     </Card>
   </a>
-  <a href="https://github.com/samui-build/samui-wallet" target="_blank" style={{ textDecoration: 'none' }}>
-    <Card title="Star our repo on GitHub" icon="github">
-      Star our repo on GitHub or fork it and start contributing!
+  <a href="/go/discord" target="_blank" style={{ textDecoration: 'none' }}>
+    <Card title="Join our Discord" icon="discord">
+      Join our Discord to talk about Samui Wallet development.
+    </Card>
+  </a>
+  <a href="/go/x" target="_blank" style={{ textDecoration: 'none' }}>
+    <Card title="Follow us on X" icon="x.com">
+      Follow us on X to stay up to date with the project!
     </Card>
   </a>
 </CardGrid>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds Discord link and implements `/go/*` redirects for social media links in the site configuration and documentation.
> 
>   - **Behavior**:
>     - Adds Discord link to `social` section in `astro.config.mjs`.
>     - Implements `/go/*` redirects in `_redirects` for Discord, GitHub, and X (Twitter).
>   - **Docs**:
>     - Updates links in `index.mdx` to use new `/go/*` redirects for GitHub, Discord, and X.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for fd4f30e23ad535f75b224205de498a894cba22a9. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->