### PR TITLE
feat(settings): clean up cluster list

### DIFF
--- a/packages/settings/src/settings-feature-cluster-list.tsx
+++ b/packages/settings/src/settings-feature-cluster-list.tsx
@@ -17,7 +17,7 @@ export function SettingsFeatureClusterList() {
     onSuccess: () => toastSuccess('Cluster deleted'),
   })
   const items = useDbClusterLive()
-  const [activeId, setActiveId] = useDbPreference('activeClusterId')
+  const [activeId] = useDbPreference('activeClusterId')
   return (
     <UiCard
       action={
@@ -32,7 +32,6 @@ export function SettingsFeatureClusterList() {
         activeId={activeId}
         deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })}
         items={items}
-        setActive={setActiveId}
       />
     </UiCard>
   )

--- a/packages/settings/src/ui/settings-ui-cluster-list.tsx
+++ b/packages/settings/src/ui/settings-ui-cluster-list.tsx
@@ -1,27 +1,25 @@
 import type { Cluster } from '@workspace/db/entity/cluster'
 
 import { Button } from '@workspace/ui/components/button'
-import { Item, ItemActions, ItemContent, ItemDescription, ItemGroup, ItemTitle } from '@workspace/ui/components/item'
+import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from '@workspace/ui/components/item'
 import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
-import { LucideCheck, LucidePencil, LucideTrash } from 'lucide-react'
+import { LucidePencil, LucideTrash } from 'lucide-react'
 import { Link } from 'react-router'
 
 export function SettingsUiClusterList({
   activeId,
   deleteItem,
   items,
-  setActive,
 }: {
   activeId: null | string
   deleteItem: (item: Cluster) => Promise<void>
   items: Cluster[]
-  setActive: (id: string) => Promise<void>
 }) {
   return (
     <ItemGroup className="gap-4">
       {items.map((item) => (
         <Item
-          className="flex-col items-stretch sm:flex-row sm:items-center"
+          className="items-stretch flex-row items-center"
           key={item.id}
           role="listitem"
           variant={activeId === item.id ? 'muted' : 'outline'}
@@ -30,16 +28,8 @@ export function SettingsUiClusterList({
             <ItemTitle className="line-clamp-1">
               <Link to={`./${item.id}`}>{item.name}</Link>
             </ItemTitle>
-            <ItemDescription>{item.endpoint}</ItemDescription>
           </ItemContent>
-          <ItemActions className="w-full sm:w-auto">
-            {activeId == item.id ? null : (
-              <UiTooltip content="Set as active">
-                <Button onClick={() => setActive(item.id)} size="icon" variant="outline">
-                  <LucideCheck className="text-green-500 size-4" />
-                </Button>
-              </UiTooltip>
-            )}
+          <ItemActions>
             <UiTooltip content="Edit">
               <Button asChild size="icon" variant="outline">
                 <Link to={`./${item.id}`}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes the ability to set an active cluster in the cluster list feature, cleaning up related UI elements and functions.
> 
>   - **Behavior**:
>     - Removes ability to set active cluster in `SettingsFeatureClusterList` and `SettingsUiClusterList`.
>     - Deletes `setActiveId` function and related UI elements.
>   - **UI Changes**:
>     - Removes "Set as active" button and `ItemDescription` from `SettingsUiClusterList`.
>     - Adjusts `Item` class to "items-stretch flex-row items-center" in `SettingsUiClusterList`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 2d366a27c9971f326e36af01c02cfc075a6cbc70. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->