### PR TITLE
chore: ensure cspell in the commit-message reads cspell config

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -16,4 +16,4 @@ commit-msg:
       run: bun commitlint --edit {1}
 
     spell-check:
-      run: bun cspell --no-summary {1}
+      run: bun spell-check --no-summary {1}


### PR DESCRIPTION
## Description

It would not let me to write the commit message in #461 because the config was not applied 😁

## Screenshots / Video

```
┃  spell-check ❯

1/1 .git/COMMIT_EDITMSG 310.26ms X
.git/COMMIT_EDITMSG:1:13 - Unknown word (uniwind)
error: "cspell" exited with code 1
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change `spell-check` command in `lefthook.yaml` to ensure `cspell` config is applied for commit messages.
> 
>   - **Behavior**:
>     - Changes `spell-check` command in `lefthook.yaml` from `bun cspell` to `bun spell-check` for commit messages.
>     - Ensures `cspell` configuration is applied during commit message checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 8a11d4a9bfa215e832a7eb17b8c4e4a1b9a58fd3. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->