### PR TITLE
chore(web): hide faucet link on localnet

### DIFF
--- a/packages/portfolio/src/ui/portfolio-ui-request-airdrop.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-request-airdrop.tsx
@@ -24,7 +24,10 @@ export function PortfolioUiRequestAirdrop({
   wallet: Wallet
 }) {
   const { isPending, mutateAsync } = useRequestAirdrop(cluster)
-  if ((lamports && lamports > 0) || cluster.type === 'solana:mainnet') {
+  const hasBalance = lamports && lamports > 0
+  const isMainnet = cluster.type === 'solana:mainnet'
+  const isLocalnet = cluster.type === 'solana:localnet'
+  if (hasBalance || isMainnet) {
     return null
   }
 
@@ -42,11 +45,13 @@ export function PortfolioUiRequestAirdrop({
           <Coins /> Confirm Airdrop
         </Button>
       </EmptyContent>
-      <Button asChild className="text-muted-foreground" size="sm" variant="link">
-        <a href="https://faucet.solana.com/" rel="noopener noreferrer" target="_blank">
-          Use Faucet <ArrowUpRightIcon />
-        </a>
-      </Button>
+      {isLocalnet ? null : (
+        <Button asChild className="text-muted-foreground" size="sm" variant="link">
+          <a href="https://faucet.solana.com/" rel="noopener noreferrer" target="_blank">
+            Use Faucet <ArrowUpRightIcon />
+          </a>
+        </Button>
+      )}
     </Empty>
   )
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Hide "Use Faucet" link in `PortfolioUiRequestAirdrop` for `solana:localnet`.
> 
>   - **Behavior**:
>     - In `PortfolioUiRequestAirdrop`, hide the "Use Faucet" link when `cluster.type` is `solana:localnet`.
>     - The link remains visible for other network types, such as `solana:mainnet`.
>   - **Code Structure**:
>     - Introduced `isLocalnet` boolean to simplify conditional rendering logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for dd58a90cfef3b7f9995fd8e07b9e2901332829c4. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->