### PR TITLE
fix(tools): make tools borders similar sized to settings

### DIFF
--- a/packages/tools/src/ui/tools-ui-overview-item.tsx
+++ b/packages/tools/src/ui/tools-ui-overview-item.tsx
@@ -9,9 +9,12 @@ export function ToolsUiOverviewItem({ tool }: { tool: Tool }) {
   return (
     <Item
       asChild
-      className={cn({
-        'text-muted-foreground': tool.comingSoon,
-      })}
+      className={
+        'rounded-xl ' +
+        cn({
+          'text-muted-foreground': tool.comingSoon,
+        })
+      }
       key={tool.path}
       size="sm"
       variant="outline"


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

Keep tools items' borders consistent with settings borders


## Screenshots/videos

**Before**

https://github.com/user-attachments/assets/e852f417-70c8-469e-9760-09a8f81746ef

**After**

https://github.com/user-attachments/assets/16dbde31-dc99-4444-962c-7202040cd037
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `rounded-xl` class to `Item` in `tools-ui-overview-item.tsx` for consistent tool borders.
> 
>   - **UI Update**:
>     - Adds `rounded-xl` class to `Item` in `tools-ui-overview-item.tsx` to make tool borders consistent with settings borders.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 93e849ad716064a558916a61204f1d3279bde33c. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->