### PR TITLE
fix: support versioned transactions in getTransaction calls

### DIFF
--- a/packages/solana-client-react/src/use-get-transaction.tsx
+++ b/packages/solana-client-react/src/use-get-transaction.tsx
@@ -67,7 +67,13 @@ export function useGetTransaction({ cluster, signature }: { cluster: Cluster; si
     enabled: isValidSignature(signature),
     queryFn: () => {
       assertIsSignature(signature)
-      return client.rpc.getTransaction(signature).send()
+      return client.rpc
+        .getTransaction(signature, {
+          commitment: 'confirmed',
+          encoding: 'json',
+          maxSupportedTransactionVersion: 0,
+        })
+        .send()
     },
     queryKey: ['getTransaction', cluster.endpoint, signature],
   })


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description
- This PR is the fix for the issue #339 where some versioned Solana transactions (v0) failed to load in the wallet activity view with the error:
`Transaction version (0) is not supported by the requesting client. Please try the request again with the following configuration parameter: "maxSupportedTransactionVersion": 0`
- so i have added the config to the getTransaction call to give the version transactions
`{
commitment: 'confirmed',
          encoding: 'json',
          maxSupportedTransactionVersion: 0,}` this configurations allows fetching both legacy and versioned (v0) transactions without RPC errors.
<!-- Please include a summary of the change and the motivation behind it. -->

Closes #339 
## Screenshots / Video

### Before 
<img width="3094" height="1670" alt="image" src="https://github.com/user-attachments/assets/b4f4de36-423e-4945-bf12-3ad3f6fec28e" />

### After
<img width="1403" height="826" alt="image" src="https://github.com/user-attachments/assets/d29921ea-fb0d-46c3-acbe-0a0a2b9be50e" />

<!-- Please include screenshots or video if UI changes are made. -->

## Checklist

- [ ] Tests have been added for my change
- [ ] Docs have been updated for my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for versioned Solana transactions in `useGetTransaction` by configuring `getTransaction` call in `use-get-transaction.tsx`.
> 
>   - **Behavior**:
>     - Adds `maxSupportedTransactionVersion: 0` to `getTransaction` call in `useGetTransaction` in `use-get-transaction.tsx`.
>     - Allows fetching both legacy and versioned (v0) Solana transactions without RPC errors.
>   - **Motivation**:
>     - Fixes issue #339 where versioned transactions failed to load in the wallet activity view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b34bcf4f239957b002b9e752403a4a9f061dfda4. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->