### PR TITLE
chore(i18n): translate onboarding ui

### DIFF
--- a/packages/i18n/i18next.config.ts
+++ b/packages/i18n/i18next.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 
       '../../examples/**',
     ],
-    ignoredAttributes: ['to', 'variant'],
+    ignoredAttributes: ['autoComplete', 'autoCorrect', 'spellCheck', 'to', 'variant'],
     input: '../../**/*.{js,jsx,ts,tsx}',
     output: 'locales/{{language}}/{{namespace}}.json',
   },

--- a/packages/i18n/locales/en/onboarding.json
+++ b/packages/i18n/locales/en/onboarding.json
@@ -3,11 +3,15 @@
   "generateCardDescription": "This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!",
   "generateCardTitle": "Generate Recovery Phrase",
   "generateToastCopied": "Mnemonic copied to clipboard",
+  "generateToastCopy": "Copy",
   "importButtonSubmit": "Import wallet",
   "importCardDescription": "Enter the seed phrase you stored when you created your wallet.",
   "importCardTitle": "Import Recovery Phrase",
+  "importToastPaste": "Paste",
   "indexLinkGenerate": "Create a new wallet",
   "indexLinkImport": "I already have a wallet",
   "indexPageDescription": "We hope you enjoy your stay!",
-  "indexPageTitle": "Welcome to 🏝️ Samui Wallet"
+  "indexPageTitle": "Welcome to 🏝️ Samui Wallet",
+  "uiMnemonicUnexpectedLength": "Unexpected mnemonic length",
+  "uiMnemonicWords": "{{words}} words"
 }

--- a/packages/i18n/locales/es/onboarding.json
+++ b/packages/i18n/locales/es/onboarding.json
@@ -3,11 +3,15 @@
   "generateCardDescription": "Esta frase semilla es la ÚNICA forma de recuperar tu billetera. ¡No la compartas con nadie!",
   "generateCardTitle": "Generar frase de recuperación",
   "generateToastCopied": "Mnemónica copiada al portapapeles",
+  "generateToastCopy": "Copiar",
   "importButtonSubmit": "Importar billetera",
   "importCardDescription": "Introduce la frase semilla que guardaste cuando creaste tu billetera.",
   "importCardTitle": "Importar frase de recuperación",
+  "importToastPaste": "Pegar",
   "indexLinkGenerate": "Crea una nueva billetera",
   "indexLinkImport": "Ya tengo una billetera",
   "indexPageDescription": "Esperamos que disfrutes tu estancia",
-  "indexPageTitle": "Bienvenido a 🏝 Samui Wallet"
+  "indexPageTitle": "Bienvenido a 🏝 Samui Wallet",
+  "uiMnemonicUnexpectedLength": "Longitud mnemónica inesperada",
+  "uiMnemonicWords": "{{words}} palabras"
 }

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -4,13 +4,17 @@ interface Resources {
     generateCardDescription: "This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!"
     generateCardTitle: 'Generate Recovery Phrase'
     generateToastCopied: 'Mnemonic copied to clipboard'
+    generateToastCopy: 'Copy'
     importButtonSubmit: 'Import wallet'
     importCardDescription: 'Enter the seed phrase you stored when you created your wallet.'
     importCardTitle: 'Import Recovery Phrase'
+    importToastPaste: 'Paste'
     indexLinkGenerate: 'Create a new wallet'
     indexLinkImport: 'I already have a wallet'
     indexPageDescription: 'We hope you enjoy your stay!'
     indexPageTitle: 'Welcome to 🏝️ Samui Wallet'
+    uiMnemonicUnexpectedLength: 'Unexpected mnemonic length'
+    uiMnemonicWords: '{{words}} words'
   }
 }
 

