### PR TITLE
fix(settings,tools): align card gaps between items of each panel

### DIFF
--- a/packages/settings/src/settings-feature-general.tsx
+++ b/packages/settings/src/settings-feature-general.tsx
@@ -10,8 +10,8 @@ import { SettingsFeatureGeneralWarningAcceptExperimental } from './settings-feat
 export function SettingsFeatureGeneral() {
   const page = useSettingsPage({ pageId: 'general' })
   return (
-    <div className="space-y-6">
-      <UiCard contentProps={{ className: 'grid gap-6' }} description={page.description} title={page.name}>
+    <div className="space-y-4">
+      <UiCard contentProps={{ className: 'grid gap-4 space-y-4' }} description={page.description} title={page.name}>
         <SettingsFeatureGeneralLanguage />
         <SettingsFeatureGeneralApiEndpoint />
         <SettingsFeatureGeneralWarningAcceptExperimental />

--- a/packages/settings/src/ui/settings-ui-layout.tsx
+++ b/packages/settings/src/ui/settings-ui-layout.tsx
@@ -8,7 +8,7 @@ export function SettingsUiLayout() {
 
   return (
     <UiPage>
-      <div className="grid grid-cols-1 md:grid-cols-3 md:gap-2 gap-y-2">
+      <div className="grid grid-cols-1 md:grid-cols-3 md:gap-4 gap-y-4">
         <div>
           <SettingsUiPageList pages={pages} />
         </div>

--- a/packages/settings/src/ui/settings-ui-page-list.tsx
+++ b/packages/settings/src/ui/settings-ui-page-list.tsx
@@ -4,7 +4,7 @@ import { SettingsUiPageItem } from './settings-ui-page-item.tsx'
 
 export function SettingsUiPageList({ pages }: { pages: SettingsPage[] }) {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-4">
       {pages.map((page) => (
         <SettingsUiPageItem key={page.id} page={page} />
       ))}

--- a/packages/tools/src/tools-feature-overview.tsx
+++ b/packages/tools/src/tools-feature-overview.tsx
@@ -3,7 +3,7 @@ import { ToolsUiOverview } from './ui/tools-ui-overview.tsx'
 
 export default function ToolsFeatureOverview() {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <ToolsUiOverview tools={tools.filter((t) => !t.comingSoon)} />
       <ToolsUiOverview tools={tools.filter((t) => t.comingSoon)} />
     </div>

--- a/packages/tools/src/ui/tools-ui-overview.tsx
+++ b/packages/tools/src/ui/tools-ui-overview.tsx
@@ -4,7 +4,7 @@ import { ToolsUiOverviewItem } from './tools-ui-overview-item.tsx'
 
 export function ToolsUiOverview({ tools }: { tools: Tool[] }) {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {tools.map((tool) => (
         <ToolsUiOverviewItem key={tool.path} tool={tool} />
       ))}


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->
Tools originally uses gaps of 6rem
Settings originally uses gaps of 2rem

Aligned them both so they're 4rem

## Screenshots / Video

https://github.com/user-attachments/assets/5e27fe06-b638-482d-892a-5ab3466c0152


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Aligns card gaps to 4rem in settings and tools panels for consistent spacing.
> 
>   - **Behavior**:
>     - Aligns card gaps to 4rem in `settings-feature-general.tsx`, `settings-ui-layout.tsx`, and `settings-ui-page-list.tsx`.
>     - Aligns card gaps to 4rem in `tools-feature-overview.tsx` and `tools-ui-overview.tsx`.
>   - **Misc**:
>     - Original gaps were 6rem in tools and 2rem in settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 5f9f9f9e63d427e5d2b0e6ca420a7287c6d69cbf. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->