### PR TITLE
fix(explorer): remove redundant explorer ui page component

### DIFF
--- a/packages/explorer/src/explorer-feature-account.tsx
+++ b/packages/explorer/src/explorer-feature-account.tsx
@@ -1,11 +1,11 @@
 import { assertIsAddress } from '@solana/kit'
 import type { Network } from '@workspace/db/entity/network'
 import { solanaAddressSchema } from '@workspace/db/schema/solana-address-schema'
+import { UiPage } from '@workspace/ui/components/ui-page'
 import { useParams } from 'react-router'
 import { ExplorerFeatureAccountOverview } from './explorer-feature-account-overview.tsx'
 import { ExplorerFeatureAccountTransactions } from './explorer-feature-account-transactions.tsx'
 import { ExplorerUiErrorPage } from './ui/explorer-ui-error-page.tsx'
-import { ExplorerUiPage } from './ui/explorer-ui-page.tsx'
 
 export function ExplorerFeatureAccount({ basePath, network }: { basePath: string; network: Network }) {
   const { address } = useParams()
@@ -15,11 +15,11 @@ export function ExplorerFeatureAccount({ basePath, network }: { basePath: string
   assertIsAddress(address)
 
   return (
-    <ExplorerUiPage>
+    <UiPage>
       <div className="space-y-2 sm:space-y-4 md:space-y-6">
         <ExplorerFeatureAccountOverview address={address} network={network} />
         <ExplorerFeatureAccountTransactions address={address} basePath={basePath} network={network} />
       </div>
-    </ExplorerUiPage>
+    </UiPage>
   )
 }

--- a/packages/explorer/src/explorer-feature-index.tsx
+++ b/packages/explorer/src/explorer-feature-index.tsx
@@ -1,12 +1,12 @@
 import { UiEmpty } from '@workspace/ui/components/ui-empty'
+import { UiPage } from '@workspace/ui/components/ui-page'
 import { useNavigate } from 'react-router'
-import { ExplorerUiPage } from './ui/explorer-ui-page.tsx'
 import { ExplorerUiSearch } from './ui/explorer-ui-search.tsx'
 
 export function ExplorerFeatureIndex({ basePath }: { basePath: string }) {
   const navigate = useNavigate()
   return (
-    <ExplorerUiPage>
+    <UiPage>
       <UiEmpty description="Search and explore accounts or transactions" icon="explorer" title="Explorer">
         <div className="w-full">
           <ExplorerUiSearch
@@ -16,6 +16,6 @@ export function ExplorerFeatureIndex({ basePath }: { basePath: string }) {
           />
         </div>
       </UiEmpty>
-    </ExplorerUiPage>
+    </UiPage>
   )
 }

--- a/packages/explorer/src/explorer-feature-tx.tsx
+++ b/packages/explorer/src/explorer-feature-tx.tsx
@@ -1,8 +1,8 @@
 import { solanaSignatureSchema } from '@workspace/db/schema/solana-signature-schema'
 import { UiEmpty } from '@workspace/ui/components/ui-empty'
+import { UiPage } from '@workspace/ui/components/ui-page'
 import { useParams } from 'react-router'
 import { ExplorerUiErrorPage } from './ui/explorer-ui-error-page.tsx'
-import { ExplorerUiPage } from './ui/explorer-ui-page.tsx'
 
 export function ExplorerFeatureTx() {
   const { signature } = useParams() as { signature: string }
@@ -16,11 +16,11 @@ export function ExplorerFeatureTx() {
   }
 
   return (
-    <ExplorerUiPage>
+    <UiPage>
       <UiEmpty description="Placeholder for the Explorer Transaction page" icon="explorer" title="Explorer Transaction">
         <pre>Signature</pre>
         <pre className="max-w-full truncate">{signature}</pre>
       </UiEmpty>
-    </ExplorerUiPage>
+    </UiPage>
   )
 }

--- a/packages/explorer/src/explorer-routes.tsx
+++ b/packages/explorer/src/explorer-routes.tsx
@@ -2,13 +2,13 @@ import type { Network } from '@workspace/db/entity/network'
 import { useDbNetworkLive } from '@workspace/db-react/use-db-network-live'
 import { useDbSetting } from '@workspace/db-react/use-db-setting'
 import { UiNotFound } from '@workspace/ui/components/ui-not-found'
+import { UiPage } from '@workspace/ui/components/ui-page'
 import { useMemo } from 'react'
 import { useRoutes } from 'react-router'
 import { ExplorerFeatureAccount } from './explorer-feature-account.tsx'
 import { ExplorerFeatureAccountRedirect } from './explorer-feature-account-redirect.tsx'
 import { ExplorerFeatureIndex } from './explorer-feature-index.tsx'
 import { ExplorerFeatureTx } from './explorer-feature-tx.tsx'
-import { ExplorerUiPage } from './ui/explorer-ui-page.tsx'
 
 export default function ExplorerRoutes({ basePath }: { basePath: string }) {
   const networkLive = useDbNetworkLive()
@@ -27,9 +27,9 @@ export function Routes({ basePath, network }: { basePath: string; network: Netwo
     { element: <ExplorerFeatureAccountRedirect basePath={basePath} />, path: 'account/:address' },
     {
       element: (
-        <ExplorerUiPage>
+        <UiPage>
           <UiNotFound />
-        </ExplorerUiPage>
+        </UiPage>
       ),
       path: '*',
     },

--- a/packages/explorer/src/ui/explorer-ui-error-page.tsx
+++ b/packages/explorer/src/ui/explorer-ui-error-page.tsx
@@ -1,10 +1,10 @@
 import { UiError } from '@workspace/ui/components/ui-error'
-import { ExplorerUiPage } from './explorer-ui-page.tsx'
+import { UiPage } from '@workspace/ui/components/ui-page'
 
 export function ExplorerUiErrorPage({ message, title }: { message: string; title: string }) {
   return (
-    <ExplorerUiPage>
+    <UiPage>
       <UiError icon="explorer" message={new Error(message)} title={title} />
-    </ExplorerUiPage>
+    </UiPage>
   )
 }

--- a/packages/explorer/src/ui/explorer-ui-page.tsx
+++ b/packages/explorer/src/ui/explorer-ui-page.tsx
@@ -1,6 +1,0 @@
-import { UiPage } from '@workspace/ui/components/ui-page'
-import type { ReactNode } from 'react'
-
-export function ExplorerUiPage({ children }: { children: ReactNode }) {
-  return <UiPage>{children}</UiPage>
-}


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

`ExplorerFeatureIndex` gets `ExplorerUiPage`, which is just `UiPage`. We use `UiPage` directly instead. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant `ExplorerUiPage` component and use `UiPage` directly in `ExplorerFeatureIndex`.
> 
>   - **Behavior**:
>     - `ExplorerFeatureIndex` now uses `UiPage` directly instead of `ExplorerUiPage`.
>   - **Code Simplification**:
>     - Removed `ExplorerUiPage` component, which was a redundant wrapper around `UiPage`.
>     - Deleted `explorer-ui-page.tsx` file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c33b3b3d3682b9e1f5660758f2e6a62922b6e47d. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->