### PR TITLE
refactor: use the backButtonTo propery on UiCard

### DIFF
--- a/packages/settings/src/settings-feature-account-create.tsx
+++ b/packages/settings/src/settings-feature-account-create.tsx
@@ -1,18 +1,10 @@
-import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 
 import { SettingsUiAccountCreateOptions } from './ui/settings-ui-account-create-options.tsx'
 
 export function SettingsFeatureAccountCreate() {
   return (
-    <UiCard
-      title={
-        <div className="flex items-center gap-2">
-          <UiBack />
-          Create Account
-        </div>
-      }
-    >
+    <UiCard backButtonTo=".." title="Create Account">
       <SettingsUiAccountCreateOptions />
     </UiCard>
   )

--- a/packages/settings/src/settings-feature-account-generate.tsx
+++ b/packages/settings/src/settings-feature-account-generate.tsx
@@ -1,5 +1,4 @@
 import { generateMnemonic } from '@workspace/keypair/generate-mnemonic'
-import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -18,13 +17,9 @@ export function SettingsFeatureAccountGenerate() {
 
   return (
     <UiCard
+      backButtonTo="/settings/accounts/create"
       contentProps={{ className: 'grid gap-6' }}
-      title={
-        <div className="flex items-center gap-2">
-          <UiBack />
-          Generate Account
-        </div>
-      }
+      title="Generate Account"
     >
       <SettingsUiAccountMnemonicStrength setStrength={setStrength} strength={strength} />
       <SettingsUiAccountFormGenerate

--- a/packages/settings/src/settings-feature-account-import.tsx
+++ b/packages/settings/src/settings-feature-account-import.tsx
@@ -1,4 +1,3 @@
-import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { useNavigate } from 'react-router'
 
@@ -11,14 +10,7 @@ export function SettingsFeatureAccountImport() {
   const navigate = useNavigate()
   const name = useDetermineAccountName()
   return (
-    <UiCard
-      title={
-        <div className="flex items-center gap-2">
-          <UiBack />
-          Import Account
-        </div>
-      }
-    >
+    <UiCard backButtonTo="/settings/accounts/create" title="Import Account">
       <SettingsUiAccountFormImport
         name={name}
         submit={async (input, redirect) => {

--- a/packages/settings/src/settings-feature-account-update.tsx
+++ b/packages/settings/src/settings-feature-account-update.tsx
@@ -1,6 +1,5 @@
 import { useDbAccountFindUnique } from '@workspace/db-react/use-db-account-find-unique'
 import { useDbAccountUpdate } from '@workspace/db-react/use-db-account-update'
-import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { UiError } from '@workspace/ui/components/ui-error'
 import { UiLoader } from '@workspace/ui/components/ui-loader'
@@ -26,14 +25,7 @@ export function SettingsFeatureAccountUpdate() {
   }
 
   return (
-    <UiCard
-      title={
-        <div className="flex items-center gap-2">
-          <UiBack />
-          Edit Account
-        </div>
-      }
-    >
+    <UiCard backButtonTo={`/settings/accounts/${item.id}`} title="Edit Account">
       <SettingsUiAccountFormUpdate
         item={item}
         submit={async (input) =>

--- a/packages/settings/src/settings-feature-cluster-create.tsx
+++ b/packages/settings/src/settings-feature-cluster-create.tsx
@@ -1,5 +1,4 @@
 import { useDbClusterCreate } from '@workspace/db-react/use-db-cluster-create'
-import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { useNavigate } from 'react-router'
 
@@ -9,15 +8,7 @@ export function SettingsFeatureClusterCreate() {
   const createMutation = useDbClusterCreate()
   const navigate = useNavigate()
   return (
-    <UiCard
-      contentProps={{ className: 'grid gap-6' }}
-      title={
-        <div className="flex items-center gap-2">
-          <UiBack />
-          Add Cluster
-        </div>
-      }
-    >
+    <UiCard backButtonTo=".." contentProps={{ className: 'grid gap-6' }} title="Add Cluster">
       <SettingsUiClusterFormCreate
         submit={(input) =>
           createMutation.mutateAsync({ input }).then(() => {

--- a/packages/settings/src/settings-feature-cluster-update.tsx
+++ b/packages/settings/src/settings-feature-cluster-update.tsx
@@ -1,6 +1,5 @@
 import { useDbClusterFindUnique } from '@workspace/db-react/use-db-cluster-find-unique'
 import { useDbClusterUpdate } from '@workspace/db-react/use-db-cluster-update'
-import { UiBack } from '@workspace/ui/components/ui-back'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { UiError } from '@workspace/ui/components/ui-error'
 import { UiLoader } from '@workspace/ui/components/ui-loader'
@@ -26,14 +25,7 @@ export function SettingsFeatureClusterUpdate() {
   }
 
   return (
-    <UiCard
-      title={
-        <div className="flex items-center gap-2">
-          <UiBack />
-          Edit Cluster
-        </div>
-      }
-    >
+    <UiCard backButtonTo=".." title="Edit Cluster">
       <SettingsUiClusterFormUpdate
         item={item}
         submit={async (input) => {


### PR DESCRIPTION
In #261 I added the `backButtonTo` option to `UiCard` that can be used to add a back button with a link to a card title.

This prevents a bunch of duplication of a common UI pattern.

This PR removes the imperative buttons and replaces it with the use of this property.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor components to use `backButtonTo` in `UiCard` for back navigation, removing `UiBack` usage.
> 
>   - **Refactor**:
>     - Replace manual back button creation with `backButtonTo` in `UiCard` in `settings-feature-account-create.tsx`, `settings-feature-account-generate.tsx`, and `settings-feature-account-import.tsx`.
>     - Apply similar refactor in `settings-feature-account-update.tsx`, `settings-feature-cluster-create.tsx`, and `settings-feature-cluster-update.tsx`.
>   - **Removal**:
>     - Remove `UiBack` component usage in all affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for debb8fcaa0323459dd1a144647a9fba133afacd2. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->