### PR TITLE
feat(i18n): translate ui shell layout

### DIFF
--- a/packages/i18n/locales/en/shell.json
+++ b/packages/i18n/locales/en/shell.json
@@ -1,0 +1,6 @@
+{
+  "explorerLabel": "Explorer",
+  "portfolioLabel": "Portfolio",
+  "settingsLabel": "Settings",
+  "toolsLabel": "Tools"
+}

--- a/packages/i18n/locales/es/shell.json
+++ b/packages/i18n/locales/es/shell.json
@@ -1,0 +1,6 @@
+{
+  "explorerLabel": "Explorador",
+  "portfolioLabel": "Portafolio",
+  "settingsLabel": "Ajustes",
+  "toolsLabel": "Herramientas"
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -5,7 +5,9 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 import enOnboarding from '../locales/en/onboarding.json' with { type: 'json' }
+import enShell from '../locales/en/shell.json' with { type: 'json' }
 import esOnboarding from '../locales/es/onboarding.json' with { type: 'json' }
+import esShell from '../locales/es/shell.json' with { type: 'json' }
 
 i18n.use(initReactI18next).init({
   fallbackLng: 'en',
@@ -16,9 +18,11 @@ i18n.use(initReactI18next).init({
   resources: {
     en: {
       onboarding: enOnboarding,
+      shell: enShell,
     },
     es: {
       onboarding: esOnboarding,
+      shell: esShell,
     },
   },
 })

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -16,6 +16,12 @@ interface Resources {
     uiMnemonicUnexpectedLength: 'Unexpected mnemonic length'
     uiMnemonicWords: '{{words}} words'
   }
+  shell: {
+    explorerLabel: 'Explorer'
+    portfolioLabel: 'Portfolio'
+    settingsLabel: 'Settings'
+    toolsLabel: 'Tools'
+  }
 }
 
 export default Resources

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -3,5 +3,10 @@
     "outDir": "dist"
   },
   "extends": "@workspace/config-typescript/base.json",
-  "files": ["locales/en/onboarding.json", "locales/es/onboarding.json"]
+  "files": [
+    "locales/en/onboarding.json",
+    "locales/es/onboarding.json",
+    "locales/en/shell.json",
+    "locales/es/shell.json"
+  ]
 }

--- a/packages/shell/src/shell-routes.tsx
+++ b/packages/shell/src/shell-routes.tsx
@@ -5,7 +5,6 @@ import { i18n } from '@workspace/i18n'
 import { UiNotFound } from '@workspace/ui/components/ui-not-found'
 import { lazy } from 'react'
 import { createHashRouter, Navigate, RouterProvider, redirect } from 'react-router'
-import type { ShellLayoutLink } from './ui/shell-ui-layout.tsx'
 import { ShellUiLayout } from './ui/shell-ui-layout.tsx'
 
 const DevRoutes = lazy(() => import('@workspace/dev/dev-routes'))
@@ -15,13 +14,6 @@ const PortfolioRoutes = lazy(() => import('@workspace/portfolio/portfolio-routes
 const ToolsRoutes = lazy(() => import('@workspace/tools/tools-routes'))
 const SettingsFeatureReset = lazy(() => import('@workspace/settings/settings-feature-reset'))
 const SettingsRoutes = lazy(() => import('@workspace/settings/settings-routes'))
-
-const links: ShellLayoutLink[] = [
-  { icon: 'portfolio', label: 'Portfolio', to: '/portfolio' },
-  { icon: 'explorer', label: 'Explorer', to: '/explorer' },
-  { icon: 'tools', label: 'Tools', to: '/tools' },
-  { icon: 'settings', label: 'Settings', to: '/settings' },
-]
 
 const router = createHashRouter([
   {
@@ -39,7 +31,7 @@ const router = createHashRouter([
           { element: <ToolsRoutes />, path: 'tools/*' },
           { element: <UiNotFound />, path: '*' },
         ],
-        element: <ShellUiLayout links={links} />,
+        element: <ShellUiLayout />,
       },
       { element: <OnboardingRoutes />, path: 'onboarding/*' },
       { element: <SettingsFeatureReset />, path: 'reset' },

--- a/packages/shell/src/ui/shell-ui-layout.tsx
+++ b/packages/shell/src/ui/shell-ui-layout.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from '@workspace/i18n'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import type { UiIconName } from '@workspace/ui/components/ui-icon-map'
 import { cn } from '@workspace/ui/lib/utils'
@@ -11,7 +12,15 @@ export interface ShellLayoutLink {
   to: string
 }
 
-export function ShellUiLayout({ links }: { links: ShellLayoutLink[] }) {
+export function ShellUiLayout() {
+  const { t } = useTranslation('shell')
+  const links: ShellLayoutLink[] = [
+    { icon: 'portfolio', label: t(($) => $.portfolioLabel), to: '/portfolio' },
+    { icon: 'explorer', label: t(($) => $.explorerLabel), to: '/explorer' },
+    { icon: 'tools', label: t(($) => $.toolsLabel), to: '/tools' },
+    { icon: 'settings', label: t(($) => $.settingsLabel), to: '/settings' },
+  ]
+
   return (
     <div className="h-full flex flex-col justify-between items-stretch">
       <ShellUiWarningExperimental />


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

Translates the ShellUILayout so language switcher change is visible in UI.

Related #310

## Screenshots / Video

<img width="1263" height="142" alt="image" src="https://github.com/user-attachments/assets/ea00b502-0589-4e77-aab5-28b88cea20b4" />

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add i18n support for UI shell layout with English and Spanish translations, updating `ShellUiLayout` to use dynamic labels.
> 
>   - **i18n Support**:
>     - Add `shell.json` for English and Spanish in `locales/en` and `locales/es`.
>     - Update `index.ts` to import and initialize `shell` translations.
>     - Modify `resources.d.ts` to include `shell` translation keys.
>   - **UI Changes**:
>     - Remove `links` prop from `ShellUiLayout` in `shell-routes.tsx`.
>     - Use `useTranslation` in `ShellUiLayout` to dynamically render labels based on language.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3abc8d0efe326aa39bbf5d53ae5a5976fee92fdf. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->