### PR TITLE
fix(shell): don't throw an error if ShellUiLayout can't be loaded

### DIFF
--- a/packages/db-react/src/use-db-account-live.tsx
+++ b/packages/db-react/src/use-db-account-live.tsx
@@ -2,9 +2,8 @@ import { db } from '@workspace/db/db'
 import { dbAccountFindByWalletId } from '@workspace/db/db-account-find-by-wallet-id'
 import type { Account } from '@workspace/db/entity/account'
 import { useLiveQuery } from 'dexie-react-hooks'
-import { useRouteLoaderData } from 'react-router'
-import type { DbLoaderData } from './db-loader.tsx'
 import { useDbSetting } from './use-db-setting.tsx'
+import { useRootLoaderData } from './use-root-loader-data.tsx'
 
 export function useDbAccountLive({ walletId }: { walletId?: null | string } = {}) {
   const [activeWalletId] = useDbSetting('activeWalletId')
@@ -12,9 +11,9 @@ export function useDbAccountLive({ walletId }: { walletId?: null | string } = {}
     throw new Error('No active wallet set.')
   }
 
-  const data = useRouteLoaderData<DbLoaderData>('root')
+  const data = useRootLoaderData()
   if (!data?.accounts) {
-    throw new Error('Loader not called.')
+    throw new Error('Root loader not called.')
   }
 
   return useLiveQuery<Account[], Account[]>(() => dbAccountFindByWalletId(db, walletId), [walletId], data.accounts)

--- a/packages/db-react/src/use-db-network-live.tsx
+++ b/packages/db-react/src/use-db-network-live.tsx
@@ -2,13 +2,12 @@ import { db } from '@workspace/db/db'
 import { dbNetworkFindMany } from '@workspace/db/db-network-find-many'
 import type { Network } from '@workspace/db/entity/network'
 import { useLiveQuery } from 'dexie-react-hooks'
-import { useRouteLoaderData } from 'react-router'
-import type { DbLoaderData } from './db-loader.tsx'
+import { useRootLoaderData } from './use-root-loader-data.tsx'
 
 export function useDbNetworkLive() {
-  const data = useRouteLoaderData<DbLoaderData>('root')
+  const data = useRootLoaderData()
   if (!data?.networks) {
-    throw new Error('Loader not called.')
+    throw new Error('Root loader not called.')
   }
 
   return useLiveQuery<Network[], Network[]>(() => dbNetworkFindMany(db), [], data.networks)

--- a/packages/db-react/src/use-db-setting-get-value-live.tsx
+++ b/packages/db-react/src/use-db-setting-get-value-live.tsx
@@ -2,13 +2,12 @@ import { db } from '@workspace/db/db'
 import { dbSettingGetValue } from '@workspace/db/db-setting-get-value'
 import type { SettingKey } from '@workspace/db/entity/setting-key'
 import { useLiveQuery } from 'dexie-react-hooks'
-import { useRouteLoaderData } from 'react-router'
-import type { DbLoaderData } from './db-loader.tsx'
+import { useRootLoaderData } from './use-root-loader-data.tsx'
 
 export function useDbSettingGetValueLive(key: SettingKey) {
-  const data = useRouteLoaderData<DbLoaderData>('root')
+  const data = useRootLoaderData()
   if (!data?.settings) {
-    throw new Error('Loader not called.')
+    throw new Error('Root loader not called.')
   }
 
   const value = data.settings.find((s) => s.key === key)?.value ?? null

--- a/packages/db-react/src/use-root-loader-data.tsx
+++ b/packages/db-react/src/use-root-loader-data.tsx
@@ -1,0 +1,6 @@
+import { useRouteLoaderData } from 'react-router'
+import type { DbLoaderData } from './db-loader.tsx'
+
+export function useRootLoaderData() {
+  return useRouteLoaderData<DbLoaderData>('root')
+}

--- a/packages/shell/src/ui/shell-ui-layout.tsx
+++ b/packages/shell/src/ui/shell-ui-layout.tsx
@@ -1,3 +1,4 @@
+import { useRootLoaderData } from '@workspace/db-react/use-root-loader-data'
 import { useTranslation } from '@workspace/i18n'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import type { UiIconName } from '@workspace/ui/components/ui-icon-map'
@@ -14,6 +15,11 @@ export interface ShellLayoutLink {
 
 export function ShellUiLayout() {
   const { t } = useTranslation('shell')
+  const data = useRootLoaderData()
+  if (!data?.accounts?.length) {
+    return null
+  }
+
   const links: ShellLayoutLink[] = [
     { icon: 'portfolio', label: t(($) => $.portfolioLabel), to: '/portfolio' },
     { icon: 'explorer', label: t(($) => $.explorerLabel), to: '/explorer' },


### PR DESCRIPTION
## Description

Currently, if you navigate to a url without going through the wallet onboarding flow first, the shell will thrown an error.

This PR fixes it by not rendering the shell if there are no accounts found.

We may decide to improve on the error in a future PR but let's for now show nothing instead.

## Screenshots / Video
<img width="1201" height="457" alt="image" src="https://github.com/user-attachments/assets/589a7d59-270b-49da-ae72-0710f3e28b54" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes shell error by not rendering `ShellUiLayout` if no accounts are found and refactors data loading with `useRootLoaderData`.
> 
>   - **Behavior**:
>     - `ShellUiLayout` in `shell-ui-layout.tsx` now returns `null` if no accounts are found, preventing errors when navigating without onboarding.
>   - **Data Loading**:
>     - Introduces `useRootLoaderData` in `use-root-loader-data.tsx` to encapsulate root data loading.
>     - Replaces `useRouteLoaderData` with `useRootLoaderData` in `use-db-account-live.tsx`, `use-db-network-live.tsx`, and `use-db-setting-get-value-live.tsx`.
>     - Updates error messages to "Root loader not called." in these files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 75f27d40c3ba0647e57c5a9b542ccffccd5c5ef3. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->