### PR TITLE
chore(i18n): translate onboarding feature

### DIFF
--- a/packages/i18n/i18next.config.ts
+++ b/packages/i18n/i18next.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 
       '../../examples/**',
     ],
-    ignoredAttributes: [],
+    ignoredAttributes: ['to', 'variant'],
     input: '../../**/*.{js,jsx,ts,tsx}',
     output: 'locales/{{language}}/{{namespace}}.json',
   },

--- a/packages/i18n/locales/en/onboarding.json
+++ b/packages/i18n/locales/en/onboarding.json
@@ -1,0 +1,13 @@
+{
+  "generateButtonCreate": "Create wallet",
+  "generateCardDescription": "This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!",
+  "generateCardTitle": "Generate Recovery Phrase",
+  "generateToastCopied": "Mnemonic copied to clipboard",
+  "importButtonSubmit": "Import wallet",
+  "importCardDescription": "Enter the seed phrase you stored when you created your wallet.",
+  "importCardTitle": "Import Recovery Phrase",
+  "indexLinkGenerate": "Create a new wallet",
+  "indexLinkImport": "I already have a wallet",
+  "indexPageDescription": "We hope you enjoy your stay!",
+  "indexPageTitle": "Welcome to 🏝️ Samui Wallet"
+}

--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -1,3 +1,0 @@
-{
-  "We hope you enjoy your stay!": "We hope you enjoy your stay!"
-}

--- a/packages/i18n/locales/es/onboarding.json
+++ b/packages/i18n/locales/es/onboarding.json
@@ -1,0 +1,13 @@
+{
+  "generateButtonCreate": "Crea billetera",
+  "generateCardDescription": "Esta frase semilla es la ÚNICA forma de recuperar tu billetera. ¡No la compartas con nadie!",
+  "generateCardTitle": "Generar frase de recuperación",
+  "generateToastCopied": "Mnemónica copiada al portapapeles",
+  "importButtonSubmit": "Importar billetera",
+  "importCardDescription": "Introduce la frase semilla que guardaste cuando creaste tu billetera.",
+  "importCardTitle": "Importar frase de recuperación",
+  "indexLinkGenerate": "Crea una nueva billetera",
+  "indexLinkImport": "Ya tengo una billetera",
+  "indexPageDescription": "Esperamos que disfrutes tu estancia",
+  "indexPageTitle": "Bienvenido a 🏝 Samui Wallet"
+}

