### PR TITLE
feat: move application reset to a separate route

### DIFF
--- a/packages/settings/src/settings-feature-general-danger-delete-database.tsx
+++ b/packages/settings/src/settings-feature-general-danger-delete-database.tsx
@@ -1,28 +1,39 @@
 import { useDbReset } from '@workspace/db-react/use-db-reset'
 import { Button } from '@workspace/ui/components/button'
+import { Checkbox } from '@workspace/ui/components/checkbox'
 import { Label } from '@workspace/ui/components/label'
+import { useId, useState } from 'react'
 
 export function SettingsFeatureGeneralDangerDeleteDatabase() {
   const mutation = useDbReset()
+  const [accept, setAccept] = useState(false)
+  const acceptId = useId()
   return (
-    <div className="flex items-center justify-between space-x-2">
-      <Label>Delete the database</Label>
-      <Button
-        onClick={async () => {
-          if (!window.confirm('Are you sure? This action can not be reversed.')) {
-            return
-          }
-          if (!window.confirm('Any mnemonic stored in the database will be lost. Do you want to continue?')) {
-            return
-          }
-          await mutation.mutateAsync()
-
-          window.location.replace('/')
-        }}
-        variant="destructive"
-      >
-        Delete Database
-      </Button>
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <Checkbox checked={accept} id={acceptId} onCheckedChange={() => setAccept((prev) => !prev)} />
+        <div className="grid gap-2">
+          <Label htmlFor={acceptId}>Accept deletion of the database.</Label>
+          <p className="text-muted-foreground text-sm">
+            By clicking this checkbox, you accept that all data will be lost.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center justify-end space-x-2">
+        <Button
+          disabled={!accept}
+          onClick={async () => {
+            if (!window.confirm('Are you sure? This action can not be reversed.')) {
+              return
+            }
+            await mutation.mutateAsync()
+            window.location.replace('/')
+          }}
+          variant="destructive"
+        >
+          Delete Database
+        </Button>
+      </div>
     </div>
   )
 }

--- a/packages/settings/src/settings-feature-general.tsx
+++ b/packages/settings/src/settings-feature-general.tsx
@@ -1,21 +1,25 @@
+import { Button } from '@workspace/ui/components/button'
 import { UiCard } from '@workspace/ui/components/ui-card'
-
+import { Link } from 'react-router'
 import { useSettingsPage } from './data-access/use-settings-page.tsx'
 import { SettingsFeatureGeneralApiEndpoint } from './settings-feature-general-api-endpoint.tsx'
-import { SettingsFeatureGeneralDangerDeleteDatabase } from './settings-feature-general-danger-delete-database.tsx'
 import { SettingsFeatureGeneralDeveloperModeEnable } from './settings-feature-general-developer-mode-enable.tsx'
 import { SettingsFeatureGeneralWarningAcceptExperimental } from './settings-feature-general-warning-accept-experimental.tsx'
 
 export function SettingsFeatureGeneral() {
   const page = useSettingsPage({ pageId: 'general' })
   return (
-    <UiCard contentProps={{ className: 'grid gap-6' }} description={page.description} title={page.name}>
-      <SettingsFeatureGeneralApiEndpoint />
-      <SettingsFeatureGeneralWarningAcceptExperimental />
-      <SettingsFeatureGeneralDeveloperModeEnable />
-      <div className="border border-red-500 rounded-md p-4">
-        <SettingsFeatureGeneralDangerDeleteDatabase />
-      </div>
-    </UiCard>
+    <div className="space-y-6">
+      <UiCard contentProps={{ className: 'grid gap-6' }} description={page.description} title={page.name}>
+        <SettingsFeatureGeneralApiEndpoint />
+        <SettingsFeatureGeneralWarningAcceptExperimental />
+        <SettingsFeatureGeneralDeveloperModeEnable />
+      </UiCard>
+      <UiCard className="border-red-500" contentProps={{ className: 'grid gap-6' }} title="Danger zone">
+        <Button asChild variant="destructive">
+          <Link to="/reset">Reset application</Link>
+        </Button>
+      </UiCard>
+    </div>
   )
 }

