### PR TITLE
chore(ci): add surfpool wait-on timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,9 +78,9 @@ jobs:
 
       - name: Start Surfpool
         run: |
-          docker run -d --name surfpool -p 8899:8899 -p 8900:8900 surfpool/surfpool start --offline --no-tui
-          bunx wait-on tcp:localhost:8899 --verbose
-          bunx wait-on tcp:localhost:8900 --verbose
+          docker run -d --name surfpool -p 8899:8899 -p 8900:8900 surfpool/surfpool:main start --offline --no-tui
+          bunx wait-on tcp:localhost:8899 --verbose --timeout 10000
+          bunx wait-on tcp:localhost:8900 --verbose --timeout 10000
 
       - name: Test Integration
         run: bun run test:integration


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

It would appear Surfpool sometimes does not start. Adding a timeout to fail the job instead of retrying for infinity.

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add timeout to `wait-on` command in CI workflow to prevent indefinite retries for Surfpool startup.
> 
>   - **CI Workflow**:
>     - Adds `--timeout 10000` to `bunx wait-on` commands in `ci.yaml` for ports 8899 and 8900 to prevent indefinite retries when Surfpool does not start.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 34e69fa036d887141e1b56711751a5e6aaf8ff77. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->