### PR TITLE
feat(i18n): translate ui components

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -582,6 +582,7 @@
         "@radix-ui/react-toggle": "^1.1.10",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@workspace/i18n": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",

--- a/packages/i18n/locales/en/ui.json
+++ b/packages/i18n/locales/en/ui.json
@@ -1,0 +1,10 @@
+{
+  "errorTitle": "Oops, an error occurred",
+  "experimentalWarningDescription": "Use this wallet at your own risk. Do not use any real funds.",
+  "experimentalWarningTitle": "This is experimental software.",
+  "notFoundDescription": "The page you're looking for doesn't exist.",
+  "notFoundTitle": "404 - Not Found",
+  "relativeDateToday": "Today",
+  "relativeDateYesterday": "Yesterday",
+  "textCopyFailed": "Failed to copy text"
+}

--- a/packages/i18n/locales/es/ui.json
+++ b/packages/i18n/locales/es/ui.json
@@ -1,0 +1,10 @@
+{
+  "errorTitle": "Uy, ocurrió un error",
+  "experimentalWarningDescription": "Utilice esta billetera bajo su propio riesgo. No use fondos reales.",
+  "experimentalWarningTitle": "Este es un software experimental.",
+  "notFoundDescription": "La página que está buscando no existe.",
+  "notFoundTitle": "404 - No encontrado",
+  "relativeDateToday": "Hoy",
+  "relativeDateYesterday": "Ayer",
+  "textCopyFailed": "Error al copiar texto"
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -7,9 +7,11 @@ import { initReactI18next } from 'react-i18next'
 import enOnboarding from '../locales/en/onboarding.json' with { type: 'json' }
 import enSettings from '../locales/en/settings.json' with { type: 'json' }
 import enShell from '../locales/en/shell.json' with { type: 'json' }
+import enUi from '../locales/en/ui.json' with { type: 'json' }
 import esOnboarding from '../locales/es/onboarding.json' with { type: 'json' }
 import esSettings from '../locales/es/settings.json' with { type: 'json' }
 import esShell from '../locales/es/shell.json' with { type: 'json' }
+import esUi from '../locales/es/ui.json' with { type: 'json' }
 
 i18n.use(initReactI18next).init({
   fallbackLng: 'en',
@@ -22,11 +24,13 @@ i18n.use(initReactI18next).init({
       onboarding: enOnboarding,
       settings: enSettings,
       shell: enShell,
+      ui: enUi,
     },
     es: {
       onboarding: esOnboarding,
       settings: esSettings,
       shell: esShell,
+      ui: esUi,
     },
   },
 })

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -115,6 +115,16 @@ interface Resources {
     walletEdit: 'Edit wallet'
     walletSettings: 'Wallet settings'
   }
+  ui: {
+    errorTitle: 'Oops, an error occurred'
+    experimentalWarningDescription: 'Use this wallet at your own risk. Do not use any real funds.'
+    experimentalWarningTitle: 'This is experimental software.'
+    notFoundDescription: "The page you're looking for doesn't exist."
+    notFoundTitle: '404 - Not Found'
+    relativeDateToday: 'Today'
+    relativeDateYesterday: 'Yesterday'
+    textCopyFailed: 'Failed to copy text'
+  }
 }
 
 export default Resources

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@workspace/i18n": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/ui/src/components/ui-error.tsx
+++ b/packages/ui/src/components/ui-error.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from '@workspace/i18n'
 import type { ReactNode } from 'react'
 import { UiEmpty } from './ui-empty.tsx'
 import type { UiIconName } from './ui-icon-map.tsx'
@@ -5,11 +6,14 @@ import type { UiIconName } from './ui-icon-map.tsx'
 export function UiError({
   icon,
   message,
-  title = 'Oops, an error occurred',
+  title,
 }: {
   icon?: UiIconName | undefined
   message?: Error
   title?: ReactNode
 }) {
-  return <UiEmpty description={message ? message?.message : undefined} icon={icon} title={title} />
+  const { t } = useTranslation('ui')
+  return (
+    <UiEmpty description={message ? message?.message : undefined} icon={icon} title={title ?? t(($) => $.errorTitle)} />
+  )
 }

