### PR TITLE
chore(ci): pin surfpool container to main tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Start Surfpool
         run: |
-          docker run -d --name surfpool -p 8899:8899 -p 8900:8900 surfpool/surfpool start --offline --no-tui
+          docker run -d --name surfpool -p 8899:8899 -p 8900:8900 surfpool/surfpool:main start --offline --no-tui
           bunx wait-on tcp:localhost:8899 --verbose
           bunx wait-on tcp:localhost:8900 --verbose
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pins `surfpool` Docker container to `main` tag in CI workflow for consistent versioning.
> 
>   - **CI Configuration**:
>     - Pins `surfpool` Docker container to `main` tag in `.github/workflows/ci.yaml` to ensure consistent versioning during CI runs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 4322106328300af4c90b64a22cea33998ee13e98. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->