### PR TITLE
feat: invalidate queries on sending sol or spl tokens

### DIFF
--- a/packages/portfolio/src/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/use-create-and-send-sol-transaction.tsx
@@ -1,13 +1,17 @@
 import type { Wallet } from '@workspace/db/entity/wallet'
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
+import { getAccountInfoQueryOptions } from '@workspace/solana-client-react/use-get-account-info'
+import { getBalanceQueryOptions } from '@workspace/solana-client-react/use-get-balance'
 import { useSolanaClient } from '@workspace/solana-client-react/use-solana-client'
 import { createAndSendSolTransaction } from '@workspace/solana-client/create-and-send-sol-transaction'
 
 import type { ClusterWallet } from './portfolio-routes-loaded.js'
 
 export function useCreateAndSendSolTransaction(props: ClusterWallet) {
+  const { cluster, wallet } = props
+  const queryClient = useQueryClient()
   const client = useSolanaClient({ cluster: props.cluster })
 
   return useMutation({
@@ -18,6 +22,14 @@ export function useCreateAndSendSolTransaction(props: ClusterWallet) {
       const sender = await createKeyPairSignerFromJson({ json: wallet.secretKey })
 
       return createAndSendSolTransaction(client, { amount, destination, sender })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: getBalanceQueryOptions({ client, cluster, wallet }).queryKey,
+      })
+      queryClient.invalidateQueries({
+        queryKey: getAccountInfoQueryOptions({ client, cluster, wallet }).queryKey,
+      })
     },
   })
 }

--- a/packages/portfolio/src/use-create-and-send-spl-transaction.tsx
+++ b/packages/portfolio/src/use-create-and-send-spl-transaction.tsx
@@ -1,13 +1,18 @@
 import type { Wallet } from '@workspace/db/entity/wallet'
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
+import { getAccountInfoQueryOptions } from '@workspace/solana-client-react/use-get-account-info'
+import { getBalanceQueryOptions } from '@workspace/solana-client-react/use-get-balance'
+import { getTokenAccountsQueryOptions } from '@workspace/solana-client-react/use-get-token-accounts'
 import { useSolanaClient } from '@workspace/solana-client-react/use-solana-client'
 import { createAndSendSplTransaction } from '@workspace/solana-client/create-and-send-spl-transaction'
 
 import type { ClusterWallet } from './portfolio-routes-loaded.js'
 
 export function useCreateAndSendSplTransaction(props: ClusterWallet) {
+  const { cluster, wallet } = props
+  const queryClient = useQueryClient()
   const client = useSolanaClient({ cluster: props.cluster })
 
   return useMutation({
@@ -30,6 +35,17 @@ export function useCreateAndSendSplTransaction(props: ClusterWallet) {
       const sender = await createKeyPairSignerFromJson({ json: wallet.secretKey })
 
       return createAndSendSplTransaction(client, { amount, decimals, destination, mint, sender })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: getBalanceQueryOptions({ client, cluster, wallet }).queryKey,
+      })
+      queryClient.invalidateQueries({
+        queryKey: getAccountInfoQueryOptions({ client, cluster, wallet }).queryKey,
+      })
+      queryClient.invalidateQueries({
+        queryKey: getTokenAccountsQueryOptions({ client, cluster, wallet }).queryKey,
+      })
     },
   })
 }

--- a/packages/solana-client-react/src/use-get-token-accounts.tsx
+++ b/packages/solana-client-react/src/use-get-token-accounts.tsx
@@ -1,16 +1,29 @@
 import type { Cluster } from '@workspace/db/entity/cluster'
 import type { Wallet } from '@workspace/db/entity/wallet'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
 
-import { useQuery } from '@tanstack/react-query'
+import { queryOptions, useQuery } from '@tanstack/react-query'
 import { getTokenAccounts } from '@workspace/solana-client/get-token-accounts'
 
 import { useSolanaClient } from './use-solana-client'
 
-export function useGetTokenAccounts({ cluster, wallet }: { cluster: Cluster; wallet: Wallet }) {
-  const client = useSolanaClient({ cluster })
-
-  return useQuery({
+export function getTokenAccountsQueryOptions({
+  client,
+  cluster,
+  wallet,
+}: {
+  client: SolanaClient
+  cluster: Cluster
+  wallet: Wallet
+}) {
+  return queryOptions({
     queryFn: () => getTokenAccounts(client, { address: wallet.publicKey }),
     queryKey: ['get-token-accounts', { cluster, publicKey: wallet?.publicKey }],
   })
+}
+
+export function useGetTokenAccounts({ cluster, wallet }: { cluster: Cluster; wallet: Wallet }) {
+  const client = useSolanaClient({ cluster })
+
+  return useQuery(getTokenAccountsQueryOptions({ client, cluster, wallet }))
 }


### PR DESCRIPTION
Closes #206

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Invalidate queries on successful SOL and SPL transactions to ensure data consistency and reactivity.
> 
>   - **Behavior**:
>     - Invalidate queries on successful SOL and SPL transactions in `useCreateAndSendSolTransaction` and `useCreateAndSendSplTransaction`.
>     - Invalidate `getBalanceQueryOptions`, `getAccountInfoQueryOptions`, and `getTokenAccountsQueryOptions` (SPL only) on success.
>   - **Functions**:
>     - Add `getTokenAccountsQueryOptions` in `use-get-token-accounts.tsx` for query management.
>     - Use `getTokenAccountsQueryOptions` in `useGetTokenAccounts` for query configuration.
>   - **Imports**:
>     - Add `useQueryClient` and query options imports in transaction hooks for query invalidation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for d5cbf0f60932c4ff664bd82c5a33d56fdf48c0a2. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->