### PR TITLE
fix(onboarding): ensure button click does not get handled twice

### DIFF
--- a/packages/onboarding/src/onboarding-feature-generate.tsx
+++ b/packages/onboarding/src/onboarding-feature-generate.tsx
@@ -38,11 +38,7 @@ export function OnboardingFeatureGenerate() {
         footer={
           <div className="flex w-full justify-between">
             <UiTextCopyButton text={mnemonic} toast="Mnemonic copied to clipboard" />
-            <OnboardingUiMnemonicSave
-              disabled={!validateMnemonic({ mnemonic })}
-              label="Create wallet"
-              onClick={handleSubmit}
-            />
+            <OnboardingUiMnemonicSave disabled={!validateMnemonic({ mnemonic })} label="Create wallet" />
           </div>
         }
         title={

--- a/packages/onboarding/src/onboarding-feature-import.tsx
+++ b/packages/onboarding/src/onboarding-feature-import.tsx
@@ -83,7 +83,7 @@ export function OnboardingFeatureImport() {
         footer={
           <div className="flex w-full justify-between">
             <UiTextPasteButton onPaste={handlePaste} />
-            <OnboardingUiMnemonicSave disabled={!isFormComplete} label="Import wallet" onClick={handleSubmit} />
+            <OnboardingUiMnemonicSave disabled={!isFormComplete} label="Import wallet" />
           </div>
         }
         title={

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-save.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-save.tsx
@@ -5,11 +5,10 @@ import { LucideSave } from 'lucide-react'
 
 export function OnboardingUiMnemonicSave({
   label,
-  onClick,
   ...props
-}: { label: string; onClick: () => Promise<void> } & Omit<ComponentProps<typeof Button>, 'onClick'>) {
+}: { label: string } & Omit<ComponentProps<typeof Button>, 'onClick'>) {
   return (
-    <Button onClick={onClick} type="submit" {...props}>
+    <Button type="submit" {...props}>
       <LucideSave />
       {label}
     </Button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `onClick` prop from `OnboardingUiMnemonicSave` to prevent double handling of button clicks in onboarding forms.
> 
>   - **Behavior**:
>     - Remove `onClick` prop from `OnboardingUiMnemonicSave` in `onboarding-feature-generate.tsx` and `onboarding-feature-import.tsx` to prevent double handling of button clicks.
>     - Form `onSubmit` now handles button click logic in both `onboarding-feature-generate.tsx` and `onboarding-feature-import.tsx`.
>   - **Components**:
>     - `OnboardingUiMnemonicSave` no longer accepts `onClick` prop in `onboarding-ui-mnemonic-save.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for bdea0303c1a494c50251595dc0e15614f4cbf5b3. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->