### PR TITLE
fix(extension): ensure popup has fixed width

### DIFF
--- a/apps/extension/src/entrypoints/popup/index.html
+++ b/apps/extension/src/entrypoints/popup/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark w-100 h-100">
+<html lang="en" class="dark w-[375px] h-[600px]">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
This makes it so that the extension popup has a fixed width of `375px` by `600px` which is in line with Backpack, Phantom and Solflare.
 
<img width="427" height="670" alt="image" src="https://github.com/user-attachments/assets/fbc43df7-db5e-4ee7-8031-708f5dadde10" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets fixed dimensions for the extension popup to `375px` by `600px` in `index.html`.
> 
>   - **Behavior**:
>     - Sets fixed dimensions for the extension popup to `375px` width and `600px` height in `index.html`.
>     - Aligns popup size with Backpack, Phantom, and Solflare extensions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 76d6ee4e9ac43740bc87f0189ba8ee9dbde316ba. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->