### PR TITLE
fix(onboarding): use a form with submit button in onboarding generate/import screens

### DIFF
--- a/packages/onboarding/src/onboarding-feature-generate.tsx
+++ b/packages/onboarding/src/onboarding-feature-generate.tsx
@@ -1,6 +1,7 @@
 import type { MnemonicStrength } from '@workspace/keypair/generate-mnemonic'
 
 import { generateMnemonic } from '@workspace/keypair/generate-mnemonic'
+import { validateMnemonic } from '@workspace/keypair/validate-mnemonic'
 import { UiBackButton } from '@workspace/ui/components/ui-back-button'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
@@ -26,29 +27,40 @@ export function OnboardingFeatureGenerate() {
   }
 
   return (
-    <UiCard
-      description="This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!"
-      footer={
-        <div className="flex w-full justify-between">
-          <UiTextCopyButton text={mnemonic} toast="Mnemonic copied to clipboard" />
-          <OnboardingUiMnemonicSave label="Create wallet" onClick={handleSubmit} />
-        </div>
-      }
-      title={
-        <div>
-          <UiBackButton className="mr-2" />
-          Generate Recovery Phrase
-        </div>
-      }
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault()
+        await handleSubmit()
+      }}
     >
-      <div className="space-y-6">
-        <div className="flex justify-between">
-          <div>
-            <OnboardingUiMnemonicSelectStrength setStrength={setStrength} strength={strength} />
+      <UiCard
+        description="This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!"
+        footer={
+          <div className="flex w-full justify-between">
+            <UiTextCopyButton text={mnemonic} toast="Mnemonic copied to clipboard" />
+            <OnboardingUiMnemonicSave
+              disabled={!validateMnemonic({ mnemonic })}
+              label="Create wallet"
+              onClick={handleSubmit}
+            />
           </div>
+        }
+        title={
+          <div>
+            <UiBackButton className="mr-2" />
+            Generate Recovery Phrase
+          </div>
+        }
+      >
+        <div className="space-y-6">
+          <div className="flex justify-between">
+            <div>
+              <OnboardingUiMnemonicSelectStrength setStrength={setStrength} strength={strength} />
+            </div>
+          </div>
+          <OnboardingUiMnemonicShow mnemonic={mnemonic} />
         </div>
-        <OnboardingUiMnemonicShow mnemonic={mnemonic} />
-      </div>
-    </UiCard>
+      </UiCard>
+    </form>
   )
 }

--- a/packages/onboarding/src/onboarding-feature-import.tsx
+++ b/packages/onboarding/src/onboarding-feature-import.tsx
@@ -72,13 +72,18 @@ export function OnboardingFeatureImport() {
   }
 
   return (
-    <div className="space-y-2">
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault()
+        await handleSubmit()
+      }}
+    >
       <UiCard
         description="Enter the seed phrase you stored when you created your wallet."
         footer={
           <div className="flex w-full justify-between">
             <UiTextPasteButton onPaste={handlePaste} />
-            <OnboardingUiMnemonicSave label="Import wallet" onClick={handleSubmit} />
+            <OnboardingUiMnemonicSave disabled={!isFormComplete} label="Import wallet" onClick={handleSubmit} />
           </div>
         }
         title={
@@ -115,7 +120,7 @@ export function OnboardingFeatureImport() {
           {error && <p className="text-red-500 text-sm mt-4 text-center">{error}</p>}
         </div>
       </UiCard>
-    </div>
+    </form>
   )
 }
 

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-save.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-save.tsx
@@ -1,9 +1,15 @@
+import type { ComponentProps } from 'react'
+
 import { Button } from '@workspace/ui/components/button'
 import { LucideSave } from 'lucide-react'
 
-export function OnboardingUiMnemonicSave({ label, onClick }: { label: string; onClick: () => Promise<void> }) {
+export function OnboardingUiMnemonicSave({
+  label,
+  onClick,
+  ...props
+}: { label: string; onClick: () => Promise<void> } & Omit<ComponentProps<typeof Button>, 'onClick'>) {
   return (
-    <Button onClick={onClick}>
+    <Button onClick={onClick} type="submit" {...props}>
       <LucideSave />
       {label}
     </Button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps onboarding generate/import screens in forms, adds mnemonic validation, and disables submit button if invalid.
> 
>   - **Behavior**:
>     - Wraps content in `onboarding-feature-generate.tsx` and `onboarding-feature-import.tsx` in `<form>` elements to handle submissions.
>     - Adds `onSubmit` handlers to prevent default form submission and call `handleSubmit()`.
>     - Disables `OnboardingUiMnemonicSave` button if mnemonic is invalid in `onboarding-feature-generate.tsx` and if form is incomplete in `onboarding-feature-import.tsx`.
>   - **Validation**:
>     - Uses `validateMnemonic` in `onboarding-feature-generate.tsx` to check mnemonic validity before enabling the submit button.
>     - Checks form completeness in `onboarding-feature-import.tsx` using `isFormComplete`.
>   - **Components**:
>     - Updates `OnboardingUiMnemonicSave` to accept additional props and set `type="submit"` for the button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 261dbd05e0eb0bac7e6092c152626697ba431051. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->