### PR TITLE
fix(portfolio-send): add horizontal padding all screen sizes

### DIFF
--- a/packages/portfolio/src/ui/portfolio-ui-account-form-send.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-account-form-send.tsx
@@ -28,7 +28,7 @@ export function PortfolioUiAccountFormSend({
   }, [balances, mintAddress])
 
   return (
-    <div className="w-full max-w-md md:px-4">
+    <div className="w-full max-w-md px-4">
       <form>
         <FieldGroup>
           <FieldSet>


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

Include padding to `PortfolioUiAccountFormSend` regardless of screen size.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds horizontal padding to `PortfolioUiAccountFormSend` for all screen sizes.
> 
>   - **UI Update**:
>     - Adds horizontal padding (`px-4`) to `PortfolioUiAccountFormSend` for all screen sizes in `portfolio-ui-account-form-send.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 79561e1ecf7c16a3fbd88443a262804c0a25970d. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->