### PR TITLE
fix: ensure CI fails when bun lock file changes

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yml
+++ b/.github/workflows/actions/install-dependencies/action.yml
@@ -16,4 +16,9 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: bun ci
+      run: bun install
+
+# TODO: This check can go when this issue is fixed https://github.com/oven-sh/bun/issues/24223
+    - name: Check for dirty git repo
+      shell: bash
+      run:  git diff --quiet --ignore-submodules HEAD

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "samui",
@@ -232,6 +231,7 @@
         "dexie-react-hooks": "^4.2.0",
         "react": "catalog:",
         "react-dom": "catalog:",
+        "react-router": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",


### PR DESCRIPTION
Fixes #410 

After being left with a dirty repo for the n-th time over the last few days I decided to add a check to make CI fail.

Upstream issue has already been created. https://github.com/oven-sh/bun/issues/24223
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure CI fails if `bun.lock` changes by adding a git diff check in the workflow.
> 
>   - **CI Workflow**:
>     - In `install-dependencies/action.yml`, change `bun ci` to `bun install`.
>     - Add a step to check for a dirty git repository using `git diff --quiet --ignore-submodules HEAD`.
>   - **Dependencies**:
>     - Update `bun.lock` to add `react-router` as a dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 29abaad46e497a9c1e64e9027e8a4e4bbd559ded. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->