### PR TITLE
fix: sync word count

### DIFF
--- a/packages/onboarding/src/onboarding-feature-import.tsx
+++ b/packages/onboarding/src/onboarding-feature-import.tsx
@@ -17,7 +17,7 @@ export function OnboardingFeatureImport() {
   const create = useCreateNewWallet()
   const [strength, setStrength] = useState<MnemonicStrength>(128)
 
-  const [wordCount, setWordCount] = useState(12)
+  const wordCount = strength === 128 ? 12 : 24
   const [words, setWords] = useState(Array(24).fill(''))
   const [error, setError] = useState('')
 
@@ -33,7 +33,6 @@ export function OnboardingFeatureImport() {
 
     const len = getMnemonicStrength(pastedWords.length)
     if (len !== false) {
-      setWordCount(pastedWords.length)
       setStrength(len)
       const newWords = Array(24).fill('')
       pastedWords.forEach((word, i) => {


### PR DESCRIPTION

## Description
Closes #427

Fixes the bug where clicking the "24 words" button in the onboarding import screen had no effect.

## Solution

`  const wordCount = strength === 128 ? 12 : 24`

I Removed the `setWordCount()` call in `handlePaste()` too since it's not state anymore.

## Why I Made This Change

Just derive it directly. It's a one-line ternary , i thought there is  no need to overcomplicate things. `useEffect` would add an extra render cycle and `useMemo` is expensive  for something this stuff. If there is any issue, please, let me know.


## Screenshots / Video

<img width="537" height="486" alt="image" src="https://github.com/user-attachments/assets/e377d536-1c66-4196-82e1-c0cf5f0de903" />

<img width="512" height="653" alt="image" src="https://github.com/user-attachments/assets/88d87903-b43a-4f06-b0a3-566e33505735" />





<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in onboarding import screen by deriving `wordCount` from `strength` and removing unnecessary state management.
> 
>   - **Behavior**:
>     - Fixes bug where "24 words" button in onboarding import screen had no effect.
>     - `wordCount` is now derived directly from `strength` using a ternary operator.
>     - Removes `setWordCount()` call in `handlePaste()`.
>   - **Code Changes**:
>     - Updates `wordCount` logic in `OnboardingFeatureImport` to use `strength === 128 ? 12 : 24`.
>     - Removes `setWordCount()` from `handlePaste()` in `onboarding-feature-import.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 57ebf9d3513f216257aef7da081f4dea92afb126. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->