### PR TITLE
feat: add endpointSubscriptions property to Cluster entity

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,9 +4,13 @@
 VITE_API_ENDPOINT=http://localhost:8787
 # Set the cluster url for Devnet during db provisioning. Set the value to an empty string to disable the cluster.
 #VITE_CLUSTER_DEVNET=''
+#VITE_CLUSTER_DEVNET_SUBSCRIPTIONS=''
 # Set the cluster url for Localnet during db provisioning. Set the value to an empty string to disable the cluster.
 #VITE_CLUSTER_LOCALNET=''
+#VITE_CLUSTER_LOCALNET_SUBSCRIPTIONS=''
 # Set the cluster url for Mainnet during db provisioning. Set the value to an empty string to disable the cluster.
 #VITE_CLUSTER_MAINNET=''
+#VITE_CLUSTER_MAINNET_SUBSCRIPTIONS=''
 # Set the cluster url for Testnet during db provisioning. Set the value to an empty string to disable the cluster.
 #VITE_CLUSTER_TESTNET=''
+#VITE_CLUSTER_TESTNET_SUBSCRIPTIONS=''

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -4,7 +4,11 @@ setEnv({
   activeClusterId: import.meta.env.VITE_ACTIVE_CLUSTER_ID,
   apiEndpoint: import.meta.env.VITE_API_ENDPOINT,
   clusterDevnet: import.meta.env.VITE_CLUSTER_DEVNET,
+  clusterDevnetSubscriptions: import.meta.env.VITE_CLUSTER_DEVNET_SUBSCRIPTIONS,
   clusterLocalnet: import.meta.env.VITE_CLUSTER_LOCALNET,
+  clusterLocalnetSubscriptions: import.meta.env.VITE_CLUSTER_LOCALNET_SUBSCRIPTIONS,
   clusterMainnet: import.meta.env.VITE_CLUSTER_MAINNET,
+  clusterMainnetSubscriptions: import.meta.env.VITE_CLUSTER_MAINNET_SUBSCRIPTIONS,
   clusterTestnet: import.meta.env.VITE_CLUSTER_TESTNET,
+  clusterTestnetSubscriptions: import.meta.env.VITE_CLUSTER_TESTNET_SUBSCRIPTIONS,
 })

