### PR TITLE
feat: add option to export wallet/account secrets

### DIFF
--- a/packages/settings/src/ui/account-ui-export-secret-button.tsx
+++ b/packages/settings/src/ui/account-ui-export-secret-button.tsx
@@ -1,0 +1,43 @@
+import type { Account } from '@workspace/db/entity/account'
+import { Button } from '@workspace/ui/components/button'
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
+import { handleCopyText } from '@workspace/ui/lib/handle-copy-text'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+
+export function AccountExportSecretButton({ account }: { account: Account }) {
+  if (!account.secretKey) {
+    return (
+      <UiTooltip content="Secret key is not available for this account">
+        <Button disabled size="icon" type="button" variant="outline">
+          <UiIcon className="size-4" icon="key" />
+        </Button>
+      </UiTooltip>
+    )
+  }
+
+  async function exportSecret() {
+    const confirmed = window.confirm(
+      'Exporting the secret key reveals sensitive information. Do you want to copy it to your clipboard?',
+    )
+    if (!confirmed) {
+      return
+    }
+    try {
+      await handleCopyText(account.secretKey as string)
+      toastSuccess('Secret key copied to clipboard')
+    } catch {
+      window.prompt('Copy your secret key from this dialog:', account.secretKey)
+      toastError('Clipboard copy blocked. Secret key shown for manual copy.')
+    }
+  }
+
+  return (
+    <UiTooltip content="Copy secret key to clipboard">
+      <Button onClick={exportSecret} size="icon" type="button" variant="outline">
+        <UiIcon className="size-4" icon="key" />
+      </Button>
+    </UiTooltip>
+  )
+}

--- a/packages/settings/src/ui/settings-ui-account-table.tsx
+++ b/packages/settings/src/ui/settings-ui-account-table.tsx
@@ -1,9 +1,8 @@
 import type { Account } from '@workspace/db/entity/account'
-
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
 import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
