### PR TITLE
fix(settings): ensure we can navigate to account edit form

### DIFF
--- a/packages/settings/src/settings-feature-account-details.tsx
+++ b/packages/settings/src/settings-feature-account-details.tsx
@@ -3,13 +3,16 @@ import { useDbWalletCreate } from '@workspace/db-react/use-db-wallet-create'
 import { useDbWalletLive } from '@workspace/db-react/use-db-wallet-live'
 import { importKeyPairToPublicKeySecretKey } from '@workspace/keypair/import-key-pair-to-public-key-secret-key'
 import { assertIsAddress } from '@workspace/solana-client'
+import { Button } from '@workspace/ui/components/button'
 import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { UiError } from '@workspace/ui/components/ui-error'
 import { UiLoader } from '@workspace/ui/components/ui-loader'
 import { UiNotFound } from '@workspace/ui/components/ui-not-found'
+import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
-import { useParams } from 'react-router'
+import { LucidePencil } from 'lucide-react'
+import { Link, useParams } from 'react-router'
 
 import { useActiveWallet } from './data-access/use-active-wallet.js'
 import { useDeriveAndCreateWallet } from './data-access/use-derive-and-create-wallet.js'
@@ -62,9 +65,18 @@ export function SettingsFeatureAccountDetails() {
   return (
     <UiCard
       title={
-        <div className="flex items-center gap-2">
-          <UiBack />
-          <SettingsUiAccountItem item={item} />
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <UiBack />
+            <SettingsUiAccountItem item={item} />
+          </div>
+          <UiTooltip content="Edit account">
+            <Button asChild size="icon" variant="outline">
+              <Link to={`./edit`}>
+                <LucidePencil className="size-4" />
+              </Link>
+            </Button>
+          </UiTooltip>
         </div>
       }
     >

--- a/packages/settings/src/ui/settings-ui-account-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list-item.tsx
@@ -30,7 +30,7 @@ export function SettingsUiAccountListItem({
       </ItemContent>
       <ItemActions>
         {active?.id === item.id ? null : (
-          <UiTooltip content="Set as active">
+          <UiTooltip content="Set account as active">
             <Button
               onClick={async () => {
                 await setActive(item.id)
@@ -42,14 +42,14 @@ export function SettingsUiAccountListItem({
             </Button>
           </UiTooltip>
         )}
-        <UiTooltip content="Edit">
+        <UiTooltip content="Edit account">
           <Button asChild size="icon" variant="outline">
-            <Link to={`./${item.id}`}>
+            <Link to={`./${item.id}/edit`}>
               <LucidePencil className="size-4" />
             </Link>
           </Button>
         </UiTooltip>
-        <UiTooltip content="Delete">
+        <UiTooltip content="Delete account">
           <Button
             onClick={async (e) => {
               e.preventDefault()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add edit buttons with tooltips to navigate to account edit form in `SettingsFeatureAccountDetails` and `SettingsUiAccountListItem`.
> 
>   - **UI Enhancements**:
>     - Add edit button with `UiTooltip` in `SettingsFeatureAccountDetails` to navigate to `./edit`.
>     - Update `SettingsUiAccountListItem` to change edit link to `./${item.id}/edit` and update tooltip text to "Edit account".
>   - **Tooltips**:
>     - Change tooltip text from "Edit" to "Edit account" and "Delete" to "Delete account" in `SettingsUiAccountListItem`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b9ed3fefd304114531f26c30dd4d0ca71058c6a4. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->