--- a/packages/onboarding/src/onboarding-feature-generate.tsx
+++ b/packages/onboarding/src/onboarding-feature-generate.tsx
@@ -38,7 +38,11 @@ export function OnboardingFeatureGenerate() {
         description={t(($) => $.generateCardDescription)}
         footer={
           <div className="flex w-full justify-between">
-            <UiTextCopyButton text={mnemonic} toast={t(($) => $.generateToastCopied)} />
+            <UiTextCopyButton
+              label={t(($) => $.generateToastCopy)}
+              text={mnemonic}
+              toast={t(($) => $.generateToastCopied)}
+            />
             <OnboardingUiMnemonicSave
               disabled={!validateMnemonic({ mnemonic })}
               label={t(($) => $.generateButtonCreate)}

--- a/packages/onboarding/src/onboarding-feature-import.tsx
+++ b/packages/onboarding/src/onboarding-feature-import.tsx
@@ -82,7 +82,7 @@ export function OnboardingFeatureImport() {
         description={t(($) => $.importCardDescription)}
         footer={
           <div className="flex w-full justify-between">
-            <UiTextPasteButton onPaste={handlePaste} />
+            <UiTextPasteButton label={t(($) => $.importToastPaste)} onPaste={handlePaste} />
             <OnboardingUiMnemonicSave disabled={!isFormComplete} label={t(($) => $.importButtonSubmit)} />
           </div>
         }

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-select-strength.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-select-strength.tsx
@@ -1,5 +1,5 @@
+import { useTranslation } from '@workspace/i18n'
 import type { MnemonicStrength } from '@workspace/keypair/generate-mnemonic'
-
 import { ToggleGroup, ToggleGroupItem } from '@workspace/ui/components/toggle-group'
 
 export function OnboardingUiMnemonicSelectStrength({
@@ -9,6 +9,7 @@ export function OnboardingUiMnemonicSelectStrength({
   setStrength: (value: MnemonicStrength) => void
   strength: MnemonicStrength
 }) {
+  const { t } = useTranslation('onboarding')
   return (
     <ToggleGroup
       className="w-full"
@@ -19,7 +20,7 @@ export function OnboardingUiMnemonicSelectStrength({
     >
       {[128, 256].map((value) => (
         <ToggleGroupItem key={value} value={value.toString()}>
-          {value === 128 ? '12' : '24'} words
+          {t(($) => $.uiMnemonicWords, { words: value === 128 ? 12 : 24 })}
         </ToggleGroupItem>
       ))}
     </ToggleGroup>

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-show.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-show.tsx
@@ -1,16 +1,18 @@
+import { useTranslation } from '@workspace/i18n'
 import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { useMemo } from 'react'
 import { OnboardingUiMnemonicWordReadonly } from './onboarding-ui-mnemonic-word-readonly.tsx'
 
 export function OnboardingUiMnemonicShow({ mnemonic }: { mnemonic: string }) {
+  const { t } = useTranslation('onboarding')
   const expected = [12, 24]
   const words = useMemo(() => mnemonic.trim().split(/\s+/), [mnemonic])
   if (!expected.includes(words.length)) {
     return (
       <Alert variant="destructive">
         <UiIcon icon="alert" />
-        <AlertTitle>Unexpected mnemonic length</AlertTitle>
+        <AlertTitle>{t(($) => $.uiMnemonicUnexpectedLength)}</AlertTitle>
         <AlertDescription>
           Mnemonic has {words.length} words, expected {expected.join(' or ')}
         </AlertDescription>

--- a/packages/ui/src/components/ui-text-copy-button.tsx
+++ b/packages/ui/src/components/ui-text-copy-button.tsx
@@ -4,7 +4,7 @@ import { handleCopyText } from '../lib/handle-copy-text.ts'
 import { toastSuccess } from '../lib/toast-success.ts'
 import { Button } from './button.tsx'
 
-export function UiTextCopyButton({ text, toast = 'Copied to clipboard' }: { text: string; toast?: string }) {
+export function UiTextCopyButton({ label, text, toast }: { label: string; text: string; toast: string }) {
   return (
     <Button
       onClick={() => {
@@ -17,7 +17,7 @@ export function UiTextCopyButton({ text, toast = 'Copied to clipboard' }: { text
       variant="secondary"
     >
       <LucideCopy />
-      Copy
+      {label}
     </Button>
   )
 }

--- a/packages/ui/src/components/ui-text-paste-button.tsx
+++ b/packages/ui/src/components/ui-text-paste-button.tsx
@@ -3,7 +3,7 @@ import { LucideCopy } from 'lucide-react'
 import { handleTextPaste } from '../lib/handle-text-paste.ts'
 import { Button } from './button.tsx'
 
-export function UiTextPasteButton({ onPaste }: { onPaste: (text: string) => void }) {
+export function UiTextPasteButton({ label, onPaste }: { label: string; onPaste: (text: string) => void }) {
   return (
     <Button
       onClick={async () => {
@@ -16,7 +16,7 @@ export function UiTextPasteButton({ onPaste }: { onPaste: (text: string) => void
       variant="secondary"
     >
       <LucideCopy />
-      Paste
+      {label}
     </Button>
   )
 }


### PR DESCRIPTION
Part of #310 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add i18n support for onboarding UI, updating translation files and components for copy/paste buttons and mnemonic handling.
> 
>   - **i18n Support**:
>     - Add translations for onboarding UI in `locales/en/onboarding.json` and `locales/es/onboarding.json`.
>     - Update `resources.d.ts` to include new translation keys.
>   - **Component Updates**:
>     - Modify `UiTextCopyButton` and `UiTextPasteButton` to accept `label` prop for i18n support.
>     - Update `onboarding-feature-generate.tsx` and `onboarding-feature-import.tsx` to use translated labels for copy and paste buttons.
>     - Use `useTranslation` in `onboarding-ui-mnemonic-select-strength.tsx` and `onboarding-ui-mnemonic-show.tsx` for dynamic text.
>   - **Config Changes**:
>     - Update `i18next.config.ts` to ignore additional attributes for translation extraction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for a5213e76b2de23b47aa4a3a4e8fc425746763c80. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->