### PR TITLE
fix(shell): useDbAccountLive hook for account list

### DIFF
--- a/packages/db-react/src/use-db-account-live.tsx
+++ b/packages/db-react/src/use-db-account-live.tsx
@@ -1,8 +1,9 @@
 import type { Account } from '@workspace/db/entity/account'
 
 import { db } from '@workspace/db/db'
+import { dbAccountFindMany } from '@workspace/db/db-account-find-many'
 import { useLiveQuery } from 'dexie-react-hooks'
 
 export function useDbAccountLive() {
-  return useLiveQuery<Account[], Account[]>(() => db.accounts.orderBy('name').toArray(), [], [])
+  return useLiveQuery<Account[], Account[]>(() => dbAccountFindMany(db), [], [])
 }

--- a/packages/shell/src/ui/shell-ui-menu.tsx
+++ b/packages/shell/src/ui/shell-ui-menu.tsx
@@ -1,6 +1,4 @@
-import type { Account } from '@workspace/db/entity/account'
-
-import { useDbAccountFindMany } from '@workspace/db-react/use-db-account-find-many'
+import { useDbAccountLive } from '@workspace/db-react/use-db-account-live'
 import { useDbClusterLive } from '@workspace/db-react/use-db-cluster-live'
 import { useDbPreference } from '@workspace/db-react/use-db-preference'
 import { getDevOptions } from '@workspace/dev/dev-features'
@@ -16,12 +14,10 @@ import { ShellUiMenuDevelopment } from './shell-ui-menu-development.js'
 export function ShellUiMenu() {
   const { active: activeAccount } = useActiveAccount()
   const { active: activeWallet, setActive: setActiveWalletId } = useActiveWallet()
-  const accountsQuery = useDbAccountFindMany({ input: {} })
+  const accounts = useDbAccountLive()
   const items = useDbClusterLive()
   const [activeId, setActiveClusterId] = useDbPreference('activeClusterId')
   const activeCluster = useMemo(() => items.find((c) => c.id === activeId), [items, activeId])
-
-  const accounts: Account[] = accountsQuery.data ?? []
 
   return (
     <Menubar className="py-2 h-10 md:h-14 bg-transparent border-none">


### PR DESCRIPTION
This should fix the issue where the Account menu does not
get updated when new wallets or accounts are added.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Account menu update issue by using `useDbAccountLive` for live account querying.
> 
>   - **Behavior**:
>     - Replaces `useDbAccountFindMany` with `useDbAccountLive` in `shell-ui-menu.tsx` to ensure the Account menu updates with new wallets or accounts.
>     - Modifies `useDbAccountLive` in `use-db-account-live.tsx` to use `dbAccountFindMany` for live querying.
>   - **Imports**:
>     - Removes `useDbAccountFindMany` import from `shell-ui-menu.tsx`.
>     - Adds `dbAccountFindMany` import to `use-db-account-live.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for cd4dbac08684b13667fb47e2e9ee720dc44e2862. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->