--- a/packages/i18n/locales/es/translation.json
+++ b/packages/i18n/locales/es/translation.json
@@ -1,3 +1,0 @@
-{
-  "We hope you enjoy your stay!": ""
-}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -4,11 +4,10 @@ import './i18next.d.ts'
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
-import enTranslations from '../locales/en/translation.json' with { type: 'json' }
-import esTranslations from '../locales/es/translation.json' with { type: 'json' }
+import enOnboarding from '../locales/en/onboarding.json' with { type: 'json' }
+import esOnboarding from '../locales/es/onboarding.json' with { type: 'json' }
 
 i18n.use(initReactI18next).init({
-  defaultNS: 'translation',
   fallbackLng: 'en',
   interpolation: {
     escapeValue: false,
@@ -16,10 +15,10 @@ i18n.use(initReactI18next).init({
   lng: 'en',
   resources: {
     en: {
-      translation: enTranslations,
+      onboarding: enOnboarding,
     },
     es: {
-      translation: esTranslations,
+      onboarding: esOnboarding,
     },
   },
 })

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -1,6 +1,16 @@
 interface Resources {
-  translation: {
-    'We hope you enjoy your stay!': 'We hope you enjoy your stay!'
+  onboarding: {
+    generateButtonCreate: 'Create wallet'
+    generateCardDescription: "This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!"
+    generateCardTitle: 'Generate Recovery Phrase'
+    generateToastCopied: 'Mnemonic copied to clipboard'
+    importButtonSubmit: 'Import wallet'
+    importCardDescription: 'Enter the seed phrase you stored when you created your wallet.'
+    importCardTitle: 'Import Recovery Phrase'
+    indexLinkGenerate: 'Create a new wallet'
+    indexLinkImport: 'I already have a wallet'
+    indexPageDescription: 'We hope you enjoy your stay!'
+    indexPageTitle: 'Welcome to 🏝️ Samui Wallet'
   }
 }
 

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -3,5 +3,5 @@
     "outDir": "dist"
   },
   "extends": "@workspace/config-typescript/base.json",
-  "files": ["locales/en/translation.json", "locales/es/translation.json"]
+  "files": ["locales/en/onboarding.json", "locales/es/onboarding.json"]
 }

--- a/packages/onboarding/src/onboarding-feature-generate.tsx
+++ b/packages/onboarding/src/onboarding-feature-generate.tsx
@@ -1,5 +1,5 @@
+import { useTranslation } from '@workspace/i18n'
 import type { MnemonicStrength } from '@workspace/keypair/generate-mnemonic'
-
 import { generateMnemonic } from '@workspace/keypair/generate-mnemonic'
 import { validateMnemonic } from '@workspace/keypair/validate-mnemonic'
 import { UiBackButton } from '@workspace/ui/components/ui-back-button'
@@ -14,6 +14,7 @@ import { OnboardingUiMnemonicSelectStrength } from './ui/onboarding-ui-mnemonic-
 import { OnboardingUiMnemonicShow } from './ui/onboarding-ui-mnemonic-show.tsx'
 
 export function OnboardingFeatureGenerate() {
+  const { t } = useTranslation('onboarding')
   const create = useCreateNewWallet()
   const [strength, setStrength] = useState<MnemonicStrength>(128)
   const mnemonic = useMemo(() => generateMnemonic({ strength }), [strength])
@@ -34,17 +35,20 @@ export function OnboardingFeatureGenerate() {
       }}
     >
       <UiCard
-        description="This seed phrase is the ONLY way to recover your account. Don't share it with anyone!"
+        description={t(($) => $.generateCardDescription)}
         footer={
           <div className="flex w-full justify-between">
-            <UiTextCopyButton text={mnemonic} toast="Mnemonic copied to clipboard" />
-            <OnboardingUiMnemonicSave disabled={!validateMnemonic({ mnemonic })} label="Create account" />
+            <UiTextCopyButton text={mnemonic} toast={t(($) => $.generateToastCopied)} />
+            <OnboardingUiMnemonicSave
+              disabled={!validateMnemonic({ mnemonic })}
+              label={t(($) => $.generateButtonCreate)}
+            />
           </div>
         }
         title={
           <div>
             <UiBackButton className="mr-2" />
-            Generate Recovery Phrase
+            {t(($) => $.generateCardTitle)}
           </div>
         }
       >

--- a/packages/onboarding/src/onboarding-feature-import.tsx
+++ b/packages/onboarding/src/onboarding-feature-import.tsx
@@ -1,5 +1,5 @@
+import { useTranslation } from '@workspace/i18n'
 import type { MnemonicStrength } from '@workspace/keypair/generate-mnemonic'
-
 import { validateMnemonic } from '@workspace/keypair/validate-mnemonic'
 import { UiBackButton } from '@workspace/ui/components/ui-back-button'
 import { UiCard } from '@workspace/ui/components/ui-card'
@@ -13,6 +13,7 @@ import { OnboardingUiMnemonicSave } from './ui/onboarding-ui-mnemonic-save.tsx'
 import { OnboardingUiMnemonicSelectStrength } from './ui/onboarding-ui-mnemonic-select-strength.tsx'
 
 export function OnboardingFeatureImport() {
+  const { t } = useTranslation('onboarding')
   const create = useCreateNewWallet()
   const [strength, setStrength] = useState<MnemonicStrength>(128)
 
@@ -79,17 +80,17 @@ export function OnboardingFeatureImport() {
       }}
     >
       <UiCard
-        description="Enter the seed phrase you stored when you created your account."
+        description={t(($) => $.importCardDescription)}
         footer={
           <div className="flex w-full justify-between">
             <UiTextPasteButton onPaste={handlePaste} />
-            <OnboardingUiMnemonicSave disabled={!isFormComplete} label="Import account" />
+            <OnboardingUiMnemonicSave disabled={!isFormComplete} label={t(($) => $.importButtonSubmit)} />
           </div>
         }
         title={
           <div>
             <UiBackButton className="mr-2" />
-            Import Recovery Phrase
+            {t(($) => $.importCardTitle)}
           </div>
         }
       >

--- a/packages/onboarding/src/onboarding-feature-index.tsx
+++ b/packages/onboarding/src/onboarding-feature-index.tsx
@@ -5,21 +5,21 @@ import { UiExperimentalWarning } from '@workspace/ui/components/ui-experimental-
 import { Link } from 'react-router'
 
 export function OnboardingFeatureIndex() {
-  const { t } = useTranslation()
+  const { t } = useTranslation('onboarding')
   const [accepted, setAccepted] = useDbSetting('warningAcceptExperimental')
   return (
     <div className="flex flex-col gap-6 items-center min-w-[400px]">
       <div className="flex flex-col items-center space-y-2">
-        <div className="text-2xl">Welcome to 🏝️ Samui Wallet</div>
-        <div className="text-lg text-muted-foreground">{t(($) => $['We hope you enjoy your stay!'])}</div>
+        <div className="text-2xl">{t(($) => $.indexPageTitle)}</div>
+        <div className="text-lg text-muted-foreground">{t(($) => $.indexPageDescription)}</div>
       </div>
       {accepted === 'true' ? null : <UiExperimentalWarning close={() => setAccepted('true')} />}
       <div className="flex flex-col space-y-2 w-full">
         <Button asChild>
-          <Link to="generate">Create a new wallet</Link>
+          <Link to="generate">{t(($) => $.indexLinkGenerate)}</Link>
         </Button>
         <Button asChild variant="secondary">
-          <Link to="import">I already have a wallet</Link>
+          <Link to="import">{t(($) => $.indexLinkImport)}</Link>
         </Button>
       </div>
     </div>


### PR DESCRIPTION
Working on #310 

<img width="520" height="352" alt="Screenshot 2025-11-03 at 8 55 29 PM" src="https://github.com/user-attachments/assets/e5af1b3a-0840-4b5d-9526-93540bcb69eb" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Translate onboarding feature into English and Spanish, updating i18n configuration and onboarding components to use new translation files.
> 
>   - **i18n Configuration**:
>     - Updated `i18next.config.ts` to ignore attributes `to` and `variant`.
>     - Removed `translation.json` imports and added `onboarding.json` imports in `index.ts`.
>   - **Translation Files**:
>     - Added `onboarding.json` for English and Spanish in `locales/en` and `locales/es`.
>     - Deleted `translation.json` files in `locales/en` and `locales/es`.
>   - **Onboarding Components**:
>     - Updated `onboarding-feature-generate.tsx`, `onboarding-feature-import.tsx`, and `onboarding-feature-index.tsx` to use `useTranslation('onboarding')` for text elements.
>     - Replaced hardcoded strings with translation keys in the above components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 2ac5866b2db16716ef3875eed28462b7126d0f5e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->