### PR TITLE
fix(explorer): consistent content container

### DIFF
--- a/packages/explorer/src/ui/explorer-ui-page.tsx
+++ b/packages/explorer/src/ui/explorer-ui-page.tsx
@@ -2,5 +2,5 @@ import { UiContainer } from '@workspace/ui/components/ui-container'
 import type { ReactNode } from 'react'
 
 export function ExplorerUiPage({ children }: { children: ReactNode }) {
-  return <UiContainer className="py-2 sm:py-4 md:py-6 lg:py-8">{children}</UiContainer>
+  return <UiContainer className="py-2 sm:py-4 md:py-6 lg:py-8 sm:max-w-3xl">{children}</UiContainer>
 }


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

Restrict explorer container growth on wider viewports

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `sm:max-w-3xl` to `UiContainer` in `explorer-ui-page.tsx` to restrict container width on small viewports.
> 
>   - **UI Update**:
>     - In `explorer-ui-page.tsx`, added `sm:max-w-3xl` to `UiContainer` to restrict container width on small viewports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 641e5baf07f3a10838e56a641553b7f3ae3be7f9. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->