### PR TITLE
fix(shell): provide hydrateFallback element

### DIFF
--- a/packages/shell/src/shell-routes.tsx
+++ b/packages/shell/src/shell-routes.tsx
@@ -1,6 +1,7 @@
 import { optionsSetting } from '@workspace/db-react/options-setting'
 import { queryClient } from '@workspace/db-react/query-client'
 import { UiErrorBoundary } from '@workspace/ui/components/ui-error-boundary'
+import { UiLoaderFull } from '@workspace/ui/components/ui-loader-full'
 import { UiNotFound } from '@workspace/ui/components/ui-not-found'
 import { lazy } from 'react'
 import { createHashRouter, Navigate, type RouteObject, RouterProvider } from 'react-router'
@@ -21,6 +22,7 @@ function createRouter({ browser, context }: ShellFeatureProps) {
     {
       children: context === 'Onboarding' ? getOnboardingRoutes() : getAppRoutes({ browser, context }),
       errorElement: <UiErrorBoundary />,
+      hydrateFallbackElement: <UiLoaderFull />,
       id: 'root',
       loader: rootRouteLoader(context),
       shouldRevalidate: () => {


### PR DESCRIPTION
## Description

This gets rid of this warning during during development:

> No `HydrateFallback` element provided to render during initial hydration
 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `hydrateFallbackElement` to `createRouter()` in `shell-routes.tsx` to resolve hydration warning.
> 
>   - **Behavior**:
>     - Adds `hydrateFallbackElement: <UiLoaderFull />` to the router configuration in `createRouter()` in `shell-routes.tsx` to provide a fallback UI during initial hydration.
>   - **Imports**:
>     - Imports `UiLoaderFull` from `@workspace/ui/components/ui-loader-full` in `shell-routes.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3fc1d6e9a4a4ee6e887f9c40216729a00d7536bb. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->