### PR TITLE
feat(shell): add top-level navigation options to command menu

### DIFF
--- a/packages/i18n/locales/en/shell.json
+++ b/packages/i18n/locales/en/shell.json
@@ -5,6 +5,8 @@
   "accountPublicKeyCopySuccess": "Copied public key",
   "commandEmpty": "No results found.",
   "commandInputPlaceholder": "Type a command or search...",
+  "commandNavigate": "Navigate",
+  "commandNavigateTo": "Navigate to",
   "commandSuggestions": "Suggestions",
   "labelExplorer": "Explorer",
   "labelPortfolio": "Portfolio",

--- a/packages/i18n/locales/es/shell.json
+++ b/packages/i18n/locales/es/shell.json
@@ -5,6 +5,8 @@
   "accountPublicKeyCopySuccess": "Clave pública copiada",
   "commandEmpty": "Ningún resultado encontrado.",
   "commandInputPlaceholder": "Escriba un comando o busque...",
+  "commandNavigate": "Navegar",
+  "commandNavigateTo": "Navega a",
   "commandSuggestions": "Sugerencias",
   "labelExplorer": "Explorador",
   "labelPortfolio": "Portafolio",

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -106,6 +106,8 @@ interface Resources {
     accountPublicKeyCopySuccess: 'Copied public key'
     commandEmpty: 'No results found.'
     commandInputPlaceholder: 'Type a command or search...'
+    commandNavigate: 'Navigate'
+    commandNavigateTo: 'Navigate to'
     commandSuggestions: 'Suggestions'
     labelExplorer: 'Explorer'
     labelPortfolio: 'Portfolio'

--- a/packages/shell/src/ui/use-shell-command-group-navigate.tsx
+++ b/packages/shell/src/ui/use-shell-command-group-navigate.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from '@workspace/i18n'
+import { useLocation, useNavigate } from 'react-router'
+import type { ShellCommandGroup } from './use-shell-command-groups.tsx'
+
+export function useShellCommandGroupNavigate(): ShellCommandGroup {
+  const { t } = useTranslation('shell')
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+
+  const options: { label: string; path: string }[] = [
+    {
+      label: t(($) => $.labelPortfolio),
+      path: '/portfolio',
+    },
+    {
+      label: t(($) => $.labelExplorer),
+      path: '/explorer',
+    },
+    {
+      label: t(($) => $.labelTools),
+      path: '/tools',
+    },
+    {
+      label: t(($) => $.labelSettings),
+      path: '/settings',
+    },
+  ]
+
+  return {
+    commands: options.map(({ label, path }) => ({
+      disabled: pathname.startsWith(path),
+      handler: async () => {
+        await navigate(path)
+      },
+      label: `${t(($) => $.commandNavigateTo)} ${label}`,
+    })),
+    label: t(($) => $.commandNavigate),
+  }
+}

--- a/packages/shell/src/ui/use-shell-command-group-suggestions.tsx
+++ b/packages/shell/src/ui/use-shell-command-group-suggestions.tsx
@@ -1,0 +1,27 @@
+import { useAccountActive } from '@workspace/db-react/use-account-active'
+import { useTranslation } from '@workspace/i18n'
+import { handleCopyText } from '@workspace/ui/lib/handle-copy-text'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import type { ShellCommandGroup } from './use-shell-command-groups.tsx'
+
+export function useShellCommandGroupSuggestions(): ShellCommandGroup {
+  const { t } = useTranslation('shell')
+  const { publicKey } = useAccountActive()
+  return {
+    commands: [
+      {
+        handler: async () => {
+          try {
+            await handleCopyText(publicKey)
+            toastSuccess(t(($) => $.accountPublicKeyCopySuccess))
+          } catch (error) {
+            toastError(error instanceof Error ? error.message : t(($) => $.accountPublicKeyCopyFailed))
+          }
+        },
+        label: t(($) => $.accountPublicKeyCopy),
+      },
+    ],
+    label: t(($) => $.commandSuggestions),
+  }
+}

--- a/packages/shell/src/ui/use-shell-command-groups.tsx
+++ b/packages/shell/src/ui/use-shell-command-groups.tsx
@@ -1,0 +1,20 @@
+import { useShellCommandGroupNavigate } from './use-shell-command-group-navigate.tsx'
+import { useShellCommandGroupSuggestions } from './use-shell-command-group-suggestions.tsx'
+
+export interface ShellCommand {
+  disabled?: boolean
+  handler: () => Promise<void>
+  label: string
+}
+
+export interface ShellCommandGroup {
+  commands: ShellCommand[]
+  label: string
+}
+
+export function useShellCommandGroups(): ShellCommandGroup[] {
+  const suggestions = useShellCommandGroupSuggestions()
+  const navigate = useShellCommandGroupNavigate()
+
+  return [suggestions, navigate]
+}


### PR DESCRIPTION
## Description

I gave a stab at extracting out the commands which should make it easier to add more groups of commands to the palette. 


## Screenshots / Video
<img width="755" height="1290" alt="image" src="https://github.com/user-attachments/assets/5d087b51-40b1-4e0c-85d9-6f40aac271e7" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add top-level navigation options to the shell command menu with support for command groups.
> 
>   - **Feature**:
>     - Add top-level navigation options to the command menu in `shell-ui-command-menu.tsx`.
>     - Introduce command groups using `use-shell-command-groups.tsx`.
>   - **Command Groups**:
>     - `use-shell-command-group-navigate.tsx` for navigation commands.
>     - `use-shell-command-group-suggestions.tsx` for suggestion commands.
>   - **i18n**:
>     - Add `commandNavigate` and `commandNavigateTo` to `en/shell.json` and `es/shell.json`.
>   - **Refactor**:
>     - Remove direct command handling from `shell-ui-command-menu.tsx` and use command groups instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c8d2a2ac5be7a4862379959de25fc4f24cb5ba37. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->