### PR TITLE
fix(onboarding): persist experimental warning state across app lifecycle

### DIFF
--- a/packages/onboarding/src/onboarding-feature-index.tsx
+++ b/packages/onboarding/src/onboarding-feature-index.tsx
@@ -1,19 +1,19 @@
+import { useDbPreference } from '@workspace/db-react/use-db-preference'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { UiExperimentalWarning } from '@workspace/ui/components/ui-experimental-warning'
-import { useState } from 'react'
 import { Link } from 'react-router'
 
 export function OnboardingFeatureIndex() {
   const { t } = useTranslation()
-  const [accepted, setAccepted] = useState(false)
+  const [accepted, setAccepted] = useDbPreference('warningAcceptExperimental')
   return (
     <div className="flex flex-col gap-6 items-center min-w-[400px]">
       <div className="flex flex-col items-center space-y-2">
         <div className="text-2xl">Welcome to 🏝️ Samui Wallet</div>
         <div className="text-lg text-muted-foreground">{t(($) => $['We hope you enjoy your stay!'])}</div>
       </div>
-      {accepted ? null : <UiExperimentalWarning close={() => setAccepted(true)} />}
+      {accepted === 'true' ? null : <UiExperimentalWarning close={() => setAccepted('true')} />}
       <div className="flex flex-col space-y-2 w-full">
         <Button asChild>
           <Link to="generate">Create a new wallet</Link>


### PR DESCRIPTION
## Description

When users closed the UiExperimentalWarning during onboarding, it would
reappear after completing onboarding. This happened because the onboarding
component used local React state while the main shell used database-persisted
state.

Replace useState with useDbPreference hook to persist the warning's closed
state to the database, ensuring the preference is maintained throughout the
application.

Closes #311 

## Checklist

- [ ] Tests have been added for my change
- [ ] Docs have been updated for my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `useState` with `useDbPreference` in `OnboardingFeatureIndex` to persist `UiExperimentalWarning` state across app lifecycle.
> 
>   - **Behavior**:
>     - Replaces `useState` with `useDbPreference` in `OnboardingFeatureIndex` to persist `UiExperimentalWarning` closed state to the database.
>     - Ensures `UiExperimentalWarning` remains closed after onboarding is completed.
>   - **Code Changes**:
>     - Modifies `onboarding-feature-index.tsx` to use `useDbPreference` for `accepted` state.
>     - Updates condition to check `accepted !== 'true'` for rendering `UiExperimentalWarning`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 1f77199de8ed438e6db1f9d0f3c05549fcd1bd53. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->