### PR TITLE
fix(site): remove astro getStaticPaths warning in dev mode

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -33,7 +33,23 @@ export default defineConfig({
       customCss: ['./src/styles/global.css'],
     }),
   ],
+  redirects: {
+    // These redirects also exist in /public/_redirects.
+    '/go/discord': {
+      destination: 'https://discord.gg/x6WcQ7bVgF',
+      status: 302,
+    },
+    '/go/github': {
+      destination: 'https://github.com/samui-build/samui-wallet',
+      status: 302,
+    },
+    '/go/x': {
+      destination: 'https://x.com/SamuiBuild',
+      status: 302,
+    }
+  },
   vite: {
+    // @ts-expect-error Astro 5 uses Vite 6, we use Vite 7 in our monorepo
     plugins: [tailwindcss()],
   },
 })


### PR DESCRIPTION
[WARN] [router] A `getStaticPaths()` route pattern was matched, but no
matching static path was found for requested path `/go/discord`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds redirects in `astro.config.mjs` to prevent `getStaticPaths()` warning in dev mode by redirecting specific paths to external URLs.
> 
>   - **Behavior**:
>     - Adds redirects in `astro.config.mjs` for `/go/discord`, `/go/github`, and `/go/x` to prevent `getStaticPaths()` warning in dev mode.
>     - Redirects point to external URLs with a 302 status.
>   - **Misc**:
>     - Adds a comment about existing redirects in `/public/_redirects`.
>     - Includes a `@ts-expect-error` comment for Vite version compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for bd2702d671a92a4ab8b45ac81cb5c16448710d14. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->