### PR TITLE
feat: prevent sending more SOL than is available to the account

### DIFF
--- a/packages/portfolio/src/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/use-create-and-send-sol-transaction.tsx
@@ -7,17 +7,44 @@ import { createAndSendSolTransaction } from '@workspace/solana-client/create-and
 
 import type { ClusterWallet } from './portfolio-routes-loaded.js'
 
-export function useCreateAndSendSolTransaction(props: ClusterWallet) {
+export function useCreateAndSendSolTransaction(
+  props: {
+    onError?: (error: Error) => void
+  } & ClusterWallet,
+) {
   const client = useSolanaClient({ cluster: props.cluster })
 
   return useMutation({
-    mutationFn: async ({ amount, destination, wallet }: { amount: string; destination: string; wallet: Wallet }) => {
+    mutationFn: async ({
+      amount,
+      balance,
+      destination,
+      wallet,
+    }: {
+      amount: string
+      balance: bigint | string
+      destination: string
+      wallet: Wallet
+    }) => {
       if (!wallet.secretKey) {
         throw new Error(`No secret key for this wallet`)
       }
       const sender = await createKeyPairSignerFromJson({ json: wallet.secretKey })
 
-      return createAndSendSolTransaction(client, { amount, destination, sender })
+      try {
+        const signature = await createAndSendSolTransaction(client, {
+          amount,
+          destination,
+          sender,
+          senderBalance: String(balance),
+        })
+        return signature
+      } catch (error) {
+        if (props.onError && error instanceof Error) {
+          props.onError(error)
+        }
+        throw error
+      }
     },
   })
 }

--- a/packages/solana-client/src/max-available-sol-amount.ts
+++ b/packages/solana-client/src/max-available-sol-amount.ts
@@ -1,0 +1,24 @@
+import type { Lamports } from '@solana/kit'
+
+import { lamports } from '@solana/kit'
+
+export const SOL_TRANSFER_FEE_LAMPORTS: Lamports = lamports(5000n)
+
+/**
+ * Calculates the maximum amount of SOL (in lamports) that can be sent
+ * from an account, accounting for the transaction fee.
+ @param availableBalance
+ @returns
+ */
+export function maxAvailableSolAmount(availableBalance: bigint | string): Lamports {
+  const balance = BigInt(availableBalance)
+
+  // If the balance is less than or equal to the fee, they can't send anything.
+  if (balance <= SOL_TRANSFER_FEE_LAMPORTS) {
+    return lamports(0n)
+  }
+
+  // Otherwise, they can send their balance minus the fee.
+  // We must cast the fee back to a bigint for the calculation.
+  return lamports(balance - BigInt(SOL_TRANSFER_FEE_LAMPORTS))
+}

--- a/packages/solana-client/test/max-available-sol-amounts.test.ts
+++ b/packages/solana-client/test/max-available-sol-amounts.test.ts
@@ -1,0 +1,35 @@
+import { lamports } from '@solana/kit'
+import { describe, expect, it } from 'vitest'
+
+import { maxAvailableSolAmount, SOL_TRANSFER_FEE_LAMPORTS } from '../src/max-available-sol-amount'
+
+describe('maxAvailableSolAmount', () => {
+  // Get the fee (which is 5000n lamports)
+  const fee = SOL_TRANSFER_FEE_LAMPORTS
+
+  it('should return 0n lamports if balance is less than the fee', () => {
+    const result = maxAvailableSolAmount('1000')
+    expect(result).toBe(lamports(0n))
+  })
+
+  it('should return 0n lamports if balance is equal to the fee', () => {
+    // Pass in the fee as a string or bigint, both should work
+    const result = maxAvailableSolAmount(String(fee))
+    expect(result).toBe(lamports(0n))
+  })
+
+  it('should return (balance - fee) if balance is greater than the fee', () => {
+    const balance = 1_000_000n
+    // We must cast the Lamports-branded fee back to a BigInt for subtraction
+    const expected = lamports(balance - BigInt(fee))
+    const result = maxAvailableSolAmount(balance)
+
+    expect(result).toBe(expected)
+    expect(result).toBe(lamports(995000n))
+  })
+
+  it('should return 0n lamports for zero balance', () => {
+    const result = maxAvailableSolAmount('0')
+    expect(result).toBe(lamports(0n))
+  })
+})


### PR DESCRIPTION
delivered:
- Implement the maxAvailableSolAmount function with tests in the solana-client package
- Update the createAndSendSolTransaction to take the senderBalance: string
- Call maxAvailableSolAmount in the createAndSendSolTransaction and throw an error if the conditions are not met
- Add an onError prop to useCreateAndSendSolTransaction that displays the error.


feature demo:
https://www.loom.com/share/274770d14b8a420b811178dca0dd8288

(open to any suggestions)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `maxAvailableSolAmount` to prevent sending more SOL than available, updating transaction logic and error handling.
> 
>   - **Behavior**:
>     - Implement `maxAvailableSolAmount` in `max-available-sol-amount.ts` to calculate max sendable SOL after fees.
>     - Update `createAndSendSolTransaction` in `create-and-send-sol-transaction.ts` to use `maxAvailableSolAmount` and throw error if requested amount exceeds available balance.
>     - Add `onError` prop to `useCreateAndSendSolTransaction` in `use-create-and-send-sol-transaction.tsx` to handle errors.
>   - **UI**:
>     - Update `PortfolioFeatureTabTokens` in `portfolio-feature-tab-tokens.tsx` to display error if account balance is unavailable.
>   - **Tests**:
>     - Add tests for `maxAvailableSolAmount` in `max-available-sol-amounts.test.ts` to cover various balance scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 8a249fba7495c242979b5f83353117eb1a3e8d45. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->