### PR TITLE
fix(dev): remove duplicate feature imports

### DIFF
--- a/packages/dev/src/dev-routes.tsx
+++ b/packages/dev/src/dev-routes.tsx
@@ -1,22 +1,6 @@
 import { UiTabRoutes } from '@workspace/ui/components/ui-tab-routes'
-import { lazy } from 'react'
-
-const DevFeatureDb = lazy(() => import('./dev-feature-db.tsx'))
-const DevFeatureScratchPad = lazy(() => import('./dev-feature-scratch-pad.tsx'))
-const DevFeatureSolana = lazy(() => import('./dev-feature-solana.tsx'))
-const DevFeatureUi = lazy(() => import('./dev-feature-ui.tsx'))
+import { devFeatures } from './dev-features.tsx'
 
 export default function DevRoutes() {
-  return (
-    <UiTabRoutes
-      basePath="/dev"
-      className="mt-2 mb-4 lg:mb-6"
-      tabs={[
-        { element: <DevFeatureScratchPad />, label: 'Scratch Pad', path: 'scratch-pad' },
-        { element: <DevFeatureDb />, label: 'DB', path: 'db' },
-        { element: <DevFeatureSolana />, label: 'Solana', path: 'solana' },
-        { element: <DevFeatureUi />, label: 'UI', path: 'ui' },
-      ]}
-    />
-  )
+  return <UiTabRoutes basePath="/dev" className="mt-2 mb-4 lg:mb-6" tabs={devFeatures} />
 }


### PR DESCRIPTION
In #198 I extracted the dev routes/tabs into an object so they could be loaded in the menu bar.

However, I didn't remove the duplicate routes in `dev-routes.tsx`.

This PR fixes that.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes duplicate feature imports in `dev-routes.tsx` by using `devFeatures` from `dev-features.tsx`.
> 
>   - **Behavior**:
>     - Removes duplicate feature imports in `dev-routes.tsx` by using `devFeatures` from `dev-features.tsx`.
>     - Simplifies `DevRoutes` function to use `devFeatures` for tab configuration.
>   - **Imports**:
>     - Removes lazy imports of `DevFeatureDb`, `DevFeatureScratchPad`, `DevFeatureSolana`, and `DevFeatureUi` in `dev-routes.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 5d2aa60765991bac6f885eabfa414384c533093d. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->