--- a/packages/ui/src/components/ui-experimental-warning.tsx
+++ b/packages/ui/src/components/ui-experimental-warning.tsx
@@ -1,14 +1,15 @@
+import { useTranslation } from '@workspace/i18n'
 import { AlertTriangle, LucideX } from 'lucide-react'
-
 import { Alert, AlertDescription, AlertTitle } from './alert.tsx'
 import { Button } from './button.tsx'
 
 export function UiExperimentalWarning({ close }: { close?: () => void }) {
+  const { t } = useTranslation('ui')
   return (
     <Alert className="rounded-none border-1 border-yellow-500 bg-yellow-500/10 text-yellow-500">
       <AlertTriangle />
-      <AlertTitle>This is experimental software.</AlertTitle>
-      <AlertDescription>Use this wallet at your own risk. Do not use any real funds.</AlertDescription>
+      <AlertTitle>{t(($) => $.experimentalWarningTitle)}</AlertTitle>
+      <AlertDescription>{t(($) => $.experimentalWarningDescription)}</AlertDescription>
       {close ? (
         <Button className="absolute top-2 right-2" onClick={() => close()} size="icon" variant="ghost">
           <LucideX />

--- a/packages/ui/src/components/ui-not-found.tsx
+++ b/packages/ui/src/components/ui-not-found.tsx
@@ -1,5 +1,7 @@
+import { useTranslation } from '@workspace/i18n'
 import { UiEmpty } from './ui-empty.tsx'
 
 export function UiNotFound() {
-  return <UiEmpty description="The page you're looking for doesn't exist." title="404 - Not Found" />
+  const { t } = useTranslation('ui')
+  return <UiEmpty description={t(($) => $.notFoundDescription)} title={t(($) => $.notFoundTitle)} />
 }

--- a/packages/ui/src/components/ui-relative-date.tsx
+++ b/packages/ui/src/components/ui-relative-date.tsx
@@ -1,13 +1,16 @@
+import { useTranslation } from '@workspace/i18n'
 import { format, isThisWeek, isToday, isYesterday } from 'date-fns'
 
 export function UiRelativeDate({ date }: { date: Date }) {
+  const { t } = useTranslation('ui')
   if (isToday(date)) {
-    return 'Today'
+    return t(($) => $.relativeDateToday)
   }
   if (isYesterday(date)) {
-    return 'Yesterday'
+    return t(($) => $.relativeDateYesterday)
   }
   if (isThisWeek(date)) {
+    // TODO: Use date-fns locales
     return format(date, 'EEEE')
   }
   return format(date, 'MMM d')

--- a/packages/ui/src/components/ui-text-copy-button.tsx
+++ b/packages/ui/src/components/ui-text-copy-button.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from '@workspace/i18n'
 import type { ComponentProps } from 'react'
 import { handleCopyText } from '../lib/handle-copy-text.ts'
 import { toastError } from '../lib/toast-error.ts'
@@ -12,6 +13,7 @@ export function UiTextCopyButton({
   toastFailed,
   ...props
 }: ComponentProps<typeof Button> & { label?: string; text: string; toast?: string; toastFailed?: string }) {
+  const { t } = useTranslation('ui')
   return (
     <Button
       className="cursor-pointer"
@@ -22,7 +24,7 @@ export function UiTextCopyButton({
             toastSuccess(toast)
           }
         } catch (error) {
-          toastError(error instanceof Error ? error.message : (toastFailed ?? 'Failed to copy text'))
+          toastError(error instanceof Error ? error.message : (toastFailed ?? t(($) => $.textCopyFailed)))
         }
       }}
       type="button"


### PR DESCRIPTION
## Description

Part of #310


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add i18n support for UI components with English and Spanish translations, updating components to use dynamic text rendering.
> 
>   - **i18n Integration**:
>     - Add `ui.json` for English and Spanish in `locales` to provide translations for UI components.
>     - Update `index.ts` to include `ui` translations in i18n resources.
>     - Update `resources.d.ts` to define `ui` translation keys.
>   - **UI Components**:
>     - Modify `UiError`, `UiExperimentalWarning`, `UiNotFound`, `UiRelativeDate`, and `UiTextCopyButton` to use `useTranslation` for dynamic text rendering.
>   - **Dependencies**:
>     - Add `@workspace/i18n` to `dependencies` in `package.json` for i18n support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c97afad28ba8a732210e7f13451bf8cbad1b4b7d. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->