-
+import { AccountExportSecretButton } from './account-ui-export-secret-button.tsx'
 import { AccountUiItem } from './account-ui-item.tsx'
 
 export function SettingsUiAccountTable({ items }: { items: Account[] }) {
@@ -14,6 +13,7 @@ export function SettingsUiAccountTable({ items }: { items: Account[] }) {
           <TableHead className="w-[50px]">Name</TableHead>
           <TableHead>Public Key</TableHead>
           <TableHead className="w-[50px]">Type</TableHead>
+          <TableHead className="w-[120px] text-right">Actions</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -29,6 +29,9 @@ export function SettingsUiAccountTable({ items }: { items: Account[] }) {
               </span>
             </TableCell>
             <TableCell className="font-mono text-xs">{item.type}</TableCell>
+            <TableCell className="text-right">
+              <AccountExportSecretButton account={item} />
+            </TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/packages/settings/src/ui/settings-ui-wallet-export-mnemonic-button.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-export-mnemonic-button.tsx
@@ -1,0 +1,38 @@
+import type { Wallet } from '@workspace/db/entity/wallet'
+
+import { Button } from '@workspace/ui/components/button'
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
+import { handleCopyText } from '@workspace/ui/lib/handle-copy-text'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import type { MouseEvent } from 'react'
+
+export function SettingsUiWalletExportMnemonicButton({ wallet }: { wallet: Wallet }) {
+  async function exportMnemonic(event: MouseEvent<HTMLButtonElement>) {
+    event.preventDefault()
+    const confirmed = window.confirm(
+      'Exporting the mnemonic reveals sensitive information. Do you want to copy it to your clipboard?',
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    try {
+      await handleCopyText(wallet.mnemonic)
+      toastSuccess('Mnemonic copied to clipboard')
+    } catch {
+      window.prompt('Copy your mnemonic from this dialog:', wallet.mnemonic)
+      toastError('Clipboard copy blocked. Mnemonic shown for manual copy.')
+    }
+  }
+
+  return (
+    <UiTooltip content="Export mnemonic">
+      <Button onClick={exportMnemonic} size="icon" type="button" variant="outline">
+        <UiIcon className="size-4" icon="mnemonic" />
+      </Button>
+    </UiTooltip>
+  )
+}

--- a/packages/settings/src/ui/settings-ui-wallet-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-list-item.tsx
@@ -5,6 +5,7 @@ import { Item, ItemActions, ItemContent, ItemTitle } from '@workspace/ui/compone
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiTooltip } from '@workspace/ui/components/ui-tooltip'
 import { Link } from 'react-router'
+import { SettingsUiWalletExportMnemonicButton } from './settings-ui-wallet-export-mnemonic-button.tsx'
 import { SettingsUiWalletItem } from './settings-ui-wallet-item.tsx'
 
 export function SettingsUiWalletListItem({
@@ -26,6 +27,7 @@ export function SettingsUiWalletListItem({
         </ItemTitle>
       </ItemContent>
       <ItemActions>
+        <SettingsUiWalletExportMnemonicButton wallet={item} />
         <UiTooltip content="Edit wallet">
           <Button asChild size="icon" variant="outline">
             <Link to={`./${item.id}/edit`}>

--- a/packages/ui/src/components/ui-icon-map.tsx
+++ b/packages/ui/src/components/ui-icon-map.tsx
@@ -20,6 +20,7 @@ import {
   LucideHardDrive,
   LucideImage,
   LucideImport,
+  LucideKeyRound,
   LucideLetterText,
   LucideNetwork,
   LucideNotepadText,
@@ -67,6 +68,7 @@ export type UiIconName =
   | 'hardware'
   | 'image'
   | 'import'
+  | 'key'
   | 'mnemonic'
   | 'network'
   | 'portfolio'
@@ -105,6 +107,7 @@ const uiIconMap = new Map<UiIconName, UiIconLucide>()
   .set('hardware', LucideHardDrive)
   .set('image', LucideImage)
   .set('import', LucideImport)
+  .set('key', LucideKeyRound)
   .set('mnemonic', LucideNotepadText)
   .set('network', LucideNetwork)
   .set('portfolio', LucidePieChart)


### PR DESCRIPTION
Closes #377 

**Implementation**

- Introduce copySensitiveText helper that returns a boolean so UI knows when clipboard write fails
- Reuse it in both wallet list + account table actions to gate toasts/fallback prompts
- Add new account/wallet actions column + export (copy) button
- The feature only surfaces secrets already stored in the user’s local session/IndexedDB.

**Wallet list actions**

- Add an “Export mnemonic” control to every wallet row.
<img width="1476" height="576" alt="image" src="https://github.com/user-attachments/assets/bd46f3c0-045a-488c-960d-54656c153f28" />

- Triggering the control opens a <UiTooltip> confirmation dialog that spells out the risk. The mnemonic is only copied (and the success toast fired) if the user explicitly confirms.
<img width="1586" height="916" alt="image" src="https://github.com/user-attachments/assets/105863cc-fe58-450a-b19f-a7ce8714a3a5" />

**Account table actions**

- Introduce an Actions column with a “Copy secret key” control per account.
<img width="1664" height="860" alt="image" src="https://github.com/user-attachments/assets/a989c9f8-4dcb-4883-b94a-6fccee95465c" />

- If secretKey is missing (i.e., watched accounts), keep the button disabled and explain why via tooltip.
<img width="628" height="166" alt="image" src="https://github.com/user-attachments/assets/bfaa38bb-d3bd-459d-9df7-ca01f8f4a325" />

- If the copy step fails for any reason, we surface an error toast.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add feature to export wallet/account secrets with UI enhancements and error handling using `copySensitiveText`.
> 
>   - **Implementation**:
>     - Add `copySensitiveText` in `handle-copy-text.ts` to handle clipboard operations and return success status.
>     - Use `copySensitiveText` in `settings-ui-account-table.tsx` and `settings-ui-wallet-list-item.tsx` for exporting secrets.
>     - Add export buttons in account and wallet UI components with confirmation dialogs and tooltips.
>   - **UI Enhancements**:
>     - Add "Export mnemonic" button in `settings-ui-wallet-list-item.tsx` with confirmation and fallback prompt.
>     - Add "Copy secret key" button in `settings-ui-account-table.tsx` with confirmation and fallback prompt.
>     - Disable button for accounts without `secretKey` and show tooltip explanation.
>   - **Icons**:
>     - Add `key` icon to `ui-icon-map.tsx` for use in export buttons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b1c59a72d8e8a6d3d021d9100b96173a240b2f45. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->