### PR TITLE
fix(settings): ensure we can update a network without the endpointSubscriptions field

### DIFF
--- a/packages/db/src/schema/network-schema.ts
+++ b/packages/db/src/schema/network-schema.ts
@@ -5,7 +5,7 @@ import { networkTypeSchema } from './network-type-schema.ts'
 export const networkSchema = z.object({
   createdAt: z.date(),
   endpoint: z.url(),
-  endpointSubscriptions: z.url().optional(),
+  endpointSubscriptions: z.url().or(z.literal('')).optional(),
   id: z.string(),
   name: z.string(),
   type: networkTypeSchema,

--- a/packages/solana-client/src/create-solana-client.ts
+++ b/packages/solana-client/src/create-solana-client.ts
@@ -15,7 +15,7 @@ export function createSolanaClient<TClusterUrl extends ClusterUrl>({
   if (urlSubscriptions?.trim().length && !urlSubscriptions.startsWith('ws')) {
     throw new Error('Invalid subscription url')
   }
-  const rpcSubscriptionsUrl = urlSubscriptions ? urlSubscriptions : url.replace('http', 'ws')
+  const rpcSubscriptionsUrl = urlSubscriptions?.length ? urlSubscriptions : url.replace('http', 'ws')
   return {
     rpc: createSolanaRpc(url),
     rpcSubscriptions: createSolanaRpcSubscriptions(rpcSubscriptionsUrl),


### PR DESCRIPTION
## Description

This fixes the issue where we're unable to submit a network without a Subscriptions endpoint. 

## Screenshots / Video
<img width="1064" height="1010" alt="image" src="https://github.com/user-attachments/assets/4ab60998-d4a2-440c-b869-09bf6df6d443" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes validation in `networkSchema` to allow empty `endpointSubscriptions` by preprocessing empty strings to `undefined` and making the field nullable.
> 
>   - Adds preprocessing to `endpointSubscriptions` field in `networkSchema` to convert empty strings to `undefined`, allowing network updates without a subscriptions endpoint URL.
>   - Makes `endpointSubscriptions` nullable in addition to optional to handle various empty value cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b8911b015e1abda31c8569a9adfad69078e8c786. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->