### PR TITLE
fix: export i18n from package as named export

### DIFF
--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -25,4 +25,4 @@ i18n.use(initReactI18next).init({
 
 export { useTranslation } from 'react-i18next'
 
-export default i18n
+export { i18n }


### PR DESCRIPTION
Fixes #451
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `i18n` export from default to named export in `index.ts`.
> 
>   - **Exports**:
>     - Change `i18n` export from default to named export in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for a4d5b1c53f61d440de728dbd87b8c26e3dc67de0. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->