### PR TITLE
feat(settings): add vanity wallet generation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "samui",

--- a/packages/keypair/src/generate-vanity-key-pair.spec.ts
+++ b/packages/keypair/src/generate-vanity-key-pair.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { generateVanityKeyPair } from './generate-vanity-key-pair.ts'
+
+describe('generateVanityKeyPair', () => {
+  describe('expected behavior', () => {
+    it('should generate a key pair with a specific prefix', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const prefix = 'A'
+
+      // ACT
+      const result = await generateVanityKeyPair({ prefix })
+
+      // ASSERT
+      expect(result).toBeDefined()
+      expect(result.address.startsWith(prefix)).toBe(true)
+    })
+
+    it('should generate a key pair with a specific suffix', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const suffix = 'A'
+
+      // ACT
+      const result = await generateVanityKeyPair({ suffix })
+
+      // ASSERT
+      expect(result).toBeDefined()
+      expect(result.address.endsWith(suffix)).toBe(true)
+    })
+
+    it('should generate a key pair with case insensitive prefix', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const prefix = 'a'
+
+      // ACT
+      const result = await generateVanityKeyPair({ caseSensitive: false, prefix })
+
+      // ASSERT
+      expect(result).toBeDefined()
+      expect(result.address.toLowerCase().startsWith(prefix)).toBe(true)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      consoleSpy.mockRestore()
+      vi.restoreAllMocks()
+    })
+
+    it('should surface failures from the underlying crypto primitive', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const cryptoSpy = vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(() => {
+        throw new Error('crypto failure')
+      })
+
+      // ACT & ASSERT
+      await expect(generateVanityKeyPair({ prefix: 'X' })).rejects.toThrow('crypto failure')
+
+      cryptoSpy.mockRestore()
+    })
+  })
+})

--- a/packages/keypair/src/generate-vanity-key-pair.ts
+++ b/packages/keypair/src/generate-vanity-key-pair.ts
@@ -1,0 +1,49 @@
+import { createKeyPairSignerFromPrivateKeyBytes, type KeyPairSigner } from '@solana/kit'
+
+export interface GenerateVanityKeyPairProps {
+  caseSensitive?: boolean
+  prefix?: string
+  suffix?: string
+}
+
+export async function generateVanityKeyPair({
+  caseSensitive = true,
+  prefix = '',
+  suffix = '',
+}: GenerateVanityKeyPairProps): Promise<KeyPairSigner> {
+  if (!prefix && !suffix) {
+    const privateKeyBytes = crypto.getRandomValues(new Uint8Array(32))
+    return createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes, true)
+  }
+
+  // We can't report progress from here directly without a callback or generator
+  // But for the worker implementation, we will rewrite the loop there.
+  // This function stays as a utility for simple synchronous usage (though it's async due to createKeyPairSignerFromPrivateKeyBytes)
+
+  while (true) {
+    const privateKeyBytes = crypto.getRandomValues(new Uint8Array(32))
+    const signer = await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes, true)
+    const address = signer.address
+
+    let match = true
+    if (prefix) {
+      if (caseSensitive) {
+        if (!address.startsWith(prefix)) match = false
+      } else {
+        if (!address.toLowerCase().startsWith(prefix.toLowerCase())) match = false
+      }
+    }
+
+    if (match && suffix) {
+      if (caseSensitive) {
+        if (!address.endsWith(suffix)) match = false
+      } else {
+        if (!address.toLowerCase().endsWith(suffix.toLowerCase())) match = false
+      }
+    }
+
+    if (match) {
+      return signer
+    }
+  }
+}

