### PR TITLE
chore: enforce package manager

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yml
+++ b/.github/workflows/actions/install-dependencies/action.yml
@@ -10,8 +10,8 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: 22
-        cache: "pnpm"
+        node-version: 24
+        cache: 'pnpm'
 
     - name: Install dependencies
       shell: bash

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24",
+    "pnpm": ">=10"
   },
-  "packageManager": "pnpm@10.19.0",
+  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@tailwindcss/oxide",
@@ -37,6 +38,7 @@
     "format:check": "syncpack format --check && NODE_OPTIONS=\"--experimental-strip-types\" prettier --check \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
+    "preinstall": "npx only-allow pnpm",
     "prepare": "lefthook install",
     "test": "vitest run",
     "test:watch": "vitest --watch"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,3 +31,5 @@ catalog:
   zod: ^4.1.12
 
 minimumReleaseAge: 10080
+
+engineStrict: true


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enforces `pnpm` as the package manager, updates Node.js and `pnpm` versions, and sets `engineStrict` to true.
> 
>   - **Package Manager Enforcement**:
>     - Adds `preinstall` script in `package.json` to enforce `pnpm` usage.
>     - Sets `engineStrict: true` in `pnpm-workspace.yaml`.
>   - **Version Updates**:
>     - Updates Node.js version to `24` in `action.yml`.
>     - Updates `pnpm` version to `10.20.0` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for be685aed8a7ff4a438319b16e3d2e147ffc031a7. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->