### PR TITLE
feat(shell): add language command

### DIFF
--- a/packages/i18n/locales/en/shell.json
+++ b/packages/i18n/locales/en/shell.json
@@ -7,6 +7,8 @@
   "actionsSidebarShow": "Show sidebar",
   "commandEmpty": "No results found.",
   "commandInputPlaceholder": "Type a command or search...",
+  "commandLanguage": "Language",
+  "commandLanguageChangeTo": "Change to",
   "commandNavigate": "Navigate",
   "commandNavigateTo": "Navigate to",
   "commandSuggestions": "Suggestions",

--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -1,0 +1,4 @@
+{
+  "languageEnglish": "English",
+  "languageSpanish": "Spanish"
+}

--- a/packages/i18n/locales/es/shell.json
+++ b/packages/i18n/locales/es/shell.json
@@ -7,6 +7,8 @@
   "actionsSidebarShow": "Abrir barra lateral",
   "commandEmpty": "Ningún resultado encontrado.",
   "commandInputPlaceholder": "Escriba un comando o busque...",
+  "commandLanguage": "Idioma",
+  "commandLanguageChangeTo": "Cambiar a",
   "commandNavigate": "Navegar",
   "commandNavigateTo": "Navega a",
   "commandSuggestions": "Sugerencias",