--- a/packages/settings/src/settings-feature-wallet-generate-vanity.tsx
+++ b/packages/settings/src/settings-feature-wallet-generate-vanity.tsx
@@ -1,0 +1,165 @@
+import { Alert, AlertDescription, AlertTitle } from '@workspace/ui/components/alert'
+import { Button } from '@workspace/ui/components/button'
+import { UiCard } from '@workspace/ui/components/ui-card'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router'
+
+import {
+  SettingsUiWalletFormGenerateVanity,
+  type VanityWalletFormInput,
+} from './ui/settings-ui-wallet-form-generate-vanity.tsx'
+
+export function SettingsFeatureWalletGenerateVanity() {
+  const navigate = useNavigate()
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [result, setResult] = useState<{ address: string; secretKey: string } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [showSecret, setShowSecret] = useState(false)
+  const [count, setCount] = useState(0)
+  const workerRef = useRef<Worker | null>(null)
+
+  useEffect(() => {
+    return () => {
+      workerRef.current?.terminate()
+      workerRef.current = null
+    }
+  }, [])
+
+  const handleGenerate = async (input: VanityWalletFormInput) => {
+    setIsGenerating(true)
+    setError(null)
+    setResult(null)
+    setShowSecret(false)
+    setCount(0)
+
+    try {
+      workerRef.current?.terminate()
+      const worker = new Worker(new URL('./workers/vanity-worker.ts', import.meta.url), { type: 'module' })
+      workerRef.current = worker
+
+      worker.onmessage = (event) => {
+        const { type, payload } = event.data ?? {}
+        if (type === 'progress' && typeof payload === 'number') {
+          setCount(payload)
+          return
+        }
+        if (type === 'found' && payload) {
+          setResult({
+            address: payload.address,
+            secretKey: payload.secretKey,
+          })
+          if (typeof payload.attempts === 'number') {
+            setCount(payload.attempts)
+          }
+          setIsGenerating(false)
+          workerRef.current?.terminate()
+          workerRef.current = null
+          return
+        }
+        if (type === 'error') {
+          setError(typeof payload === 'string' ? payload : 'Failed to generate vanity address')
+          setIsGenerating(false)
+          workerRef.current?.terminate()
+          workerRef.current = null
+        }
+      }
+
+      worker.onerror = (event) => {
+        setError(event.message ?? 'Worker error')
+        setIsGenerating(false)
+        workerRef.current?.terminate()
+        workerRef.current = null
+      }
+
+      worker.postMessage(input)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to start worker')
+      setIsGenerating(false)
+    }
+  }
+
+  const handleCancel = () => {
+    workerRef.current?.terminate()
+    workerRef.current = null
+    setIsGenerating(false)
+  }
+
+  return (
+    <UiCard backButtonTo="/settings/wallets/create" title="Generate Vanity Wallet">
+      <div className="grid gap-6">
+        <Alert>
+          <AlertTitle>Warning</AlertTitle>
+          <AlertDescription>
+            Generating runs on the main thread for now.
+            <strong>Long prefixes/suffixes will freeze the browser!</strong>
+            <br />
+            Use short patterns (1-3 characters) for best results.
+          </AlertDescription>
+        </Alert>
+
+        {!result ? (
+          <div className="space-y-6">
+            <SettingsUiWalletFormGenerateVanity disabled={isGenerating} submit={handleGenerate} />
+
+            {isGenerating && (
+              <div className="flex flex-col items-center justify-center gap-3 rounded-lg border bg-muted/50 p-6 text-center animate-in fade-in">
+                <div className="text-3xl font-mono font-bold">{count.toLocaleString()}</div>
+                <p className="text-sm text-muted-foreground">Wallets checked</p>
+                <Button onClick={handleCancel} variant="destructive">
+                  Stop Generation
+                </Button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="grid gap-4 p-4 border rounded-lg animate-in fade-in slide-in-from-bottom-4">
+            <div className="grid gap-2">
+              <h3 className="font-medium">Found Address!</h3>
+              <div className="font-mono text-sm break-all bg-muted p-3 rounded border">{result.address}</div>
+              {count > 0 ? (
+                <p className="text-xs text-muted-foreground">Found after checking {count.toLocaleString()} wallets.</p>
+              ) : null}
+            </div>
+
+            <div className="grid gap-2">
+              <div className="flex items-center justify-between">
+                <h3 className="font-medium">Secret Key JSON</h3>
+                <Button onClick={() => setShowSecret(!showSecret)} size="sm" variant="ghost">
+                  {showSecret ? 'Hide' : 'Show'}
+                </Button>
+              </div>
+              {showSecret && (
+                <div className="font-mono text-xs break-all bg-muted p-3 rounded border text-muted-foreground">
+                  {result.secretKey}
+                </div>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2 pt-4">
+              <Button onClick={() => setResult(null)} variant="outline">
+                Try Again
+              </Button>
+              <Button
+                onClick={() => {
+                  navigator.clipboard.writeText(result.secretKey)
+                  toastSuccess('Secret key copied to clipboard')
+                  navigate('/settings/wallets/import')
+                }}
+              >
+                Copy & Import
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertTitle>Error</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+      </div>
+    </UiCard>
+  )
+}

--- a/packages/settings/src/settings-routes.tsx
+++ b/packages/settings/src/settings-routes.tsx
@@ -7,6 +7,7 @@ import { SettingsFeatureWalletAddAccount } from './settings-feature-wallet-add-a
 import { SettingsFeatureWalletCreate } from './settings-feature-wallet-create.tsx'
 import { SettingsFeatureWalletDetails } from './settings-feature-wallet-details.tsx'
 import { SettingsFeatureWalletGenerate } from './settings-feature-wallet-generate.tsx'
+import { SettingsFeatureWalletGenerateVanity } from './settings-feature-wallet-generate-vanity.tsx'
 import { SettingsFeatureWalletImport } from './settings-feature-wallet-import.tsx'
 import { SettingsFeatureWalletList } from './settings-feature-wallet-list.tsx'
 import { SettingsFeatureWalletUpdate } from './settings-feature-wallet-update.tsx'
@@ -22,6 +23,7 @@ export default function SettingsRoutes() {
             { element: <SettingsFeatureWalletList />, index: true },
             { element: <SettingsFeatureWalletCreate />, path: 'create' },
             { element: <SettingsFeatureWalletGenerate />, path: 'generate' },
+            { element: <SettingsFeatureWalletGenerateVanity />, path: 'generate-vanity' },
             { element: <SettingsFeatureWalletImport />, path: 'import' },
             { element: <SettingsFeatureWalletDetails />, path: ':walletId' },
             { element: <SettingsFeatureWalletAddAccount />, path: ':walletId/add' },

--- a/packages/settings/src/ui/settings-ui-wallet-create-options.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-create-options.tsx
@@ -16,6 +16,11 @@ export function SettingsUiWalletCreateOptions() {
         title="Import an existing wallet"
         to="/settings/wallets/import"
       />
+      <SettingsUiWalletCreateLink
+        description="Generate a new wallet with a custom prefix or suffix"
+        title="Generate a vanity wallet"
+        to="/settings/wallets/generate-vanity"
+      />
       <SettingsUiWalletCreateHeader icon="hardware" label="Hardware accounts" />
       <SettingsUiWalletCreateComingSoon
         description="Unruggable is the first Solana native hardware account."

--- a/packages/settings/src/ui/settings-ui-wallet-form-generate-vanity.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-form-generate-vanity.tsx
@@ -1,0 +1,100 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@workspace/ui/components/button'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@workspace/ui/components/form'
+import { Input } from '@workspace/ui/components/input'
+import { Switch } from '@workspace/ui/components/switch'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+const schema = z.object({
+  caseSensitive: z.boolean().default(true),
+  prefix: z.string().optional().default(''),
+  suffix: z.string().optional().default(''),
+})
+
+export type VanityWalletFormInput = z.infer<typeof schema>
+
+export function SettingsUiWalletFormGenerateVanity({
+  disabled,
+  submit,
+}: {
+  disabled?: boolean
+  submit: (input: VanityWalletFormInput) => Promise<void>
+}) {
+  const form = useForm<VanityWalletFormInput>({
+    defaultValues: {
+      caseSensitive: true,
+      prefix: '',
+      suffix: '',
+    },
+    resolver: zodResolver(schema),
+  })
+
+  return (
+    <Form {...form}>
+      <form className="flex flex-col gap-6" onSubmit={form.handleSubmit(submit)}>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="prefix"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Prefix</FormLabel>
+                <FormControl>
+                  {/* Ensure value is always a string to prevent 'value.split is not a function' error in some UI libraries */}
+                  <Input {...field} disabled={disabled} placeholder="Start with..." value={field.value || ''} />
+                </FormControl>
+                <FormDescription>Characters the address should start with</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="suffix"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Suffix</FormLabel>
+                <FormControl>
+                  <Input {...field} disabled={disabled} placeholder="End with..." value={field.value || ''} />
+                </FormControl>
+                <FormDescription>Characters the address should end with</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="caseSensitive"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel className="text-base">Case Sensitive</FormLabel>
+                <FormDescription>Match exact case (slower)</FormDescription>
+              </div>
+              <FormControl>
+                <Switch checked={field.value} disabled={disabled} onCheckedChange={field.onChange} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <div className="flex justify-end">
+          <Button disabled={disabled} size="lg" type="submit">
+            {disabled ? 'Generating...' : 'Find Vanity Address'}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  )
+}

--- a/packages/settings/src/workers/vanity-worker.ts
+++ b/packages/settings/src/workers/vanity-worker.ts
@@ -1,0 +1,67 @@
+/// <reference lib="webworker" />
+
+import { createKeyPairSignerFromPrivateKeyBytes } from '@solana/kit'
+import { convertKeyPairToJson } from '@workspace/keypair/convert-key-pair-to-json'
+
+type VanityWorkerInput = {
+  caseSensitive?: boolean
+  prefix?: string
+  suffix?: string
+}
+type VanityWorkerMessage =
+  | { payload: number; type: 'progress' }
+  | { payload: { address: string; attempts: number; secretKey: string }; type: 'found' }
+  | { payload: string; type: 'error' }
+
+const PROGRESS_INTERVAL = 1000
+
+self.onmessage = async (event: MessageEvent<VanityWorkerInput>) => {
+  const { caseSensitive = true, prefix = '', suffix = '' } = event.data ?? {}
+  const normalizedPrefix = caseSensitive ? prefix : prefix.toLowerCase()
+  const normalizedSuffix = caseSensitive ? suffix : suffix.toLowerCase()
+
+  let attempts = 0
+
+  try {
+    while (true) {
+      const privateKeyBytes = crypto.getRandomValues(new Uint8Array(32))
+      const signer = await createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes, true)
+      const addressToCheck = caseSensitive ? signer.address : signer.address.toLowerCase()
+
+      let match = true
+      if (normalizedPrefix) {
+        match = addressToCheck.startsWith(normalizedPrefix)
+      }
+      if (match && normalizedSuffix) {
+        match = addressToCheck.endsWith(normalizedSuffix)
+      }
+
+      attempts += 1
+
+      if (attempts === 1 || attempts % PROGRESS_INTERVAL === 0) {
+        const progressMessage: VanityWorkerMessage = { payload: attempts, type: 'progress' }
+        self.postMessage(progressMessage)
+      }
+
+      if (match) {
+        const secretKey = await convertKeyPairToJson(signer.keyPair)
+        const foundMessage: VanityWorkerMessage = {
+          payload: {
+            address: signer.address,
+            attempts,
+            secretKey,
+          },
+          type: 'found',
+        }
+        self.postMessage(foundMessage)
+        break
+      }
+    }
+  } catch (error) {
+    const errorMessage: VanityWorkerMessage = {
+      payload: error instanceof Error ? error.message : 'Unknown worker error',
+      type: 'error',
+    }
+    self.postMessage(errorMessage)
+  }
+}


### PR DESCRIPTION
## Description

This adds a Vanity Wallet creation path to Settings, wiring up the worker based generator, UI form, progress/cancel controls, and copy/import result card. It reuses @workspace/keypair for the underlying keypair work.


## Screenshots / Video

https://github.com/user-attachments/assets/c0fadd00-ca1f-47fd-a9f0-18500829b82e



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds vanity wallet generation feature with UI integration and worker-based key pair generation.
> 
>   - **Feature**:
>     - Adds `generateVanityKeyPair` function in `generate-vanity-key-pair.ts` to generate key pairs with specific prefixes/suffixes.
>     - Implements `SettingsFeatureWalletGenerateVanity` component in `settings-feature-wallet-generate-vanity.tsx` for UI integration.
>     - Adds `vanity-worker.ts` to handle key pair generation in a web worker.
>   - **UI Components**:
>     - Adds `SettingsUiWalletFormGenerateVanity` in `settings-ui-wallet-form-generate-vanity.tsx` for form input.
>     - Updates `settings-ui-wallet-create-options.tsx` to include vanity wallet generation option.
>   - **Routing**:
>     - Updates `settings-routes.tsx` to include route for vanity wallet generation.
>   - **Tests**:
>     - Adds tests in `generate-vanity-key-pair.spec.ts` for key pair generation with prefix, suffix, and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c4d38f9ae99d8b12dcf6ebef45b909ae7f03be7e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->