### PR TITLE
chore: set node version to lts/krypton in .nvmrc and github actions

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yml
+++ b/.github/workflows/actions/install-dependencies/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: 24
+        node-version: lts/krypton
         cache: 'pnpm'
 
     - name: Install dependencies

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/krypton


### PR DESCRIPTION
The node version in `package.json` was not in line with the one in `.nvmrc` since #295

<img width="766" height="249" alt="image" src="https://github.com/user-attachments/assets/9b97efe5-bd01-4f6e-bafd-0d25d0c6bdfc" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Node.js version in `.nvmrc` to `24` for consistency with `package.json`.
> 
>   - **Configuration**:
>     - Updates Node.js version in `.nvmrc` from `lts/*` to `24` to match `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 195c0b9a5935191f9047b5a823b1bc36e5c60a30. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->