### PR TITLE
chore(web): externalize dependencies to decrease the bundle size

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,6 +4,28 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
+const externalDependencies = [
+  '@floating-ui',
+  '@radix-react',
+  '@solana',
+  '@tanstack',
+  '@wallet-standard',
+  'dexie',
+  'i18next',
+  'lucide-react',
+  'react',
+  'react-dom',
+  'react-router',
+  'sonner',
+  'tailwind-merge',
+  'zod',
+]
+
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      external: externalDependencies.map((dep) => new RegExp(`^${dep}(\\/.*)?$`)),
+    },
+  },
   plugins: [cloudflare(), react(), tailwindcss(), tsconfigPaths()],
 })


### PR DESCRIPTION
## Description

This externalize a bunch of dependencies that increased the bundle size.

Closes #

## Screenshots / Video

<details>
<summary>Before commit 75a0a1d</summary>

```
vite v7.1.12 building for production...
✓ 2328 modules transformed.
dist/.assetsignore                                      0.02 kB
dist/index.html                                         0.47 kB │ gzip:   0.30 kB
dist/wrangler.json                                      1.28 kB │ gzip:   0.64 kB
dist/assets/index-Cb4R1j36.css                         91.08 kB │ gzip:  15.56 kB
dist/assets/toast-success-D4tyik69.js                   0.08 kB │ gzip:   0.10 kB
dist/assets/handle-copy-text-DSRloYNb.js                0.20 kB │ gzip:   0.12 kB
dist/assets/tools-feature-mint-token-D7cvAICd.js        0.21 kB │ gzip:   0.18 kB
dist/assets/db-cluster-type-options-qu1TZPpu.js         0.22 kB │ gzip:   0.12 kB
dist/assets/tools-feature-airdrop-BcvZTaiw.js           0.22 kB │ gzip:   0.19 kB
dist/assets/dev-feature-scratch-pad-BplnPjID.js         0.45 kB │ gzip:   0.32 kB
dist/assets/ui-back-Dqvfy6vb.js                         0.50 kB │ gzip:   0.36 kB
dist/assets/ui-loader-BZm8VT-Q.js                       0.54 kB │ gzip:   0.37 kB
dist/assets/portfolio-ui-cluster-guard-CQbO2SKt.js      0.63 kB │ gzip:   0.34 kB
dist/assets/umbrella-BLnrL8Tf.js                        0.85 kB │ gzip:   0.44 kB
dist/assets/dev-feature-ui-C-cg9ol2.js                  0.92 kB │ gzip:   0.42 kB
dist/assets/badge-CSPhIsyH.js                           1.23 kB │ gzip:   0.59 kB
dist/assets/dev-routes-oJGZObCy.js                      1.33 kB │ gzip:   0.60 kB
dist/assets/dev-feature-solana-BhlTPQOD.js              1.59 kB │ gzip:   0.86 kB
dist/assets/tools-routes-W9wGoZCx.js                    1.62 kB │ gzip:   0.72 kB
dist/assets/ui-card-BrEG3tq_.js                         1.71 kB │ gzip:   0.64 kB
dist/assets/index-CRSG1KqH.js                           1.75 kB │ gzip:   0.68 kB
dist/assets/item-B810Hbwv.js                            2.26 kB │ gzip:   0.86 kB
dist/assets/tools-feature-overview-CsX2HOgk.js          3.14 kB │ gzip:   1.24 kB
dist/assets/ui-tab-routes-D_KgtVO7.js                   3.99 kB │ gzip:   1.75 kB
dist/assets/tools-feature-create-token-4shO0UTD.js      4.97 kB │ gzip:   2.16 kB
dist/assets/label-CM5RxSl_.js                           7.45 kB │ gzip:   3.28 kB
dist/assets/index-DulO1wny.js                           9.07 kB │ gzip:   3.38 kB
dist/assets/convert-json-to-byte-array-FWkI0cIT.js      9.14 kB │ gzip:   3.35 kB
dist/assets/onboarding-routes-BzeCdAiN.js              11.32 kB │ gzip:   4.42 kB
dist/assets/portfolio-ui-explorer-button-CmUHugvE.js   14.66 kB │ gzip:   4.93 kB
dist/assets/dev-feature-db-Bp4N_9D6.js                 23.29 kB │ gzip:   8.05 kB
dist/assets/ellipsify-CPal8ROc.js                      25.17 kB │ gzip:   8.70 kB
dist/assets/create-solana-client-BqA7xYGw.js           25.84 kB │ gzip:   8.22 kB
dist/assets/settings-routes-IfYNu9lQ.js                60.17 kB │ gzip:  19.05 kB
dist/assets/toggle-group-xznxSd0D.js                   60.28 kB │ gzip:  26.26 kB
dist/assets/portfolio-routes-DnY07-_q.js               77.92 kB │ gzip:  27.00 kB
dist/assets/index-Bk6mWWsU.js                         718.87 kB │ gzip: 242.57 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 2.28s
```