--- a/packages/settings/src/settings-feature-reset.tsx
+++ b/packages/settings/src/settings-feature-reset.tsx
@@ -1,0 +1,20 @@
+import { UiCard } from '@workspace/ui/components/ui-card'
+import { UiPage } from '@workspace/ui/components/ui-page'
+import { SettingsFeatureGeneralDangerDeleteDatabase } from './settings-feature-general-danger-delete-database.tsx'
+
+export default function SettingsFeatureReset() {
+  return (
+    <UiPage>
+      <UiCard
+        contentProps={{ className: 'space-y-6' }}
+        description="Make sure that you have a copy of the data."
+        title="Reset application database"
+      >
+        <div className="text-red-500 font-bold text-center border border-red-500 py-4 rounded-md">
+          THIS ACTION CAN NOT BE REVERSED
+        </div>
+        <SettingsFeatureGeneralDangerDeleteDatabase />
+      </UiCard>
+    </UiPage>
+  )
+}

--- a/packages/shell/src/shell-routes.tsx
+++ b/packages/shell/src/shell-routes.tsx
@@ -10,6 +10,7 @@ const ExplorerRoutes = lazy(() => import('@workspace/explorer/explorer-routes'))
 const OnboardingRoutes = lazy(() => import('@workspace/onboarding/onboarding-routes'))
 const PortfolioRoutes = lazy(() => import('@workspace/portfolio/portfolio-routes'))
 const ToolsRoutes = lazy(() => import('@workspace/tools/tools-routes'))
+const SettingsFeatureReset = lazy(() => import('@workspace/settings/settings-feature-reset'))
 const SettingsRoutes = lazy(() => import('@workspace/settings/settings-routes'))
 
 const links: ShellLayoutLink[] = [
@@ -38,6 +39,7 @@ const router = createHashRouter([
     element: <ShellUiLayout links={links} />,
   },
   { element: <OnboardingRoutes />, path: 'onboarding/*' },
+  { element: <SettingsFeatureReset />, path: 'reset' },
 ])
 
 export function ShellRoutes() {

--- a/packages/ui/src/components/ui-card.tsx
+++ b/packages/ui/src/components/ui-card.tsx
@@ -8,7 +8,6 @@ export function UiCard({
   action,
   actionProps,
   backButtonTo,
-  cardProps,
   children,
   contentProps,
   description,
@@ -18,6 +17,7 @@ export function UiCard({
   headerProps,
   title,
   titleProps,
+  ...cardProps
 }: {
   action?: ReactNode
   actionProps?: Omit<ComponentProps<typeof CardAction>, 'children'>
@@ -32,7 +32,7 @@ export function UiCard({
   headerProps?: Omit<ComponentProps<typeof CardHeader>, 'children'>
   title?: ReactNode
   titleProps?: Omit<ComponentProps<typeof CardTitle>, 'children'>
-}) {
+} & Omit<ComponentProps<typeof Card>, 'children' | 'title'>) {
   return (
     <Card {...cardProps}>
       {action || description || title ? (


### PR DESCRIPTION
Open for suggestions when it comes to the language in these screens.

![samui-wallet-reset-app-2025-11-16](https://github.com/user-attachments/assets/a21ff742-0c81-4e9c-9e57-0a83a2efb60d)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move application reset functionality to a new route with updated UI components for user confirmation.
> 
>   - **Behavior**:
>     - Move database reset functionality to a new route `/reset` in `shell-routes.tsx`.
>     - Add `SettingsFeatureReset` component in `settings-feature-reset.tsx` for the reset page.
>     - Update `SettingsFeatureGeneral` in `settings-feature-general.tsx` to link to the new reset route.
>   - **UI Components**:
>     - Add `Checkbox` for user confirmation in `SettingsFeatureGeneralDangerDeleteDatabase`.
>     - Disable "Delete Database" button until checkbox is checked in `settings-feature-general-danger-delete-database.tsx`.
>   - **Misc**:
>     - Remove `cardProps` prop from `UiCard` in `ui-card.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for edc006fe6803f885607c53d94f7753a465a7ccbb. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->