### PR TITLE
fix(solana-client): ensure to assert transactions have valid blockhash lifetime

### DIFF
--- a/packages/solana-client/src/create-and-send-sol-transaction.ts
+++ b/packages/solana-client/src/create-and-send-sol-transaction.ts
@@ -1,6 +1,7 @@
-import type { KeyPairSigner } from '@solana/kit'
 import {
+  assertIsTransactionWithBlockhashLifetime,
   getSignatureFromTransaction,
+  type KeyPairSigner,
   sendAndConfirmTransactionFactory,
   signTransactionMessageWithSigners,
 } from '@solana/kit'
@@ -40,9 +41,10 @@ export async function createAndSendSolTransaction(
   })
 
   const signedTransaction = await signTransactionMessageWithSigners(transactionMessage)
+  assertIsTransactionWithBlockhashLifetime(signedTransaction)
+
   // @ts-expect-error rpc clients are scoped to their network, we need to figure out how to handle this
   await sendAndConfirmTransactionFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions })(
-    // @ts-expect-error TODO: Figure out "Property lastValidBlockHeight is missing in type TransactionDurableNonceLifetime but required in type"
     signedTransaction,
     { commitment: 'confirmed' },
   )

--- a/packages/solana-client/src/create-and-send-spl-transaction.ts
+++ b/packages/solana-client/src/create-and-send-spl-transaction.ts
@@ -1,7 +1,9 @@
-import type { Address, KeyPairSigner } from '@solana/kit'
 import {
+  type Address,
   address,
+  assertIsTransactionWithBlockhashLifetime,
   getSignatureFromTransaction,
+  type KeyPairSigner,
   sendAndConfirmTransactionFactory,
   signTransactionMessageWithSigners,
 } from '@solana/kit'
@@ -58,9 +60,10 @@ export async function createAndSendSplTransaction(
   })
 
   const signedTransaction = await signTransactionMessageWithSigners(transactionMessage)
+  assertIsTransactionWithBlockhashLifetime(signedTransaction)
+
   // @ts-expect-error rpc clients are scoped to their network, we need to figure out how to handle this
   await sendAndConfirmTransactionFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions })(
-    // @ts-expect-error TODO: Figure out "Property lastValidBlockHeight is missing in type TransactionDurableNonceLifetime but required in type"
     signedTransaction,
     { commitment: 'confirmed' },
   )

--- a/packages/solana-client/src/spl-token-create-token-mint.ts
+++ b/packages/solana-client/src/spl-token-create-token-mint.ts
@@ -1,8 +1,9 @@
-import type { KeyPairSigner } from '@solana/kit'
 import {
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createTransactionMessage,
   getSignatureFromTransaction,
+  type KeyPairSigner,
   pipe,
   sendAndConfirmTransactionFactory,
   setTransactionMessageFeePayerSigner,
@@ -78,10 +79,10 @@ export async function splTokenCreateTokenMint(
 
   // Sign transaction message with required signers (fee payer and mint keypair)
   const signedTransaction = await signTransactionMessageWithSigners(transactionMessage)
+  assertIsTransactionWithBlockhashLifetime(signedTransaction)
 
   // @ts-expect-error rpc clients are scoped to their cluster, we need to figure out how to handle this
   await sendAndConfirmTransactionFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions })(
-    // @ts-expect-error TODO: Figure out "Property lastValidBlockHeight is missing in type TransactionDurableNonceLifetime but required in type"
     signedTransaction,
     { commitment: 'confirmed' },
   )
@@ -120,10 +121,10 @@ export async function splTokenCreateTokenMint(
     )
 
     const signedSupplyTransaction = await signTransactionMessageWithSigners(supplyTransactionMessage)
+    assertIsTransactionWithBlockhashLifetime(signedSupplyTransaction)
 
     // @ts-expect-error rpc clients are scoped to their cluster, we need to figure out how to handle this
     await sendAndConfirmTransactionFactory({ rpc: client.rpc, rpcSubscriptions: client.rpcSubscriptions })(
-      // @ts-expect-error TODO: Figure out "Property lastValidBlockHeight is missing in type TransactionDurableNonceLifetime but required in type"
       signedSupplyTransaction,
       { commitment: 'confirmed' },
     )


### PR DESCRIPTION
## Description

Related to #458 

As per the suggestion of @mcintyre94  [here](https://github.com/samui-build/samui-wallet/issues/458#issuecomment-3543302476)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `assertIsTransactionWithBlockhashLifetime` to ensure transactions have valid blockhash lifetime in key Solana client functions.
> 
>   - **Behavior**:
>     - Adds `assertIsTransactionWithBlockhashLifetime` to `createAndSendSolTransaction`, `createAndSendSplTransaction`, and `splTokenCreateTokenMint` to ensure transactions have valid blockhash lifetime.
>   - **Imports**:
>     - Reorganizes imports in `create-and-send-sol-transaction.ts`, `create-and-send-spl-transaction.ts`, and `spl-token-create-token-mint.ts` to include `assertIsTransactionWithBlockhashLifetime` and adjust type imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for d3fc74a1eb192a448a4e58e6f400b9db8db979c9. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->