</details>

<details>
<summary>After</summary>

```
vite v7.1.12 building for production...
✓ 456 modules transformed.
dist/.assetsignore                                      0.02 kB
dist/index.html                                         0.47 kB │ gzip:  0.30 kB
dist/wrangler.json                                      1.28 kB │ gzip:  0.64 kB
dist/assets/index-Cb4R1j36.css                         91.08 kB │ gzip: 15.56 kB
dist/assets/toast-success-CL2WILeF.js                   0.07 kB │ gzip:  0.09 kB
dist/assets/ellipsify-BufquLMs.js                       0.16 kB │ gzip:  0.15 kB
dist/assets/handle-copy-text-DSRloYNb.js                0.20 kB │ gzip:  0.12 kB
dist/assets/db-cluster-type-options-qu1TZPpu.js         0.22 kB │ gzip:  0.12 kB
dist/assets/ui-back-Dqz_2KFx.js                         0.30 kB │ gzip:  0.22 kB
dist/assets/ui-loader-BpAhZEyi.js                       0.34 kB │ gzip:  0.23 kB
dist/assets/create-solana-client-aXfxR5wY.js            0.36 kB │ gzip:  0.23 kB
dist/assets/index-DBmFMVrK.js                           0.41 kB │ gzip:  0.31 kB
dist/assets/tools-feature-mint-token-C8TXeGmH.js        0.58 kB │ gzip:  0.32 kB
dist/assets/tools-feature-airdrop-CaoPTH6w.js           0.60 kB │ gzip:  0.33 kB
dist/assets/portfolio-ui-cluster-guard-CBcLnUFc.js      0.65 kB │ gzip:  0.35 kB
dist/assets/dev-feature-scratch-pad-Cu9mW0FK.js         0.82 kB │ gzip:  0.46 kB
dist/assets/badge-EvDKaA6_.js                           1.24 kB │ gzip:  0.60 kB
dist/assets/dev-feature-ui-DjOFgmBN.js                  1.26 kB │ gzip:  0.56 kB
dist/assets/label-SKFq30zn.js                           1.40 kB │ gzip:  0.70 kB
dist/assets/dev-routes-BWVXQJqz.js                      1.69 kB │ gzip:  0.73 kB
dist/assets/ui-card-T4EYSHGz.js                         1.69 kB │ gzip:  0.66 kB
dist/assets/tools-feature-overview-PTqk7w3Y.js          1.82 kB │ gzip:  0.80 kB
dist/assets/index-x38hbs4V.js                           1.83 kB │ gzip:  0.72 kB
dist/assets/tools-routes-BHaHEIYG.js                    1.95 kB │ gzip:  0.84 kB
dist/assets/dev-feature-solana-tOiuhBOa.js              1.98 kB │ gzip:  1.01 kB
dist/assets/item-DN5zsb71.js                            2.26 kB │ gzip:  0.87 kB
dist/assets/ui-tab-routes-CHhzMxJB.js                   4.05 kB │ gzip:  1.79 kB
dist/assets/tools-feature-create-token-Cybve26j.js      5.04 kB │ gzip:  2.18 kB
dist/assets/portfolio-ui-explorer-button-elRKRKB1.js    8.96 kB │ gzip:  3.06 kB
dist/assets/convert-json-to-byte-array-D2KCXbSx.js      9.08 kB │ gzip:  3.37 kB
dist/assets/onboarding-routes-DmP2hSA9.js              10.30 kB │ gzip:  4.19 kB
dist/assets/dev-feature-db-_ODepBH6.js                 22.71 kB │ gzip:  8.00 kB
dist/assets/settings-routes-J7kJmoOT.js                56.54 kB │ gzip: 18.44 kB
dist/assets/toggle-group-1CT3P2Qt.js                   60.37 kB │ gzip: 26.35 kB
dist/assets/portfolio-routes-ByYGrWyo.js               74.30 kB │ gzip: 26.51 kB
dist/assets/index-DRVwElCx.js                         132.92 kB │ gzip: 58.58 kB
✓ built in 797ms

```

</details>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Externalizes dependencies in `vite.config.ts` to reduce bundle size by configuring `rollupOptions.external`.
> 
>   - **Build Configuration**:
>     - Externalizes dependencies in `vite.config.ts` to reduce bundle size.
>     - Adds `externalDependencies` array with packages like `@floating-ui`, `react`, `zod`, etc.
>     - Configures `rollupOptions.external` to use regex for matching external dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 117aa6858a496d23e9dfaa4dbef7ca8044cd6491. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->