--- a/packages/i18n/locales/es/translation.json
+++ b/packages/i18n/locales/es/translation.json
@@ -1,0 +1,4 @@
+{
+  "languageEnglish": "Inglés",
+  "languageSpanish": "Español"
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -3,19 +3,21 @@ import './i18next.d.ts'
 
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
-
 import enOnboarding from '../locales/en/onboarding.json' with { type: 'json' }
 import enPortfolio from '../locales/en/portfolio.json' with { type: 'json' }
 import enSettings from '../locales/en/settings.json' with { type: 'json' }
 import enShell from '../locales/en/shell.json' with { type: 'json' }
+import enTranslation from '../locales/en/translation.json' with { type: 'json' }
 import enUi from '../locales/en/ui.json' with { type: 'json' }
 import esOnboarding from '../locales/es/onboarding.json' with { type: 'json' }
 import esPortfolio from '../locales/es/portfolio.json' with { type: 'json' }
 import esSettings from '../locales/es/settings.json' with { type: 'json' }
 import esShell from '../locales/es/shell.json' with { type: 'json' }
+import esTranslation from '../locales/es/translation.json' with { type: 'json' }
 import esUi from '../locales/es/ui.json' with { type: 'json' }
 
 i18n.use(initReactI18next).init({
+  defaultNS: 'translation',
   fallbackLng: 'en',
   interpolation: {
     escapeValue: false,
@@ -27,6 +29,7 @@ i18n.use(initReactI18next).init({
       portfolio: enPortfolio,
       settings: enSettings,
       shell: enShell,
+      translation: enTranslation,
       ui: enUi,
     },
     es: {
@@ -34,6 +37,7 @@ i18n.use(initReactI18next).init({
       portfolio: esPortfolio,
       settings: esSettings,
       shell: esShell,
+      translation: esTranslation,
       ui: esUi,
     },
   },
@@ -42,3 +46,5 @@ i18n.use(initReactI18next).init({
 export { useTranslation } from 'react-i18next'
 
 export { i18n }
+
+export { useSupportedLanguages } from './use-supported-languages.tsx'

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -134,6 +134,8 @@ interface Resources {
     actionsSidebarShow: 'Show sidebar'
     commandEmpty: 'No results found.'
     commandInputPlaceholder: 'Type a command or search...'
+    commandLanguage: 'Language'
+    commandLanguageChangeTo: 'Change to'
     commandNavigate: 'Navigate'
     commandNavigateTo: 'Navigate to'
     commandSuggestions: 'Suggestions'
@@ -144,6 +146,10 @@ interface Resources {
     networkSettings: 'Network settings'
     walletEdit: 'Edit wallet'
     walletSettings: 'Wallet settings'
+  }
+  translation: {
+    languageEnglish: 'English'
+    languageSpanish: 'Spanish'
   }
   ui: {
     errorTitle: 'Oops, an error occurred'

--- a/packages/i18n/src/use-supported-languages.tsx
+++ b/packages/i18n/src/use-supported-languages.tsx
@@ -1,0 +1,10 @@
+import { useTranslation } from './index.ts'
+
+export function useSupportedLanguages() {
+  const { t } = useTranslation()
+
+  return {
+    en: t(($) => $.languageEnglish),
+    es: t(($) => $.languageSpanish),
+  }
+}

--- a/packages/settings/src/settings-feature-general-language.tsx
+++ b/packages/settings/src/settings-feature-general-language.tsx
@@ -1,18 +1,14 @@
 import { useSetting } from '@workspace/db-react/use-setting'
-import { i18n, useTranslation } from '@workspace/i18n'
+import { i18n, useSupportedLanguages, useTranslation } from '@workspace/i18n'
 import { Label } from '@workspace/ui/components/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@workspace/ui/components/select'
 import { useId } from 'react'
-
-const SUPPORTED_LANGUAGES: Record<string, string> = {
-  en: 'English',
-  es: 'Spanish',
-}
 
 export function SettingsFeatureGeneralLanguage() {
   const { t } = useTranslation('settings')
   const languageId = useId()
   const [language, setLanguageSetting] = useSetting('language')
+  const supportedLanguages = useSupportedLanguages()
 
   async function handleLanguageChange(newLanguage: string) {
     await setLanguageSetting(newLanguage)
@@ -27,8 +23,8 @@ export function SettingsFeatureGeneralLanguage() {
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {Object.entries(SUPPORTED_LANGUAGES).map(([code, name]) => (
-            <SelectItem key={code} value={code}>
+          {Object.entries(supportedLanguages).map(([code, name]) => (
+            <SelectItem disabled={language === code} key={code} value={code}>
               {name}
             </SelectItem>
           ))}

--- a/packages/shell/src/ui/use-shell-command-group-language.tsx
+++ b/packages/shell/src/ui/use-shell-command-group-language.tsx
@@ -1,0 +1,25 @@
+import { useSetting } from '@workspace/db-react/use-setting'
+import { i18n, useSupportedLanguages, useTranslation } from '@workspace/i18n'
+import type { ShellCommandGroup } from './use-shell-command-groups.tsx'
+
+export function useShellCommandGroupLanguage(): ShellCommandGroup {
+  const { t } = useTranslation('shell')
+  const [language, setLanguageSetting] = useSetting('language')
+  const supportedLanguages = useSupportedLanguages()
+
+  async function handleLanguageChange(newLanguage: string) {
+    await setLanguageSetting(newLanguage)
+    await i18n.changeLanguage(newLanguage)
+  }
+
+  return {
+    commands: Object.entries(supportedLanguages).map(([code, name]) => ({
+      disabled: language === code,
+      handler: async () => {
+        await handleLanguageChange(code)
+      },
+      label: `${t(($) => $.commandLanguageChangeTo)} ${name}`,
+    })),
+    label: t(($) => $.commandLanguage),
+  }
+}

--- a/packages/shell/src/ui/use-shell-command-groups.tsx
+++ b/packages/shell/src/ui/use-shell-command-groups.tsx
@@ -1,3 +1,4 @@
+import { useShellCommandGroupLanguage } from './use-shell-command-group-language.tsx'
 import { useShellCommandGroupNavigate } from './use-shell-command-group-navigate.tsx'
 import { useShellCommandGroupSuggestions } from './use-shell-command-group-suggestions.tsx'
 
@@ -14,7 +15,8 @@ export interface ShellCommandGroup {
 
 export function useShellCommandGroups(): ShellCommandGroup[] {
   const suggestions = useShellCommandGroupSuggestions()
+  const language = useShellCommandGroupLanguage()
   const navigate = useShellCommandGroupNavigate()
 
-  return [suggestions, navigate]
+  return [suggestions, language, navigate]
 }


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

Adds a language switcher to the command menu

Related https://github.com/samui-build/samui-wallet/issues/160

## Screenshots / Video

<img width="635" height="492" alt="image" src="https://github.com/user-attachments/assets/a0b99c50-b42c-465c-b1db-25195fa5c72f" />

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a language switcher to the command menu, supporting English and Spanish, with updates to i18n configurations and components.
> 
>   - **Behavior**:
>     - Adds language switcher to command menu via `use-shell-command-group-language.tsx`.
>     - Supports English and Spanish languages.
>     - Disables current language option in `SettingsFeatureGeneralLanguage` and `useShellCommandGroupLanguage()`.
>   - **i18n Configuration**:
>     - Adds `translation.json` for English and Spanish in `locales/en` and `locales/es`.
>     - Updates `index.ts` to include `translation` namespace.
>     - Adds `useSupportedLanguages()` to provide language options.
>   - **Components**:
>     - Updates `settings-feature-general-language.tsx` to use `useSupportedLanguages()`.
>     - Adds `use-shell-command-group-language.tsx` for language command group.
>     - Modifies `use-shell-command-groups.tsx` to include language command group.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 91b87c1ffa8b38ebf4ebf8361b960dff35f6af81. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->