### PR TITLE
fix(onboarding): set type of copy/paste buttons to 'button'

### DIFF
--- a/packages/ui/src/components/ui-text-copy-button.tsx
+++ b/packages/ui/src/components/ui-text-copy-button.tsx
@@ -13,6 +13,7 @@ export function UiTextCopyButton({ text, toast = 'Copied to clipboard' }: { text
           toastSuccess(toast)
         }
       }}
+      type="button"
       variant="secondary"
     >
       <LucideCopy />

--- a/packages/ui/src/components/ui-text-paste-button.tsx
+++ b/packages/ui/src/components/ui-text-paste-button.tsx
@@ -12,6 +12,7 @@ export function UiTextPasteButton({ onPaste }: { onPaste: (text: string) => void
           onPaste(result)
         }
       }}
+      type="button"
       variant="secondary"
     >
       <LucideCopy />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `type="button"` for copy and paste buttons to prevent form submission.
> 
>   - **Behavior**:
>     - Set `type="button"` for `Button` in `UiTextCopyButton` and `UiTextPasteButton` to prevent default form submission behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f2d22746f48d58c931f9eb4db7e40638a74120a7. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->