### PR TITLE
fix(onboarding): ensure small viewport has some padding

### DIFF
--- a/packages/onboarding/src/ui/onboarding-ui-layout.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-layout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router'
 export function OnboardingUiLayout() {
   return (
     <div className="min-h-full w-full flex items-center justify-center">
-      <div className="w-full sm:max-w-lg">
+      <div className="w-full px-2 sm:px-0 max-w-lg">
         <Outlet />
       </div>
     </div>


### PR DESCRIPTION
## Description

In #437 I introduced a regression that removed the padding on small viewports in the onboarding screen.


## Screenshots / Video

### Before
<img width="612" height="832" alt="image" src="https://github.com/user-attachments/assets/05731fc5-4892-4aa1-941d-b8b55b56ed9d" />

### After
<img width="612" height="832" alt="image" src="https://github.com/user-attachments/assets/91978778-eba8-4e26-88ed-1e7210bffb00" />
 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds padding for small viewports in `OnboardingUiLayout` to fix a regression.
> 
>   - **UI Fix**:
>     - Adds `px-2` padding to the `div` in `OnboardingUiLayout` for small viewports in `onboarding-ui-layout.tsx` to restore padding removed in a previous regression.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 09156fc8e805db07005cdfe7a8b76ab06e44d430. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->