### PR TITLE
feat(settings): translate settings pages

### DIFF
--- a/packages/i18n/locales/en/settings.json
+++ b/packages/i18n/locales/en/settings.json
@@ -1,0 +1,14 @@
+{
+  "pageGeneralApiEndpoint": "API Endpoint",
+  "pageGeneralDangerZone": "Danger zone",
+  "pageGeneralDescription": "General settings for the app",
+  "pageGeneralDeveloperMode": "Enable developer mode",
+  "pageGeneralExperimentalSoftware": "Show warning about experimental software",
+  "pageGeneralLanguage": "Language",
+  "pageGeneralName": "General",
+  "pageGeneralReset": "Reset application",
+  "pageNetworkDescription": "Manage networks and endpoints",
+  "pageNetworkName": "Networks",
+  "pageWalletDescription": "Manage wallets and accounts",
+  "pageWalletName": "Wallets"
+}

--- a/packages/i18n/locales/es/settings.json
+++ b/packages/i18n/locales/es/settings.json
@@ -1,0 +1,14 @@
+{
+  "pageGeneralApiEndpoint": "Endpoint de la API",
+  "pageGeneralDangerZone": "Zona de peligro",
+  "pageGeneralDescription": "Ajustes generales de la app",
+  "pageGeneralDeveloperMode": "Habilitar modo de desarrollador",
+  "pageGeneralExperimentalSoftware": "Mostrar advertencia sobre software experimental",
+  "pageGeneralLanguage": "Idioma",
+  "pageGeneralName": "General",
+  "pageGeneralReset": "Restablecer aplicación",
+  "pageNetworkDescription": "Gestionar redes y endpoints",
+  "pageNetworkName": "Redes",
+  "pageWalletDescription": "Gestionar billeteras y cuentas",
+  "pageWalletName": "Billeteras"
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -5,8 +5,10 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 import enOnboarding from '../locales/en/onboarding.json' with { type: 'json' }
+import enSettings from '../locales/en/settings.json' with { type: 'json' }
 import enShell from '../locales/en/shell.json' with { type: 'json' }
 import esOnboarding from '../locales/es/onboarding.json' with { type: 'json' }
+import esSettings from '../locales/es/settings.json' with { type: 'json' }
 import esShell from '../locales/es/shell.json' with { type: 'json' }
 
 i18n.use(initReactI18next).init({
@@ -18,10 +20,12 @@ i18n.use(initReactI18next).init({
   resources: {
     en: {
       onboarding: enOnboarding,
+      settings: enSettings,
       shell: enShell,
     },
     es: {
       onboarding: esOnboarding,
+      settings: esSettings,
       shell: esShell,
     },
   },

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -16,6 +16,20 @@ interface Resources {
     uiMnemonicUnexpectedLength: 'Unexpected mnemonic length'
     uiMnemonicWords: '{{words}} words'
   }
+  settings: {
+    pageGeneralApiEndpoint: 'API Endpoint'
+    pageGeneralDangerZone: 'Danger zone'
+    pageGeneralDescription: 'General settings for the app'
+    pageGeneralDeveloperMode: 'Enable developer mode'
+    pageGeneralExperimentalSoftware: 'Show warning about experimental software'
+    pageGeneralLanguage: 'Language'
+    pageGeneralName: 'General'
+    pageGeneralReset: 'Reset application'
+    pageNetworkDescription: 'Manage networks and endpoints'
+    pageNetworkName: 'Networks'
+    pageWalletDescription: 'Manage wallets and accounts'
+    pageWalletName: 'Wallets'
+  }
   shell: {
     explorerLabel: 'Explorer'
     portfolioLabel: 'Portfolio'

--- a/packages/settings/src/data-access/use-settings-pages.tsx
+++ b/packages/settings/src/data-access/use-settings-pages.tsx
@@ -1,24 +1,26 @@
+import { useTranslation } from '@workspace/i18n'
 import type { SettingsPage } from './settings-page.ts'
 
 export function useSettingsPages(): SettingsPage[] {
+  const { t } = useTranslation('settings')
   return [
     {
-      description: 'General settings for the app',
+      description: t(($) => $.pageGeneralDescription),
       icon: 'settings',
       id: 'general',
-      name: 'General',
+      name: t(($) => $.pageGeneralName),
     },
     {
-      description: 'Manage networks and endpoints',
+      description: t(($) => $.pageNetworkDescription),
       icon: 'network',
       id: 'networks',
-      name: 'Networks',
+      name: t(($) => $.pageNetworkName),
     },
     {
-      description: 'Manage wallets and accounts',
+      description: t(($) => $.pageWalletDescription),
       icon: 'wallet',
       id: 'wallets',
-      name: 'Wallets',
+      name: t(($) => $.pageWalletName),
     },
   ]
 }

--- a/packages/settings/src/settings-feature-general-api-endpoint.tsx
+++ b/packages/settings/src/settings-feature-general-api-endpoint.tsx
@@ -1,15 +1,17 @@
 import { useDbSetting } from '@workspace/db-react/use-db-setting'
+import { useTranslation } from '@workspace/i18n'
 import { Input } from '@workspace/ui/components/input'
 import { Label } from '@workspace/ui/components/label'
 import { useId } from 'react'
 
 export function SettingsFeatureGeneralApiEndpoint() {
+  const { t } = useTranslation('settings')
   const apiEndpointId = useId()
   const [apiEndpoint, setApiEndpoint] = useDbSetting('apiEndpoint')
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={apiEndpointId}>API Endpoint</Label>
+      <Label htmlFor={apiEndpointId}>{t(($) => $.pageGeneralApiEndpoint)}</Label>
       <Input
         id={apiEndpointId}
         onChange={(e) => setApiEndpoint(e.target.value)}

--- a/packages/settings/src/settings-feature-general-developer-mode-enable.tsx
+++ b/packages/settings/src/settings-feature-general-developer-mode-enable.tsx
@@ -1,9 +1,11 @@
 import { useDbSetting } from '@workspace/db-react/use-db-setting'
+import { useTranslation } from '@workspace/i18n'
 import { Label } from '@workspace/ui/components/label'
 import { Switch } from '@workspace/ui/components/switch'
 import { useId } from 'react'
 
 export function SettingsFeatureGeneralDeveloperModeEnable() {
+  const { t } = useTranslation('settings')
   const enableDeveloperModeId = useId()
   const [enabled, setEnabled] = useDbSetting('developerModeEnabled')
 
@@ -14,7 +16,7 @@ export function SettingsFeatureGeneralDeveloperModeEnable() {
         id={enableDeveloperModeId}
         onCheckedChange={(checked) => setEnabled(`${checked}`)}
       />
-      <Label htmlFor={enableDeveloperModeId}>Enable developer mode</Label>
+      <Label htmlFor={enableDeveloperModeId}>{t(($) => $.pageGeneralDeveloperMode)}</Label>
     </div>
   )
 }

--- a/packages/settings/src/settings-feature-general-language.tsx
+++ b/packages/settings/src/settings-feature-general-language.tsx
@@ -1,5 +1,5 @@
 import { useDbSetting } from '@workspace/db-react/use-db-setting'
-import { i18n } from '@workspace/i18n'
+import { i18n, useTranslation } from '@workspace/i18n'
 import { Label } from '@workspace/ui/components/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@workspace/ui/components/select'
 import { useId } from 'react'
@@ -10,6 +10,7 @@ const SUPPORTED_LANGUAGES: Record<string, string> = {
 }
 
 export function SettingsFeatureGeneralLanguage() {
+  const { t } = useTranslation('settings')
   const languageId = useId()
   const [language, setLanguageSetting] = useDbSetting('language')
 
@@ -20,7 +21,7 @@ export function SettingsFeatureGeneralLanguage() {
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={languageId}>Language</Label>
+      <Label htmlFor={languageId}>{t(($) => $.pageGeneralLanguage)}</Label>
       <Select onValueChange={handleLanguageChange} value={language ?? 'en'}>
         <SelectTrigger id={languageId}>
           <SelectValue />

--- a/packages/settings/src/settings-feature-general-warning-accept-experimental.tsx
+++ b/packages/settings/src/settings-feature-general-warning-accept-experimental.tsx
@@ -1,9 +1,11 @@
 import { useDbSetting } from '@workspace/db-react/use-db-setting'
+import { useTranslation } from '@workspace/i18n'
 import { Label } from '@workspace/ui/components/label'
 import { Switch } from '@workspace/ui/components/switch'
 import { useId } from 'react'
 
 export function SettingsFeatureGeneralWarningAcceptExperimental() {
+  const { t } = useTranslation('settings')
   const warningAcceptExperimentalId = useId()
   const [warningAccepted, setWarningAccepted] = useDbSetting('warningAcceptExperimental')
 
@@ -14,7 +16,7 @@ export function SettingsFeatureGeneralWarningAcceptExperimental() {
         id={warningAcceptExperimentalId}
         onCheckedChange={(checked) => setWarningAccepted(`${!checked}`)}
       />
-      <Label htmlFor={warningAcceptExperimentalId}>Show warning about experimental software</Label>
+      <Label htmlFor={warningAcceptExperimentalId}>{t(($) => $.pageGeneralExperimentalSoftware)}</Label>
     </div>
   )
 }

--- a/packages/settings/src/settings-feature-general.tsx
+++ b/packages/settings/src/settings-feature-general.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { Link } from 'react-router'
@@ -8,6 +9,7 @@ import { SettingsFeatureGeneralLanguage } from './settings-feature-general-langu
 import { SettingsFeatureGeneralWarningAcceptExperimental } from './settings-feature-general-warning-accept-experimental.tsx'
 
 export function SettingsFeatureGeneral() {
+  const { t } = useTranslation('settings')
   const page = useSettingsPage({ pageId: 'general' })
   return (
     <div className="space-y-4">
@@ -17,9 +19,13 @@ export function SettingsFeatureGeneral() {
         <SettingsFeatureGeneralWarningAcceptExperimental />
         <SettingsFeatureGeneralDeveloperModeEnable />
       </UiCard>
-      <UiCard className="border-red-500" contentProps={{ className: 'grid gap-6' }} title="Danger zone">
+      <UiCard
+        className="border-red-500"
+        contentProps={{ className: 'grid gap-6' }}
+        title={t(($) => $.pageGeneralDangerZone)}
+      >
         <Button asChild variant="destructive">
-          <Link to="/reset">Reset application</Link>
+          <Link to="/reset">{t(($) => $.pageGeneralReset)}</Link>
         </Button>
       </UiCard>
     </div>


### PR DESCRIPTION

## Description

Translation of settings pages. 
Related: #310 
## Screenshots / Video
<img width="1007" height="812" alt="Screenshot 2025-11-18 at 7 40 19 PM" src="https://github.com/user-attachments/assets/8a81b669-5b8b-44b3-b982-100f2049b9e1" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add translations for settings pages in English and Spanish, updating components to use localized strings.
> 
>   - **Localization**:
>     - Add `settings.json` for English and Spanish in `locales/en` and `locales/es`.
>     - Update `index.ts` to include `enSettings` and `esSettings` in resources.
>     - Extend `Resources` interface in `resources.d.ts` to include `settings` keys.
>   - **Components**:
>     - Use `useTranslation` in `use-settings-pages.tsx` to translate page descriptions and names.
>     - Update `SettingsFeatureGeneralApiEndpoint`, `SettingsFeatureGeneralDeveloperModeEnable`, `SettingsFeatureGeneralLanguage`, and `SettingsFeatureGeneralWarningAcceptExperimental` to use translations for labels.
>     - Modify `SettingsFeatureGeneral` to translate the "Danger zone" title and "Reset application" button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3987d7b24ba2449d54519058d6ef9258bc5f7c34. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->