### PR TITLE
fix(solana-client): make sure we don't convert sol amount to lamports twice

### DIFF
--- a/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
@@ -83,7 +83,7 @@ export function PortfolioFeatureTabTokens(props: AccountNetwork) {
       )
 
       if (sendError) {
-        toastError('Error sending SOL')
+        toastError(`Error sending SOL: ${sendError}`)
         return
       }
 

--- a/packages/solana-client/src/create-and-send-sol-transaction.ts
+++ b/packages/solana-client/src/create-and-send-sol-transaction.ts
@@ -33,7 +33,7 @@ export async function createAndSendSolTransaction(
 
   const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
   const transactionMessage = createSolTransferTransaction({
-    amount: amount.toString(),
+    amount,
     destination,
     latestBlockhash,
     sender,

--- a/packages/solana-client/src/create-sol-transfer-transaction.ts
+++ b/packages/solana-client/src/create-sol-transfer-transaction.ts
@@ -11,8 +11,6 @@ import {
 } from '@solana/kit'
 import { getTransferSolInstruction } from '@solana-program/system'
 
-import { solToLamports } from './sol-to-lamports.ts'
-
 export interface LatestBlockhash {
   blockhash: Blockhash
   lastValidBlockHeight: bigint
@@ -25,7 +23,7 @@ export function createSolTransferTransaction({
   sender,
   source,
 }: {
-  amount: string
+  amount: bigint
   destination: Address | string
   latestBlockhash: LatestBlockhash
   sender: TransactionSigner
@@ -37,7 +35,7 @@ export function createSolTransferTransaction({
     assertIsKeyPairSigner(source)
   }
   const transferInstruction = getTransferSolInstruction({
-    amount: solToLamports(amount),
+    amount,
     destination: address(destination),
     source: source ?? sender,
   })


### PR DESCRIPTION
Currently, we convert the SOL amount to lamports inside the `createAndSendSolTransaction` as well as when calling it.

This change removes the conversion from inside the function and expects the caller to do it.

Created #379 to ensure we don't introduce regressions like this again.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes SOL to lamports conversion from `createAndSendSolTransaction`, requiring caller to provide amount in lamports.
> 
>   - **Behavior**:
>     - Removes SOL to lamports conversion from `createAndSendSolTransaction` in `create-and-send-sol-transaction.ts`.
>     - Expects caller to provide amount in lamports.
>   - **Functions**:
>     - `createSolTransferTransaction` in `create-sol-transfer-transaction.ts` now takes `amount` as `bigint` directly.
>   - **Misc**:
>     - Updates error message in `PortfolioFeatureTabTokens` to include error details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for a8d62fe5f99adc567eeeadc792308c6b6a8c38c3. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->