### PR TITLE
fix: make provider required in getExplorerUrl function

### DIFF
--- a/packages/explorer/src/ui/explorer-ui-explorer-link.tsx
+++ b/packages/explorer/src/ui/explorer-ui-explorer-link.tsx
@@ -1,23 +1,16 @@
-import {
-  type ExplorerProvider,
-  type GetExplorerUrlProps,
-  getExplorerName,
-  getExplorerUrl,
-} from '@workspace/solana-client/get-explorer-url'
+import { type GetExplorerUrlProps, getExplorerName, getExplorerUrl } from '@workspace/solana-client/get-explorer-url'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
 import { cn } from '@workspace/ui/lib/utils'
 
 export function ExplorerUiExplorerLink({
   className,
-  provider,
   ...props
 }: {
   className?: string
-  provider: ExplorerProvider
 } & GetExplorerUrlProps) {
   const href = getExplorerUrl(props)
-  const name = getExplorerName(provider)
+  const name = getExplorerName(props.provider)
   return (
     <UiTooltip content={`View in ${name}`}>
       <a

--- a/packages/explorer/src/ui/explorer-ui-tx-explorer-icon.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-explorer-icon.tsx
@@ -3,5 +3,5 @@ import type { Network } from '@workspace/db/entity/network'
 import { ExplorerUiExplorerIcon } from './explorer-ui-explorer-icon.tsx'
 
 export function ExplorerUiTxExplorerIcon({ network, signature }: { network: Network; signature: string }) {
-  return <ExplorerUiExplorerIcon network={network} path={`/tx/${signature}`} />
+  return <ExplorerUiExplorerIcon network={network} path={`/tx/${signature}`} provider="solana" />
 }

--- a/packages/portfolio/src/ui/portfolio-ui-tokens.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-tokens.tsx
@@ -28,6 +28,7 @@ export function WalletUiTokens({ network, items }: { network: Network; items: Ge
                     label={ellipsify(pubkey.toString())}
                     network={network}
                     path={`/address/${pubkey.toString()}`}
+                    provider="solana"
                   />
                 </span>
               </div>
@@ -39,6 +40,7 @@ export function WalletUiTokens({ network, items }: { network: Network; items: Ge
                     label={ellipsify(account.data.parsed.info.mint)}
                     network={network}
                     path={`/address/${account.data.parsed.info.mint.toString()}`}
+                    provider="solana"
                   />
                 </span>
               </div>

--- a/packages/portfolio/src/ui/portfolio-ui-tx-explorer-icon.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-tx-explorer-icon.tsx
@@ -3,5 +3,5 @@ import type { Network } from '@workspace/db/entity/network'
 import { PortfolioUiExplorerIcon } from './portfolio-ui-explorer-icon.tsx'
 
 export function PortfolioUiTxExplorerIcon({ network, signature }: { network: Network; signature: string }) {
-  return <PortfolioUiExplorerIcon network={network} path={`/tx/${signature}`} />
+  return <PortfolioUiExplorerIcon network={network} path={`/tx/${signature}`} provider="solana" />
 }

--- a/packages/solana-client/src/get-explorer-url.ts
+++ b/packages/solana-client/src/get-explorer-url.ts
@@ -12,10 +12,10 @@ export interface GetNetworkSuffixProps {
 export interface GetExplorerUrlProps {
   network: GetNetworkSuffixProps
   path: ExplorerPath
-  provider?: ExplorerProvider
+  provider: ExplorerProvider
 }
 
-export function getExplorerUrl({ network, path, provider = 'solana' }: GetExplorerUrlProps) {
+export function getExplorerUrl({ network, path, provider }: GetExplorerUrlProps) {
   if (!(path.startsWith('/address') || path.startsWith('/block') || path.startsWith('/tx'))) {
     throw new Error('Invalid path. Must be /address, /block, or /tx.')
   }
@@ -34,7 +34,7 @@ export function getExplorerUrl({ network, path, provider = 'solana' }: GetExplor
   return url.toString()
 }
 
-function getExplorerBaseUrl(provider: ExplorerProvider = 'solana') {
+function getExplorerBaseUrl(provider: ExplorerProvider) {
   switch (provider) {
     case 'orb':
       return 'https://orb.helius.dev'

--- a/packages/solana-client/test/get-explorer-url.test.ts
+++ b/packages/solana-client/test/get-explorer-url.test.ts
@@ -15,6 +15,7 @@ describe('get-explorer-url', () => {
         const props: GetExplorerUrlProps = {
           network: { endpoint: 'https://api.devnet.solana.com', type: 'solana:devnet' },
           path: `/address/${address}`,
+          provider: 'solana',
         }
         const expected = `https://explorer.solana.com/address/${address}?cluster=devnet`
 
@@ -34,6 +35,7 @@ describe('get-explorer-url', () => {
             type: 'solana:mainnet',
           },
           path: `/tx/${signature}`,
+          provider: 'solana',
         }
         const expected = `https://explorer.solana.com/tx/${signature}`
 
@@ -54,6 +56,7 @@ describe('get-explorer-url', () => {
             type: 'solana:localnet',
           },
           path: `/block/${block}`,
+          provider: 'solana',
         }
         const expected = `https://explorer.solana.com/block/${block}?cluster=custom&customUrl=${encodeURIComponent(endpoint)}`
 

--- a/packages/tools/src/tools-feature-airdrop.tsx
+++ b/packages/tools/src/tools-feature-airdrop.tsx
@@ -19,7 +19,12 @@ export default function ToolsFeatureAirdrop(props: { account: Account; network: 
         submit={async (input) => {
           const signature = await mutateAsync({ ...input, address: address(input.address) })
           toastSuccess(
-            <PortfolioUiExplorerLink label="View on explorer" network={props.network} path={`/tx/${signature}`} />,
+            <PortfolioUiExplorerLink
+              label="View on explorer"
+              network={props.network}
+              path={`/tx/${signature}`}
+              provider="solana"
+            />,
           )
         }}
       />

--- a/packages/tools/src/tools-feature-create-token.tsx
+++ b/packages/tools/src/tools-feature-create-token.tsx
@@ -47,10 +47,10 @@ export default function ToolsFeatureCreateToken(props: { account: Account; netwo
     if (res.supply) {
       setResultSupply(res.supply)
     }
-    console.log('Mint', getExplorerUrl({ network: props.network, path: `/address/${res.mint}` }))
-    console.log('TX', getExplorerUrl({ network: props.network, path: `/tx/${res.signature}` }))
+    console.log('Mint', getExplorerUrl({ network: props.network, path: `/address/${res.mint}`, provider: 'solana' }))
+    console.log('TX', getExplorerUrl({ network: props.network, path: `/tx/${res.signature}`, provider: 'solana' }))
     if (res.supply) {
-      console.log('Supply', getExplorerUrl({ network: props.network, path: `/tx/${res.supply}` }))
+      console.log('Supply', getExplorerUrl({ network: props.network, path: `/tx/${res.supply}`, provider: 'solana' }))
     }
   }, [mutation, props.network, queryKeypair, decimals, supply])
 
@@ -60,10 +60,20 @@ export default function ToolsFeatureCreateToken(props: { account: Account; netwo
         <div className="flex flex-col gap-6">
           <div>Token created!</div>
           <div>
-            <PortfolioUiExplorerButton label="View Mint" network={props.network} path={`/address/${resultMint}`} />
+            <PortfolioUiExplorerButton
+              label="View Mint"
+              network={props.network}
+              path={`/address/${resultMint}`}
+              provider="solana"
+            />
           </div>
           <div>
-            <PortfolioUiExplorerButton label="View Mint Transaction" network={props.network} path={`/tx/${resultTx}`} />
+            <PortfolioUiExplorerButton
+              label="View Mint Transaction"
+              network={props.network}
+              path={`/tx/${resultTx}`}
+              provider="solana"
+            />
           </div>
           {resultSupply ? (
             <div>
@@ -71,6 +81,7 @@ export default function ToolsFeatureCreateToken(props: { account: Account; netwo
                 label="View Supply Transaction"
                 network={props.network}
                 path={`/tx/${resultSupply}`}
+                provider="solana"
               />
             </div>
           ) : null}


### PR DESCRIPTION
This property was option which made it hard to use and debug an issue while building out #439.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `provider` required in `getExplorerUrl` and update components to explicitly pass `provider`.
> 
>   - **Behavior**:
>     - `provider` is now required in `getExplorerUrl` in `get-explorer-url.ts`, removing default value 'solana'.
>     - Updates `getExplorerBaseUrl` to require `provider`.
>     - Updates `getExplorerUrl` tests in `get-explorer-url.test.ts` to include `provider`.
>   - **Components**:
>     - `ExplorerUiExplorerLink` in `explorer-ui-explorer-link.tsx` now uses `props.provider`.
>     - `ExplorerUiTxExplorerIcon` in `explorer-ui-tx-explorer-icon.tsx` sets `provider` to 'solana'.
>     - `WalletUiTokens` in `portfolio-ui-tokens.tsx` sets `provider` to 'solana'.
>     - `PortfolioUiTxExplorerIcon` in `portfolio-ui-tx-explorer-icon.tsx` sets `provider` to 'solana'.
>     - `ToolsFeatureAirdrop` in `tools-feature-airdrop.tsx` sets `provider` to 'solana'.
>     - `ToolsFeatureCreateToken` in `tools-feature-create-token.tsx` sets `provider` to 'solana'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 731cf9e0055d25280e0c41f6c3b60e26ba9f2fa8. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->