### PR TITLE
feat(settings): clean up account list

### DIFF
--- a/packages/settings/src/settings-feature-account-list.tsx
+++ b/packages/settings/src/settings-feature-account-list.tsx
@@ -16,7 +16,7 @@ export function SettingsFeatureAccountList() {
     onError: () => toastError('Error deleting account'),
     onSuccess: () => toastSuccess('Account deleted'),
   })
-  const { accounts, active, setActive } = useActiveAccount()
+  const { accounts, active } = useActiveAccount()
 
   return accounts.length ? (
     <UiCard
@@ -32,7 +32,6 @@ export function SettingsFeatureAccountList() {
         active={active}
         deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })}
         items={accounts}
-        setActive={setActive}
       />
     </UiCard>
   ) : (

--- a/packages/settings/src/ui/settings-ui-account-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list-item.tsx
@@ -3,7 +3,7 @@ import type { Account } from '@workspace/db/entity/account'
 import { Button } from '@workspace/ui/components/button'
 import { Item, ItemActions, ItemContent, ItemTitle } from '@workspace/ui/components/item'
 import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
-import { LucideCheck, LucidePencil, LucideTrash } from 'lucide-react'
+import { LucidePencil, LucideTrash } from 'lucide-react'
 import { Link } from 'react-router'
 
 import { SettingsUiAccountItem } from './settings-ui-account-item.js'
@@ -12,12 +12,10 @@ export function SettingsUiAccountListItem({
   active,
   deleteItem,
   item,
-  setActive,
 }: {
   active: Account | null
   deleteItem: (item: Account) => Promise<void>
   item: Account
-  setActive: (id: string) => Promise<void>
 }) {
   return (
     <Item key={item.id} role="listitem" variant={active?.id === item.id ? 'muted' : 'outline'}>
@@ -29,19 +27,6 @@ export function SettingsUiAccountListItem({
         </ItemTitle>
       </ItemContent>
       <ItemActions>
-        {active?.id === item.id ? null : (
-          <UiTooltip content="Set account as active">
-            <Button
-              onClick={async () => {
-                await setActive(item.id)
-              }}
-              size="icon"
-              variant="outline"
-            >
-              <LucideCheck className="text-green-500 size-4" />
-            </Button>
-          </UiTooltip>
-        )}
         <UiTooltip content="Edit account">
           <Button asChild size="icon" variant="outline">
             <Link to={`./${item.id}/edit`}>

--- a/packages/settings/src/ui/settings-ui-account-list.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list.tsx
@@ -9,23 +9,15 @@ export function SettingsUiAccountList({
   active,
   deleteItem,
   items,
-  setActive,
 }: {
   active: Account | null
   deleteItem: (item: Account) => Promise<void>
   items: Array<{ wallets?: Wallet[] } & Account>
-  setActive: (id: string) => Promise<void>
 }) {
   return (
     <ItemGroup className="gap-4">
       {items.map((item) => (
-        <SettingsUiAccountListItem
-          active={active}
-          deleteItem={deleteItem}
-          item={item}
-          key={item.id}
-          setActive={setActive}
-        />
+        <SettingsUiAccountListItem active={active} deleteItem={deleteItem} item={item} key={item.id} />
       ))}
     </ItemGroup>
   )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `setActive` functionality and related UI elements from account list components.
> 
>   - **Behavior**:
>     - Removes `setActive` functionality from `SettingsFeatureAccountList`, `SettingsUiAccountList`, and `SettingsUiAccountListItem`.
>     - Deletes UI elements related to setting an account as active, including the "Set account as active" button.
>   - **Imports**:
>     - Removes `LucideCheck` import from `settings-ui-account-list-item.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 53fb55345b68fc8d4ec2679f73b3f1ebb8794b06. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->