### PR TITLE
fix(settings): set extractable to true when importing key

### DIFF
--- a/packages/settings/src/settings-feature-wallet-add-account.tsx
+++ b/packages/settings/src/settings-feature-wallet-add-account.tsx
@@ -41,7 +41,7 @@ export function SettingsFeatureWalletAddAccount() {
       return
     }
     try {
-      const { publicKey, secretKey } = await importKeyPairToPublicKeySecretKey(input)
+      const { publicKey, secretKey } = await importKeyPairToPublicKeySecretKey(input, true)
       assertIsAddress(publicKey)
       await createAccountMutation.mutateAsync({
         input: { name: ellipsify(publicKey), publicKey, secretKey, type: 'Imported', walletId },


### PR DESCRIPTION
Currently the option to `Import an account from a base85 secret key or byte array` is broken because we don't have this flag set.

> InvalidAccessError: Failed to execute 'exportKey' on 'SubtleCrypto': key is not extractable


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `InvalidAccessError` by setting `extractable` to `true` in `importKeyPairToPublicKeySecretKey()` in `settings-feature-wallet-add-account.tsx`.
> 
>   - **Bug Fix**:
>     - Set `extractable` to `true` in `importKeyPairToPublicKeySecretKey()` call in `settings-feature-wallet-add-account.tsx` to fix `InvalidAccessError` during key import.
>   - **Behavior**:
>     - Allows importing accounts from a base85 secret key or byte array without error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for d00bb4d586c18b0ceaa3fc45fe70867889086cd0. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->