### PR TITLE
feat(ui): add dark/light theme toggle

### DIFF
--- a/packages/shell/src/ui/shell-ui-layout.tsx
+++ b/packages/shell/src/ui/shell-ui-layout.tsx
@@ -1,5 +1,6 @@
 import { useRootLoaderData } from '@workspace/db-react/use-root-loader-data'
 import { useTranslation } from '@workspace/i18n'
+import { ThemeProvider } from '@workspace/ui/components/theme-provider'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import type { UiIconName } from '@workspace/ui/components/ui-icon-map'
 import { cn } from '@workspace/ui/lib/utils'
@@ -29,31 +30,33 @@ export function ShellUiLayout() {
   ]
 
   return (
-    <div className="h-full flex flex-col justify-between items-stretch">
-      <ShellUiWarningExperimental />
-      <ShellUiCommandMenu />
-      <header className="bg-secondary/50">
-        <ShellUiMenu />
-      </header>
-      <main className="flex-1 overflow-y-auto p-1 md:p-2 lg:p-4">
-        <Outlet />
-      </main>
-      <footer className="bg-secondary/50 flex justify-between items-center">
-        {links.map(({ icon, label, to }) => (
-          <NavLink
-            className={({ isActive }) =>
-              cn('items-center truncate text-xs md:text-md gap-1 md:gap-2 pt-2 pb-1 flex flex-col flex-1', {
-                'font-semibold bg-secondary/60': isActive,
-              })
-            }
-            key={to}
-            to={to}
-          >
-            <UiIcon className="size-4 md:size-6" icon={icon} />
-            {label}
-          </NavLink>
-        ))}
-      </footer>
-    </div>
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <div className="h-full flex flex-col justify-between items-stretch">
+        <ShellUiWarningExperimental />
+        <ShellUiCommandMenu />
+        <header className="bg-secondary/50">
+          <ShellUiMenu />
+        </header>
+        <main className="flex-1 overflow-y-auto p-1 md:p-2 lg:p-4">
+          <Outlet />
+        </main>
+        <footer className="bg-secondary/50 flex justify-between items-center">
+          {links.map(({ icon, label, to }) => (
+            <NavLink
+              className={({ isActive }) =>
+                cn('items-center truncate text-xs md:text-md gap-1 md:gap-2 pt-2 pb-1 flex flex-col flex-1', {
+                  'font-semibold bg-secondary/60': isActive,
+                })
+              }
+              key={to}
+              to={to}
+            >
+              <UiIcon className="size-4 md:size-6" icon={icon} />
+              {label}
+            </NavLink>
+          ))}
+        </footer>
+      </div>
+    </ThemeProvider>
   )
 }

--- a/packages/shell/src/ui/shell-ui-menu.tsx
+++ b/packages/shell/src/ui/shell-ui-menu.tsx
@@ -5,6 +5,7 @@ import { getDevOptions } from '@workspace/dev/dev-features'
 import { useActiveAccount } from '@workspace/settings/data-access/use-active-account'
 import { useActiveWallet } from '@workspace/settings/data-access/use-active-wallet'
 import { Menubar } from '@workspace/ui/components/menubar'
+import { ModeToggle } from '@workspace/ui/components/mode-toggle'
 import { useMemo } from 'react'
 import { ShellUiMenuDevelopment } from './shell-ui-menu-development.tsx'
 import { ShellUiMenuNetwork } from './shell-ui-menu-network.tsx'
@@ -32,6 +33,7 @@ export function ShellUiMenu() {
         <ShellUiMenuNetwork active={activeNetwork} networks={items} setActive={setActiveNetworkId} />
       ) : null}
       <ShellUiMenuDevelopment items={getDevOptions()} />
+      <ModeToggle />
     </Menubar>
   )
 }

--- a/packages/ui/src/components/mode-toggle.tsx
+++ b/packages/ui/src/components/mode-toggle.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@workspace/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@workspace/ui/components/dropdown-menu'
+import { Moon, Sun } from 'lucide-react'
+import { useTheme } from '@/components/theme-provider.tsx'
+
+export function ModeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        asChild
+        className="ml-auto mr-2
+      "
+      >
+        <Button size="icon" variant="outline">
+          <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme('light')}>Light</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>Dark</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>System</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/ui/src/components/theme-provider.tsx
+++ b/packages/ui/src/components/theme-provider.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'dark' | 'light' | 'system'
+
+type ThemeProviderProps = {
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
+}
+
+type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+const initialState: ThemeProviderState = {
+  setTheme: () => null,
+  theme: 'system',
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'system',
+  storageKey = 'vite-ui-theme',
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem(storageKey) as Theme) || defaultTheme)
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove('light', 'dark')
+
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+    theme,
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined) throw new Error('useTheme must be used within a ThemeProvider')
+
+  return context
+}


### PR DESCRIPTION
## Description

Added dark/light theme toggle functionality to the Samui Wallet application using shadcn ui's theme provider implementation. Users can now switch between light, dark, and system themes through a dropdown menu in the shell UI.

**Changes include:**
- [x] finalize spec
- [x] add theme setting
- [x] add logic to switch theme
- [x] default to dark theme

Closes #496 

## Screenshots / Video

https://github.com/user-attachments/assets/1570c487-03fc-4e05-bba4-ecc0c19d476b
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds dark/light theme toggle to Samui Wallet with `ThemeProvider` and `ModeToggle` components.
> 
>   - **Behavior**:
>     - Adds `ThemeProvider` to `shell-ui-layout.tsx` with default theme set to dark.
>     - Integrates `ModeToggle` in `shell-ui-menu.tsx` for theme switching.
>     - Supports light, dark, and system themes via dropdown in `mode-toggle.tsx`.
>   - **Components**:
>     - New `ThemeProvider` in `theme-provider.tsx` manages theme state and applies theme classes to document root.
>     - New `ModeToggle` in `mode-toggle.tsx` provides UI for theme selection using a dropdown menu.
>   - **Misc**:
>     - Stores theme preference in `localStorage` under key `vite-ui-theme`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b07f492fc153145f474546092003a19ce1000d65. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->