### PR TITLE
feat(portfolio): use a skeleton component

### DIFF
--- a/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
@@ -3,15 +3,17 @@ import type { Account } from '@workspace/db/entity/account'
 import type { Network } from '@workspace/db/entity/network'
 import { NATIVE_MINT } from '@workspace/solana-client/constants'
 import { useGetAccountInfo } from '@workspace/solana-client-react/use-get-account-info'
-import { Spinner } from '@workspace/ui/components/spinner'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { useCallback, useMemo } from 'react'
 import type { TokenBalance } from './data-access/use-get-token-metadata.ts'
 import { useGetTokenBalances } from './data-access/use-get-token-metadata.ts'
 import { PortfolioUiAccountButtons } from './ui/portfolio-ui-account-buttons.tsx'
+import { PortfolioUiBalance } from './ui/portfolio-ui-balance.tsx'
+import { PortfolioUiBalanceSkeleton } from './ui/portfolio-ui-balance-skeleton.tsx'
 import { PortfolioUiRequestAirdrop } from './ui/portfolio-ui-request-airdrop.tsx'
 import { PortfolioUiTokenBalances } from './ui/portfolio-ui-token-balances.tsx'
+import { PortfolioUiTokenBalancesSkeleton } from './ui/portfolio-ui-token-balances-skeleton.tsx'
 import { useCreateAndSendSolTransaction } from './use-create-and-send-sol-transaction.tsx'
 import { useCreateAndSendSplTransaction } from './use-create-and-send-spl-transaction.tsx'
 
@@ -107,16 +109,22 @@ export function PortfolioFeatureTabTokens(props: { account: Account; network: Ne
     },
     [handleSendSol, handleSendSplToken],
   )
-  if (isLoadingWalletInfo) {
-    return <Spinner />
-  }
 
   return (
     <div className="space-y-6">
-      <div className="text-4xl font-bold text-center">$ {totalBalance}</div>
+      {isLoadingWalletInfo ? <PortfolioUiBalanceSkeleton /> : <PortfolioUiBalance balance={totalBalance} />}
+
       <PortfolioUiAccountButtons balances={balances} {...props} isLoading={isLoading} send={handleSendToken} />
-      <PortfolioUiRequestAirdrop account={account} lamports={dataWalletInfo?.value?.lamports} network={network} />
-      <PortfolioUiTokenBalances items={balances} />
+
+      {isLoadingWalletInfo ? null : (
+        <PortfolioUiRequestAirdrop account={account} lamports={dataWalletInfo?.value?.lamports} network={network} />
+      )}
+
+      {isLoadingWalletInfo ? (
+        <PortfolioUiTokenBalancesSkeleton length={3} />
+      ) : (
+        <PortfolioUiTokenBalances items={balances} />
+      )}
     </div>
   )
 }

--- a/packages/portfolio/src/ui/portfolio-ui-balance-skeleton.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-balance-skeleton.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from '@workspace/ui/components/skeleton'
+
+export function PortfolioUiBalanceSkeleton() {
+  return <Skeleton className="w-24 h-10 mx-auto" />
+}

--- a/packages/portfolio/src/ui/portfolio-ui-balance.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-balance.tsx
@@ -1,0 +1,3 @@
+export function PortfolioUiBalance({ balance }: { balance: string }) {
+  return <div className="text-4xl font-bold text-center">${balance}</div>
+}

--- a/packages/portfolio/src/ui/portfolio-ui-token-balance-item-skeleton.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balance-item-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@workspace/ui/components/skeleton'
+
+export function PortfolioUiTokenBalanceItemSkeleton() {
+  return (
+    <div className="flex justify-between items-center w-full">
+      <div className="flex items-center gap-2">
+        <div className="flex justify-center items-center size-14">
+          <Skeleton className="size-12 rounded-full" />
+        </div>
+        <div className="flex flex-col items-start mr-6">
+          <Skeleton className="h-5 w-20 mb-2" />
+          <Skeleton className="h-5 w-12" />
+        </div>
+      </div>
+      <div className="flex flex-col items-end grow">
+        <Skeleton className="h-6 w-16 mb-1" />
+        <Skeleton className="h-5 w-12" />
+      </div>
+    </div>
+  )
+}

--- a/packages/portfolio/src/ui/portfolio-ui-token-balances-skeleton.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balances-skeleton.tsx
@@ -1,0 +1,5 @@
+import { PortfolioUiTokenBalanceItemSkeleton } from './portfolio-ui-token-balance-item-skeleton.tsx'
+
+export function PortfolioUiTokenBalancesSkeleton({ length }: { length: number }) {
+  return Array.from({ length }, (_, i) => i).map((index) => <PortfolioUiTokenBalanceItemSkeleton key={index} />)
+}


### PR DESCRIPTION
## Description

This replaces the spinner with a skeleton component for the homepage of the wallet.

Related https://github.com/samui-build/samui-wallet/issues/284, https://github.com/samui-build/samui-wallet/issues/253, https://github.com/samui-build/samui-wallet/issues/254

## Screenshots / Video

https://github.com/user-attachments/assets/0901f2c3-3e75-45be-9ae2-9247e923802f

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces spinner with skeleton components for loading states in portfolio feature, adding new skeleton components for balance and token balances.
> 
>   - **Behavior**:
>     - Replaces `Spinner` with `PortfolioUiBalanceSkeleton` and `PortfolioUiTokenBalancesSkeleton` in `portfolio-feature-tab-tokens.tsx` for loading states.
>     - Hides `PortfolioUiRequestAirdrop` when `isLoadingWalletInfo` is true.
>   - **Components**:
>     - Adds `PortfolioUiBalanceSkeleton` in `portfolio-ui-balance-skeleton.tsx` for balance loading state.
>     - Adds `PortfolioUiTokenBalanceItemSkeleton` and `PortfolioUiTokenBalancesSkeleton` in `portfolio-ui-token-balance-item-skeleton.tsx` and `portfolio-ui-token-balances-skeleton.tsx` for token balances loading state.
>     - Adds `PortfolioUiBalance` in `portfolio-ui-balance.tsx` for displaying balance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for d93e7a45b0cc525310a48787735729ad6cc8d488. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->