### PR TITLE
fix(ui): ensure ui-tab-routes render as expected

### DIFF
--- a/packages/ui/src/components/ui-tab-routes.tsx
+++ b/packages/ui/src/components/ui-tab-routes.tsx
@@ -27,16 +27,12 @@ export function UiTabRoutes({
   // Set default redirect route to the first tab
   const redirect = tabs[0]?.path !== '' ? tabs[0]?.path : undefined
 
-  if (!activeTab) {
-    return null
-  }
-
   return (
     <>
       <Tabs
         activationMode="manual"
         onValueChange={(value) => navigate(`${basePath}/${value}`)}
-        value={activeTab}
+        value={activeTab ?? ''}
         {...props}
       >
         <TabsList>


### PR DESCRIPTION
## Description

The `UiTabRoutes` component will redirect to the first tab in the list if that's not an index route.

For this to work though, we can't short-circuit returning `null` when `activeTab` is not set, as the component doesn't know which tab is active until after that redirect.

We may be able to optimize how this works, but in order to make the tabs render we'll have to get rid of this line.


## Screenshots / Video

Un the current `main` branch, the portfolio page doesn't redirect (see url in the screenshot):

<img width="944" height="1397" alt="image" src="https://github.com/user-attachments/assets/c37863fd-6e6e-4b40-acaf-af1fde945712" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes short-circuit return in `UiTabRoutes` to ensure proper tab rendering and redirection.
> 
>   - **Behavior**:
>     - Removes short-circuit `return null` when `activeTab` is not set in `UiTabRoutes`.
>     - Ensures `UiTabRoutes` redirects to the first tab if it's not an index route.
>   - **Components**:
>     - Updates `value` prop in `Tabs` to use `activeTab ?? ''` in `ui-tab-routes.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 6227644d387df96130f7625bae0ec78e90663a71. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->