--- a/packages/db/src/get-default-clusters.ts
+++ b/packages/db/src/get-default-clusters.ts
@@ -15,6 +15,7 @@ export function getDefaultClusters(): Cluster[] {
     .map(({ endpoint, key }) => ({
       createdAt: now,
       endpoint,
+      endpointSubscriptions: env(getEndpointSubscriptionsTypeFromEnv(key)),
       id: key,
       name: key.replace('cluster', ''),
       type: getClusterTypeFromEnv(key),
@@ -34,5 +35,19 @@ function getClusterTypeFromEnv(env: keyof Env): ClusterType {
       return 'solana:testnet'
     default:
       throw new Error(`Cannot get cluster type from ${env}`)
+  }
+}
+function getEndpointSubscriptionsTypeFromEnv(env: keyof Env): keyof Env {
+  switch (env) {
+    case 'clusterDevnet':
+      return 'clusterDevnetSubscriptions'
+    case 'clusterLocalnet':
+      return 'clusterLocalnetSubscriptions'
+    case 'clusterMainnet':
+      return 'clusterMainnetSubscriptions'
+    case 'clusterTestnet':
+      return 'clusterTestnetSubscriptions'
+    default:
+      throw new Error(`Cannot get subscriptions endpoint from ${env}`)
   }
 }

--- a/packages/db/src/schema/cluster-schema.ts
+++ b/packages/db/src/schema/cluster-schema.ts
@@ -5,6 +5,7 @@ import { clusterTypeSchema } from './cluster-type-schema'
 export const clusterSchema = z.object({
   createdAt: z.date(),
   endpoint: z.url(),
+  endpointSubscriptions: z.url().optional(),
   id: z.string(),
   name: z.string(),
   type: clusterTypeSchema,

--- a/packages/db/test/db-cluster-create.test.ts
+++ b/packages/db/test/db-cluster-create.test.ts
@@ -26,6 +26,18 @@ describe('db-cluster-create', () => {
       const items = await dbClusterFindMany(db)
       expect(items.map((i) => i.name)).toContain(input.name)
     })
+    it('should create a cluster with a subscription endpoint', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testClusterInputCreate({ endpointSubscriptions: 'ws://127.0.0.1:8900' })
+
+      // ACT
+      await dbClusterCreate(db, input)
+
+      // ASSERT
+      const items = await dbClusterFindMany(db)
+      expect(items.map((i) => i.endpointSubscriptions)).toContain(input.endpointSubscriptions)
+    })
   })
 
   describe('unexpected behavior', () => {

--- a/packages/env/src/env.ts
+++ b/packages/env/src/env.ts
@@ -6,9 +6,13 @@ export const envSchema = z.object({
     .default('clusterDevnet'),
   apiEndpoint: z.url().default('https://api.samui.build'),
   clusterDevnet: z.url().or(z.literal('')).default('https://api.devnet.solana.com'),
+  clusterDevnetSubscriptions: z.url().or(z.literal('')).default(''),
   clusterLocalnet: z.url().or(z.literal('')).default('http://localhost:8899'),
+  clusterLocalnetSubscriptions: z.url().or(z.literal('')).default('ws://127.0.0.1:8900'),
   clusterMainnet: z.url().or(z.literal('')).default(''),
+  clusterMainnetSubscriptions: z.url().or(z.literal('')).default(''),
   clusterTestnet: z.url().or(z.literal('')).default('https://api.testnet.solana.com'),
+  clusterTestnetSubscriptions: z.url().or(z.literal('')).default(''),
 })
 
 export type Env = z.infer<typeof envSchema>

--- a/packages/settings/src/ui/settings-ui-cluster-form-create.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-form-create.tsx
@@ -78,6 +78,26 @@ export function SettingsUiClusterFormCreate({ submit }: { submit: (input: Cluste
         />
         <FormField
           control={form.control}
+          name="endpointSubscriptions"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Subscriptions Endpoint</FormLabel>
+              <FormControl>
+                <Input
+                  onChange={(e) => field.onChange(e.target.value)}
+                  placeholder="Cluster Endpoint for Subscriptions"
+                  type="url"
+                  value={field.value}
+                />
+              </FormControl>
+              <FormDescription>Provide the cluster endpoint for subscriptions</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+          rules={{ required: false }}
+        />
+        <FormField
+          control={form.control}
           name="name"
           render={({ field }) => (
             <FormItem className="w-full">

--- a/packages/settings/src/ui/settings-ui-cluster-form-update.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-form-update.tsx
@@ -78,6 +78,26 @@ export function SettingsUiClusterFormUpdate({
         />
         <FormField
           control={form.control}
+          name="endpointSubscriptions"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Subscriptions Endpoint</FormLabel>
+              <FormControl>
+                <Input
+                  onChange={(e) => field.onChange(e.target.value)}
+                  placeholder="Cluster Endpoint for Subscriptions"
+                  type="url"
+                  value={field.value}
+                />
+              </FormControl>
+              <FormDescription>Provide the cluster endpoint for subscriptions</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+          rules={{ required: false }}
+        />
+        <FormField
+          control={form.control}
           name="name"
           render={({ field }) => (
             <FormItem className="w-full">
@@ -94,7 +114,7 @@ export function SettingsUiClusterFormUpdate({
               <FormMessage />
             </FormItem>
           )}
-          rules={{ required: false }}
+          rules={{ required: true }}
         />
         <div className="flex justify-end items-center w-full pt-3">
           <Button className="rounded-lg" size="sm">

--- a/packages/solana-client-react/src/use-solana-client.tsx
+++ b/packages/solana-client-react/src/use-solana-client.tsx
@@ -4,5 +4,8 @@ import { createSolanaClient } from '@workspace/solana-client/create-solana-clien
 import { useMemo } from 'react'
 
 export function useSolanaClient({ cluster }: { cluster: Cluster }) {
-  return useMemo(() => createSolanaClient({ url: cluster.endpoint }), [cluster.endpoint])
+  return useMemo(
+    () => createSolanaClient({ url: cluster.endpoint, urlSubscriptions: cluster.endpointSubscriptions }),
+    [cluster.endpoint, cluster.endpointSubscriptions],
+  )
 }

--- a/packages/solana-client/src/create-solana-client.ts
+++ b/packages/solana-client/src/create-solana-client.ts
@@ -6,11 +6,11 @@ export function createSolanaClient({ url, urlSubscriptions }: { url: ClusterUrl;
   if (!url.startsWith('http')) {
     throw new Error('Invalid cluster url')
   }
-  if (urlSubscriptions && !urlSubscriptions.startsWith('ws')) {
+  if (urlSubscriptions?.trim().length && !urlSubscriptions.startsWith('ws')) {
     throw new Error('Invalid cluster subscription url')
   }
   return {
     rpc: createSolanaRpc(url),
-    rpcSubscriptions: createSolanaRpcSubscriptions(urlSubscriptions ?? url.replace('http', 'ws')),
+    rpcSubscriptions: createSolanaRpcSubscriptions(urlSubscriptions ? urlSubscriptions : url.replace('http', 'ws')),
   }
 }


### PR DESCRIPTION
This PR adds the ability to specify the subscriptions URL for a cluster.

Currently, we infer this URL by replacing 'http' with 'ws' which works in a lot of cases, but fails on the test validator.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `endpointSubscriptions` property to `Cluster` entity, updating environment, client logic, and UI forms.
> 
>   - **Behavior**:
>     - Adds `endpointSubscriptions` property to `Cluster` entity in `cluster-schema.ts`.
>     - Updates `createSolanaClient()` in `create-solana-client.ts` to use `endpointSubscriptions` if provided, otherwise defaults to replacing 'http' with 'ws'.
>     - Modifies `useSolanaClient()` in `use-solana-client.tsx` to pass `endpointSubscriptions`.
>   - **Environment**:
>     - Adds `VITE_CLUSTER_*_SUBSCRIPTIONS` variables to `.env.example` and `env.ts`.
>     - Updates `getDefaultClusters()` in `get-default-clusters.ts` to include `endpointSubscriptions`.
>   - **UI**:
>     - Adds `endpointSubscriptions` field to `SettingsUiClusterFormCreate` and `SettingsUiClusterFormUpdate`.
>   - **Testing**:
>     - Adds test for `endpointSubscriptions` in `db-cluster-create.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 46f6ebf081c69557bcb8ae117f132554e84c2a50. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->