### PR TITLE
style(linter): enable use sorted classes rule

### DIFF
--- a/apps/extension/src/components/connect.tsx
+++ b/apps/extension/src/components/connect.tsx
@@ -4,8 +4,8 @@ import { Button } from '@workspace/ui/components/button'
 
 export function Connect() {
   return (
-    <div className="p-4 flex flex-col gap-4">
-      <h1 className="text-2xl font-bold text-center">Connect</h1>
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-center font-bold text-2xl">Connect</h1>
       <div className="flex flex-col gap-2">
         <Button
           onClick={async () => await getRequestService().resolve(await getDbService().account.walletAccounts())}

--- a/apps/extension/src/components/sign-and-send-transaction.tsx
+++ b/apps/extension/src/components/sign-and-send-transaction.tsx
@@ -10,8 +10,8 @@ interface SignAndSendTransactionProps {
 
 export function SignAndSendTransaction({ data }: SignAndSendTransactionProps) {
   return (
-    <div className="p-4 flex flex-col gap-4">
-      <h1 className="text-2xl font-bold text-center">Sign and Send Transaction</h1>
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-center font-bold text-2xl">Sign and Send Transaction</h1>
       <div className="flex flex-col gap-2">
         <Button
           onClick={async () => await getRequestService().resolve(await getSignService().signAndSendTransaction(data))}

--- a/apps/extension/src/components/sign-in.tsx
+++ b/apps/extension/src/components/sign-in.tsx
@@ -10,8 +10,8 @@ interface SignInProps {
 
 export function SignIn({ data }: SignInProps) {
   return (
-    <div className="p-4 flex flex-col gap-4">
-      <h1 className="text-2xl font-bold text-center">Sign In</h1>
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-center font-bold text-2xl">Sign In</h1>
       <div className="flex flex-col gap-2">
         <Button
           onClick={async () => await getRequestService().resolve(await getSignService().signIn(data))}

--- a/apps/extension/src/components/sign-message.tsx
+++ b/apps/extension/src/components/sign-message.tsx
@@ -10,8 +10,8 @@ interface SignMessageProps {
 
 export function SignMessage({ data }: SignMessageProps) {
   return (
-    <div className="p-4 flex flex-col gap-4">
-      <h1 className="text-2xl font-bold text-center">Sign Message</h1>
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-center font-bold text-2xl">Sign Message</h1>
       <div className="flex flex-col gap-2">
         <Button
           onClick={async () => await getRequestService().resolve(await getSignService().signMessage(data))}

--- a/apps/extension/src/components/sign-transaction.tsx
+++ b/apps/extension/src/components/sign-transaction.tsx
@@ -10,8 +10,8 @@ interface SignTransactionProps {
 
 export function SignTransaction({ data }: SignTransactionProps) {
   return (
-    <div className="p-4 flex flex-col gap-4">
-      <h1 className="text-2xl font-bold text-center">Sign Transaction</h1>
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-center font-bold text-2xl">Sign Transaction</h1>
       <div className="flex flex-col gap-2">
         <Button
           onClick={async () => await getRequestService().resolve(await getSignService().signTransaction(data))}

--- a/apps/mobile/src/features/loading/loading-feature-index.tsx
+++ b/apps/mobile/src/features/loading/loading-feature-index.tsx
@@ -7,17 +7,17 @@ import logo from '../../../assets/icon.png'
 export function LoadingFeatureIndex() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Image className="w-[128px] h-[128px]" source={logo} />
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Samui Wallet</Text>
-        <View className="gap-6 mt-6 flex items-center">
+      <View className="flex h-full flex-col items-center justify-center">
+        <Image className="h-[128px] w-[128px]" source={logo} />
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">Samui Wallet</Text>
+        <View className="mt-6 flex items-center gap-6">
           <Link params={{}} screen="Onboarding">
-            <View className="px-6 py-4 bg-neutral-50 dark:bg-neutral-900 rounded-lg items-center">
-              <Text className="text-lg text-center text-neutral-900 dark:text-neutral-100 ">Go to onboarding</Text>
+            <View className="items-center rounded-lg bg-neutral-50 px-6 py-4 dark:bg-neutral-900">
+              <Text className="text-center text-lg text-neutral-900 dark:text-neutral-100">Go to onboarding</Text>
             </View>
           </Link>
           <Link params={{}} screen="App">
-            <View className="px-6 py-4 bg-neutral-50 dark:bg-neutral-900 rounded-lg items-center">
+            <View className="items-center rounded-lg bg-neutral-50 px-6 py-4 dark:bg-neutral-900">
               <Text className="text-lg text-neutral-900 dark:text-neutral-100">Go to the app</Text>
             </View>
           </Link>

--- a/apps/mobile/src/features/onboarding/onboarding-feature-generate.tsx
+++ b/apps/mobile/src/features/onboarding/onboarding-feature-generate.tsx
@@ -27,7 +27,7 @@ export function OnboardingFeatureGenerate() {
 
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
+      <View className="flex h-full flex-col items-center justify-center">
         <Text className="text-center text-neutral-900 dark:text-neutral-100">Generate new wallet</Text>
         <View className="flex flex-row items-center gap-2">
           <Button onPress={() => generate(128)} title="12 words" />

--- a/apps/mobile/src/features/onboarding/onboarding-feature-import.tsx
+++ b/apps/mobile/src/features/onboarding/onboarding-feature-import.tsx
@@ -4,8 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 export function OnboardingFeatureImport() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Import existing wallet</Text>
+      <View className="flex h-full flex-col items-center justify-center">
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">Import existing wallet</Text>
       </View>
     </SafeAreaView>
   )

--- a/apps/mobile/src/features/portfolio/portfolio-feature-index.tsx
+++ b/apps/mobile/src/features/portfolio/portfolio-feature-index.tsx
@@ -4,8 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 export function PortfolioFeatureIndex() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Portfolio</Text>
+      <View className="flex h-full flex-col items-center justify-center">
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">Portfolio</Text>
       </View>
     </SafeAreaView>
   )

--- a/apps/mobile/src/features/settings/settings-feature-general.tsx
+++ b/apps/mobile/src/features/settings/settings-feature-general.tsx
@@ -4,8 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 export function SettingsFeatureGeneral() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">General</Text>
+      <View className="flex h-full flex-col items-center justify-center">
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">General</Text>
       </View>
     </SafeAreaView>
   )

--- a/apps/mobile/src/features/settings/settings-feature-networks.tsx
+++ b/apps/mobile/src/features/settings/settings-feature-networks.tsx
@@ -4,8 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 export function SettingsFeatureNetworks() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Networks</Text>
+      <View className="flex h-full flex-col items-center justify-center">
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">Networks</Text>
       </View>
     </SafeAreaView>
   )

--- a/apps/mobile/src/features/settings/settings-feature-wallets.tsx
+++ b/apps/mobile/src/features/settings/settings-feature-wallets.tsx
@@ -4,8 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 export function SettingsFeatureWallets() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Wallets</Text>
+      <View className="flex h-full flex-col items-center justify-center">
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">Wallets</Text>
       </View>
     </SafeAreaView>
   )

--- a/apps/mobile/src/features/tools/tools-feature-airdrop.tsx
+++ b/apps/mobile/src/features/tools/tools-feature-airdrop.tsx
@@ -4,8 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 export function ToolsFeatureAirdrop() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Airdrop</Text>
+      <View className="flex h-full flex-col items-center justify-center">
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">Airdrop</Text>
       </View>
     </SafeAreaView>
   )

--- a/apps/mobile/src/features/tools/tools-feature-token-creator.tsx
+++ b/apps/mobile/src/features/tools/tools-feature-token-creator.tsx
@@ -4,8 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 export function ToolsFeatureTokenCreator() {
   return (
     <SafeAreaView>
-      <View className="flex flex-col h-full items-center justify-center">
-        <Text className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">TokenCreator</Text>
+      <View className="flex h-full flex-col items-center justify-center">
+        <Text className="font-bold text-2xl text-neutral-900 dark:text-neutral-100">TokenCreator</Text>
       </View>
     </SafeAreaView>
   )

--- a/apps/mobile/src/ui/ui-section-list.tsx
+++ b/apps/mobile/src/ui/ui-section-list.tsx
@@ -14,12 +14,12 @@ export function UiSectionList({ sections }: { sections: UiSectionItem[] }) {
     <SectionList
       keyExtractor={(item) => item.path}
       renderItem={({ item: { label, path, icon } }) => (
-        <View className="p-4 bg-neutral-50 dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100">
+        <View className="bg-neutral-50 p-4 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100">
           <Link className="w-full" params={{}} screen={path}>
-            <View className="flex flex-row items-center justify-between w-full">
+            <View className="flex w-full flex-row items-center justify-between">
               <View className="flex flex-row items-center gap-4 text-foreground dark:text-white">
                 <UiIcon icon={icon} />
-                <Text className="text-lg font-bold text-neutral-900 dark:text-neutral-100">{label}</Text>
+                <Text className="font-bold text-lg text-neutral-900 dark:text-neutral-100">{label}</Text>
               </View>
               <View>
                 <UiIcon icon="chevronRight" />

--- a/biome.json
+++ b/biome.json
@@ -56,6 +56,16 @@
       "complexity": {
         "useLiteralKeys": "off"
       },
+      "nursery": {
+        "useSortedClasses": {
+          "fix": "safe",
+          "level": "error",
+          "options": {
+            "attributes": ["classList"],
+            "functions": ["cn", "clsx", "cva", "tw"]
+          }
+        }
+      },
       "recommended": true,
       "style": {
         "useComponentExportOnlyModules": {

--- a/examples/basic/src/app.tsx
+++ b/examples/basic/src/app.tsx
@@ -24,8 +24,8 @@ export function App() {
 
   return (
     <div className="min-h-screen bg-black p-8 text-white">
-      <div className="max-w-2xl mx-auto text-center">
-        <h1 className="text-4xl font-bold mb-8">Wallets</h1>
+      <div className="mx-auto max-w-2xl text-center">
+        <h1 className="mb-8 font-bold text-4xl">Wallets</h1>
 
         {wallet ? (
           <div className="flex flex-col gap-4">
@@ -100,7 +100,7 @@ export function App() {
             ))}
           </div>
         ) : (
-          <p className="text-xl text-white/70">No wallets found</p>
+          <p className="text-white/70 text-xl">No wallets found</p>
         )}
       </div>
     </div>

--- a/examples/basic/src/components/ui/button.tsx
+++ b/examples/basic/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps } from 'react'
 import { cn } from '../../lib/utils.ts'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     defaultVariants: {
       size: 'default',
@@ -18,16 +18,16 @@ const buttonVariants = cva(
         'icon-lg': 'size-10',
         'icon-sm': 'size-8',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
       },
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
-          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
       },
     },

--- a/packages/dev/src/dev-feature-ui-avatars.tsx
+++ b/packages/dev/src/dev-feature-ui-avatars.tsx
@@ -4,7 +4,7 @@ import { UiCard } from '@workspace/ui/components/ui-card'
 export function DevFeatureUiAvatars() {
   return (
     <UiCard title="ui avatars">
-      <div className="grid gap-4 grid-cols-4 justify-items-center">
+      <div className="grid grid-cols-4 justify-items-center gap-4">
         <UiAvatar className="size-16" label="beeman" />
         <UiAvatar className="size-16" label="tobeycodes" />
         <UiAvatar className="size-16" label="beeman" src="https://github.com/beeman.png" />

--- a/packages/dev/src/dev-feature-ui-colors.tsx
+++ b/packages/dev/src/dev-feature-ui-colors.tsx
@@ -4,11 +4,11 @@ import { getColorByName, uiColorNames } from '@workspace/ui/lib/get-initials-col
 export function DevFeatureUiColors() {
   return (
     <UiCard title="ui colors">
-      <div className="grid gap-4 grid-cols-4">
+      <div className="grid grid-cols-4 gap-4">
         {uiColorNames.map((uiColorName) => {
           const { bg, text } = getColorByName(uiColorName)
           return (
-            <div className={`${bg} ${text} aspect-square flex justify-center items-center`} key={uiColorName}>
+            <div className={`${bg} ${text} flex aspect-square items-center justify-center`} key={uiColorName}>
               {uiColorName}
             </div>
           )

--- a/packages/dev/src/dev-feature-ui-icons.tsx
+++ b/packages/dev/src/dev-feature-ui-icons.tsx
@@ -5,7 +5,7 @@ import { getIconNames } from '@workspace/ui/components/ui-icon-map'
 export function DevFeatureUiIcons() {
   return (
     <UiCard title="ui icons">
-      <div className="grid gap-4 grid-cols-6 justify-items-center">
+      <div className="grid grid-cols-6 justify-items-center gap-4">
         {getIconNames().map((name) => (
           <div className="flex flex-col items-center" key={name}>
             <UiIcon icon={name} />

--- a/packages/explorer/src/explorer-feature-account-transactions.tsx
+++ b/packages/explorer/src/explorer-feature-account-transactions.tsx
@@ -48,7 +48,7 @@ export function ExplorerFeatureAccountTransactions({
               <ExplorerUiLinkTx basePath={basePath} signature={tx.signature} />
               <ExplorerUiTxExplorerIcon network={network} signature={tx.signature} />
             </div>
-            <div className="font-mono text-xs text-muted-foreground text-right">
+            <div className="text-right font-mono text-muted-foreground text-xs">
               <ExplorerUiTxTimestamp blockTime={tx.blockTime} />
             </div>
           </div>

--- a/packages/explorer/src/ui/explorer-ui-detail-row.tsx
+++ b/packages/explorer/src/ui/explorer-ui-detail-row.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from 'react'
 export function ExplorerUiDetailRow({ label, value }: { label: string; value: null | ReactNode | undefined }) {
   return (
     <div className="text-sm">
-      <div className="text-xs mb-1 opacity-60 tracking-wider uppercase">{label}</div>
-      <div className="font-medium break-all">{value ?? 'N/A'}</div>
+      <div className="mb-1 text-xs uppercase tracking-wider opacity-60">{label}</div>
+      <div className="break-all font-medium">{value ?? 'N/A'}</div>
     </div>
   )
 }

--- a/packages/explorer/src/ui/explorer-ui-explorer-icon.tsx
+++ b/packages/explorer/src/ui/explorer-ui-explorer-icon.tsx
@@ -14,7 +14,7 @@ export function ExplorerUiExplorerIcon({
   return (
     <UiTooltip content="View in Explorer">
       <a
-        className={cn('link font-mono inline-flex gap-1', className)}
+        className={cn('link inline-flex gap-1 font-mono', className)}
         href={href}
         rel="noopener noreferrer"
         target="_blank"

--- a/packages/explorer/src/ui/explorer-ui-explorer-link.tsx
+++ b/packages/explorer/src/ui/explorer-ui-explorer-link.tsx
@@ -16,7 +16,7 @@ export function ExplorerUiExplorerLink({
   return (
     <UiTooltip content={`View in ${name}`}>
       <a
-        className={cn('link font-mono inline-flex gap-1', className)}
+        className={cn('link inline-flex gap-1 font-mono', className)}
         href={href}
         rel="noopener noreferrer"
         target="_blank"

--- a/packages/explorer/src/ui/explorer-ui-link-address.tsx
+++ b/packages/explorer/src/ui/explorer-ui-link-address.tsx
@@ -8,7 +8,7 @@ export function ExplorerUiLinkAddress({ basePath, address }: { basePath: string;
   return (
     <span className="flex items-center gap-1">
       <Link
-        className="text-sm font-mono cursor-pointer"
+        className="cursor-pointer font-mono text-sm"
         state={{ from }}
         title={address}
         to={`${basePath}/address/${address}`}

--- a/packages/explorer/src/ui/explorer-ui-link-tx.tsx
+++ b/packages/explorer/src/ui/explorer-ui-link-tx.tsx
@@ -8,7 +8,7 @@ export function ExplorerUiLinkTx({ basePath, signature }: { basePath: string; si
   return (
     <span className="flex items-center gap-1">
       <Link
-        className="text-sm font-mono cursor-pointer"
+        className="cursor-pointer font-mono text-sm"
         state={{ from }}
         title={signature}
         to={`${basePath}/tx/${signature}`}

--- a/packages/explorer/src/ui/explorer-ui-tx-details.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-details.tsx
@@ -27,7 +27,7 @@ export function ExplorerUiTxDetails({
   }
   const feePayer = tx.transaction.message.accountKeys[0]
   return (
-    <div className="text-xs space-y-4">
+    <div className="space-y-4 text-xs">
       <ExplorerUiDetailRow
         label="View on Explorer"
         value={<ExplorerUiExplorers network={network} path={`/tx/${signature}`} />}
@@ -47,7 +47,7 @@ export function ExplorerUiTxDetails({
       <Separator />
       <ExplorerUiDetailRow
         label="Raw TX"
-        value={<pre className="text-[9px] overflow-auto">{JSON.stringify(tx, null, 2)}</pre>}
+        value={<pre className="overflow-auto text-[9px]">{JSON.stringify(tx, null, 2)}</pre>}
       />
     </div>
   )

--- a/packages/explorer/src/ui/explorer-ui-tx-status.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-status.tsx
@@ -3,8 +3,8 @@ import { UiIcon } from '@workspace/ui/components/ui-icon'
 
 export function ExplorerUiTxStatus({ tx }: { tx: GetActivityItem }) {
   return tx.err ? (
-    <UiIcon className="text-red-500 size-4" icon="circleX" />
+    <UiIcon className="size-4 text-red-500" icon="circleX" />
   ) : (
-    <UiIcon className="text-green-500 size-4" icon="checkCircle" />
+    <UiIcon className="size-4 text-green-500" icon="checkCircle" />
   )
 }

--- a/packages/onboarding/src/onboarding-feature-complete.tsx
+++ b/packages/onboarding/src/onboarding-feature-complete.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from '@workspace/i18n'
 export function OnboardingFeatureComplete() {
   const { t } = useTranslation('onboarding')
   return (
-    <div className="flex flex-col gap-6 items-center">
+    <div className="flex flex-col items-center gap-6">
       <div className="flex flex-col items-center space-y-2">
         <div className="text-2xl">{t(($) => $.onboardingPageTitle)}</div>
         <div className="text-lg text-muted-foreground">{t(($) => $.onboardingPageDescription)}</div>

--- a/packages/onboarding/src/onboarding-feature-import.tsx
+++ b/packages/onboarding/src/onboarding-feature-import.tsx
@@ -102,7 +102,7 @@ export function OnboardingFeatureImport({ redirectTo }: { redirectTo: string }) 
             </div>
           </div>
 
-          <div className={`grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-4`}>
+          <div className={`grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-3`}>
             {Array.from({ length: wordCount }, (_, i) => i).map((index) => (
               <OnboardingUiMnemonicWordInput
                 index={index + 1}
@@ -119,7 +119,7 @@ export function OnboardingFeatureImport({ redirectTo }: { redirectTo: string }) 
             ))}
           </div>
 
-          {error && <p className="text-red-500 text-sm mt-4 text-center">{error}</p>}
+          {error && <p className="mt-4 text-center text-red-500 text-sm">{error}</p>}
         </div>
       </UiCard>
     </form>

--- a/packages/onboarding/src/onboarding-feature-index.tsx
+++ b/packages/onboarding/src/onboarding-feature-index.tsx
@@ -8,13 +8,13 @@ export function OnboardingFeatureIndex() {
   const { t } = useTranslation('onboarding')
   const [accepted, setAccepted] = useSetting('warningAcceptExperimental')
   return (
-    <div className="flex flex-col gap-6 items-center">
+    <div className="flex flex-col items-center gap-6">
       <div className="flex flex-col items-center space-y-2">
         <div className="text-2xl">{t(($) => $.indexPageTitle)}</div>
         <div className="text-lg text-muted-foreground">{t(($) => $.indexPageDescription)}</div>
       </div>
       {accepted === 'true' ? null : <UiExperimentalWarning close={() => setAccepted('true')} />}
-      <div className="flex flex-col space-y-2 w-full">
+      <div className="flex w-full flex-col space-y-2">
         <Button asChild>
           <Link to="generate">{t(($) => $.indexLinkGenerate)}</Link>
         </Button>

--- a/packages/onboarding/src/onboarding-ui-mnemonic-word-input.tsx
+++ b/packages/onboarding/src/onboarding-ui-mnemonic-word-input.tsx
@@ -15,7 +15,7 @@ export function OnboardingUiMnemonicWordInput({
   return (
     <div className="relative">
       <Label
-        className="absolute -top-2 left-2 inline-block bg-white dark:bg-zinc-900 px-1 text-xs font-medium text-zinc-500 dark:text-zinc-400"
+        className="-top-2 absolute left-2 inline-block bg-white px-1 font-medium text-xs text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400"
         htmlFor={`word-${index}`}
       >
         {index}
@@ -23,7 +23,7 @@ export function OnboardingUiMnemonicWordInput({
       <Input
         autoComplete="off"
         autoCorrect="off"
-        className="block w-full rounded-md border-0 py-2.5 px-3 text-zinc-900 dark:text-zinc-50 bg-transparent shadow-sm ring-1 ring-inset ring-zinc-300 dark:ring-zinc-700 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:ring-2 focus:ring-inset focus:ring-blue-600 dark:focus:ring-blue-500 sm:text-sm sm:leading-6 transition-all duration-150"
+        className="block w-full rounded-md border-0 bg-transparent px-3 py-2.5 text-zinc-900 shadow-sm ring-1 ring-zinc-300 ring-inset transition-all duration-150 placeholder:text-zinc-400 focus:ring-2 focus:ring-blue-600 focus:ring-inset sm:text-sm sm:leading-6 dark:text-zinc-50 dark:ring-zinc-700 dark:focus:ring-blue-500 dark:placeholder:text-zinc-500"
         id={`word-${index}`}
         onChange={(event) => onChange(index - 1, event.target.value)}
         onPaste={(event) => {

--- a/packages/onboarding/src/ui/onboarding-ui-layout.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-layout.tsx
@@ -2,8 +2,8 @@ import { Outlet } from 'react-router'
 
 export function OnboardingUiLayout() {
   return (
-    <div className="min-h-full w-full flex items-center justify-center">
-      <div className="w-full px-2 sm:px-0 max-w-lg">
+    <div className="flex min-h-full w-full items-center justify-center">
+      <div className="w-full max-w-lg px-2 sm:px-0">
         <Outlet />
       </div>
     </div>

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-show.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-show.tsx
@@ -20,7 +20,7 @@ export function OnboardingUiMnemonicShow({ mnemonic }: { mnemonic: string }) {
     )
   }
   return (
-    <div className={`grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-4`}>
+    <div className={`grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-3`}>
       {words.map((word, index) => (
         <OnboardingUiMnemonicWordReadonly index={index} key={word} word={word} />
       ))}

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-word-readonly.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-word-readonly.tsx
@@ -5,7 +5,7 @@ export function OnboardingUiMnemonicWordReadonly({ index, word }: { index: numbe
   return (
     <div className="relative">
       <Label
-        className="absolute -top-2 left-2 inline-block bg-white dark:bg-zinc-900 px-1 text-xs font-medium text-zinc-500 dark:text-zinc-400"
+        className="-top-2 absolute left-2 inline-block bg-white px-1 font-medium text-xs text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400"
         htmlFor={`${word}-${index}`}
       >
         <span>{index + 1}</span>
@@ -13,7 +13,7 @@ export function OnboardingUiMnemonicWordReadonly({ index, word }: { index: numbe
       <Input
         autoComplete="off"
         autoCorrect="off"
-        className="block w-full rounded-md border-0 py-2.5 px-3 text-zinc-900 dark:text-zinc-50 bg-transparent shadow-sm ring-1 ring-inset ring-zinc-300 dark:ring-zinc-700 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:ring-2 focus:ring-inset focus:ring-blue-600 dark:focus:ring-blue-500 sm:text-sm sm:leading-6 transition-all duration-150"
+        className="block w-full rounded-md border-0 bg-transparent px-3 py-2.5 text-zinc-900 shadow-sm ring-1 ring-zinc-300 ring-inset transition-all duration-150 placeholder:text-zinc-400 focus:ring-2 focus:ring-blue-600 focus:ring-inset sm:text-sm sm:leading-6 dark:text-zinc-50 dark:ring-zinc-700 dark:focus:ring-blue-500 dark:placeholder:text-zinc-500"
         defaultValue={word}
         id={`${word}-${index}`}
         readOnly

--- a/packages/portfolio/src/portfolio-feature-tab-activity.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-activity.tsx
@@ -21,8 +21,8 @@ export function PortfolioFeatureTabActivity() {
 
   return (
     <div className="space-y-2">
-      <div className="flex justify-between items-center">
-        <h2 className="text-xl font-bold">{t(($) => $.pageTitleActivity)}</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="font-bold text-xl">{t(($) => $.pageTitleActivity)}</h2>
         <div className="space-x-2">
           <Button disabled={isLoading} onClick={() => refetch()} size="icon" variant="outline">
             {isLoading ? <Spinner /> : <UiIcon icon="refresh" />}

--- a/packages/portfolio/src/portfolio-routes.tsx
+++ b/packages/portfolio/src/portfolio-routes.tsx
@@ -7,10 +7,10 @@ import { PortfolioFeatureTabTokens } from './portfolio-feature-tab-tokens.tsx'
 export default function PortfolioRoutes() {
   const { t } = useTranslation('portfolio')
   return (
-    <UiPage className="lg:max-w-2xl md:max-w-2xl sm:max-w-2xl xl:max-w-2xl">
+    <UiPage className="sm:max-w-2xl md:max-w-2xl lg:max-w-2xl xl:max-w-2xl">
       <UiTabRoutes
         basePath="/portfolio"
-        className="items-center mb-4 lg:mb-6"
+        className="mb-4 items-center lg:mb-6"
         tabs={[
           { element: <PortfolioFeatureTabTokens />, label: t(($) => $.labelTokens), path: 'tokens' },
           { element: <PortfolioFeatureTabActivity />, label: t(($) => $.labelActivity), path: 'activity' },

--- a/packages/portfolio/src/ui/portfolio-ui-account-buttons.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-account-buttons.tsx
@@ -17,7 +17,7 @@ export function PortfolioUiAccountButtons({
   network: Network
 }) {
   return account ? (
-    <div className="gap-2 flex justify-center">
+    <div className="flex justify-center gap-2">
       <PortfolioUiAccountSheetReceive account={account} />
       <PortfolioUiAccountSheetSend balances={balances} isLoading={isLoading} send={send} />
     </div>

--- a/packages/portfolio/src/ui/portfolio-ui-account-form-token-dropdown.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-account-form-token-dropdown.tsx
@@ -32,7 +32,7 @@ export function PortfolioUiAccountFormTokenDropdown({
   return (
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger asChild>
-        <Button aria-expanded={open} className="w-full h-[60px] justify-between" role="combobox" variant="outline">
+        <Button aria-expanded={open} className="h-[60px] w-full justify-between" role="combobox" variant="outline">
           {mint ? <PortfolioUiTokenBalanceItem item={mint} /> : t(($) => $.searchInputSelect)}
           <UiIcon className="opacity-50" icon="chevronsUpDown" />
         </Button>

--- a/packages/portfolio/src/ui/portfolio-ui-activity-list.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-activity-list.tsx
@@ -29,7 +29,7 @@ export function PortfolioUiActivityList({
         <div className="space-y-4">
           {grouped.map(({ date, transactions }) => (
             <div className="space-y-4" key={date.getTime()}>
-              <div className="flex text-muted-foreground text-xs font-mono gap-2">
+              <div className="flex gap-2 font-mono text-muted-foreground text-xs">
                 <UiIcon className="size-4" icon="calendar" />
                 <UiTooltip content={`${date.toLocaleDateString()}`}>
                   <UiRelativeDate date={date} />
@@ -44,7 +44,7 @@ export function PortfolioUiActivityList({
                       <PortfolioUiTxLink from={from} tx={tx} />
                       <ExplorerUiExplorerIcon network={network} path={`/tx/${tx.signature}`} provider="solana" />
                     </div>
-                    <div className="font-mono text-xs text-muted-foreground whitespace-nowrap text-right truncate">
+                    <div className="truncate whitespace-nowrap text-right font-mono text-muted-foreground text-xs">
                       <ExplorerUiTxTimestamp blockTime={tx.blockTime} />
                     </div>
                   </div>

--- a/packages/portfolio/src/ui/portfolio-ui-balance-skeleton.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-balance-skeleton.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from '@workspace/ui/components/skeleton'
 
 export function PortfolioUiBalanceSkeleton() {
-  return <Skeleton className="w-24 h-10 mx-auto" />
+  return <Skeleton className="mx-auto h-10 w-24" />
 }

--- a/packages/portfolio/src/ui/portfolio-ui-balance.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-balance.tsx
@@ -1,3 +1,3 @@
 export function PortfolioUiBalance({ balance }: { balance: string }) {
-  return <div className="text-4xl font-bold text-center">${balance}</div>
+  return <div className="text-center font-bold text-4xl">${balance}</div>
 }

--- a/packages/portfolio/src/ui/portfolio-ui-token-balance-item-skeleton.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balance-item-skeleton.tsx
@@ -2,18 +2,18 @@ import { Skeleton } from '@workspace/ui/components/skeleton'
 
 export function PortfolioUiTokenBalanceItemSkeleton() {
   return (
-    <div className="flex justify-between items-center w-full">
+    <div className="flex w-full items-center justify-between">
       <div className="flex items-center gap-2">
-        <div className="flex justify-center items-center size-14">
+        <div className="flex size-14 items-center justify-center">
           <Skeleton className="size-12 rounded-full" />
         </div>
-        <div className="flex flex-col items-start mr-6">
-          <Skeleton className="h-5 w-20 mb-2" />
+        <div className="mr-6 flex flex-col items-start">
+          <Skeleton className="mb-2 h-5 w-20" />
           <Skeleton className="h-5 w-12" />
         </div>
       </div>
-      <div className="flex flex-col items-end grow">
-        <Skeleton className="h-6 w-16 mb-1" />
+      <div className="flex grow flex-col items-end">
+        <Skeleton className="mb-1 h-6 w-16" />
         <Skeleton className="h-5 w-12" />
       </div>
     </div>

--- a/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
@@ -8,16 +8,16 @@ export function PortfolioUiTokenBalanceItem({ item }: { item: TokenBalance }) {
   const symbol = item.metadata?.symbol ?? ellipsify(item.mint, 2, '').toLocaleUpperCase()
   const icon = item.metadata?.icon
   return (
-    <div className="flex justify-between items-center w-full" key={item.mint}>
+    <div className="flex w-full items-center justify-between" key={item.mint}>
       <div className="flex items-center gap-2">
-        <div className="flex justify-center items-center size-14">
+        <div className="flex size-14 items-center justify-center">
           {icon ? (
             <UiAvatar className="size-12" label={name} src={icon} />
           ) : (
             <UiAvatar className="size-12" label={symbol} />
           )}
         </div>
-        <div className="flex flex-col items-start mr-6">
+        <div className="mr-6 flex flex-col items-start">
           <div className="font-bold">{name}</div>
           <div className="text-muted-foreground">{symbol}</div>
         </div>

--- a/packages/portfolio/src/ui/portfolio-ui-tx-link.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-tx-link.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router'
 
 export function PortfolioUiTxLink({ from, tx }: { from: string; tx: GetActivityItem }) {
   return (
-    <Link className="text-sm font-mono cursor-pointer" state={{ from }} to={`/explorer/tx/${tx.signature}`}>
+    <Link className="cursor-pointer font-mono text-sm" state={{ from }} to={`/explorer/tx/${tx.signature}`}>
       {ellipsify(tx.signature, 8)}
     </Link>
   )

--- a/packages/portfolio/src/ui/portfolio-ui-tx-status.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-tx-status.tsx
@@ -3,8 +3,8 @@ import { UiIcon } from '@workspace/ui/components/ui-icon'
 
 export function PortfolioUiTxStatus({ tx }: { tx: GetActivityItem }) {
   return tx.err ? (
-    <UiIcon className="text-red-500 size-4" icon="circleX" />
+    <UiIcon className="size-4 text-red-500" icon="circleX" />
   ) : (
-    <UiIcon className="text-green-500 size-4" icon="checkCircle" />
+    <UiIcon className="size-4 text-green-500" icon="checkCircle" />
   )
 }

--- a/packages/settings/src/settings-feature-reset.tsx
+++ b/packages/settings/src/settings-feature-reset.tsx
@@ -10,7 +10,7 @@ export default function SettingsFeatureReset() {
         description="Make sure that you have a copy of the data."
         title="Reset application database"
       >
-        <div className="text-red-500 font-bold text-center border border-red-500 py-4 rounded-md">
+        <div className="rounded-md border border-red-500 py-4 text-center font-bold text-red-500">
           THIS ACTION CAN NOT BE REVERSED
         </div>
         <SettingsFeatureGeneralDangerDeleteDatabase />

--- a/packages/settings/src/settings-feature-wallet-details.tsx
+++ b/packages/settings/src/settings-feature-wallet-details.tsx
@@ -34,7 +34,7 @@ export function SettingsFeatureWalletDetails() {
     <UiCard
       backButtonTo="/settings/wallets"
       title={
-        <div className="w-full flex items-center justify-between">
+        <div className="flex w-full items-center justify-between">
           <SettingsUiWalletItem item={item} />
           <div className="flex items-center gap-2">
             <UiTooltip content={t(($) => $.actionEditWallet)}>

--- a/packages/settings/src/ui/settings-ui-layout.tsx
+++ b/packages/settings/src/ui/settings-ui-layout.tsx
@@ -8,7 +8,7 @@ export function SettingsUiLayout() {
 
   return (
     <UiPage>
-      <div className="grid grid-cols-1 md:grid-cols-3 md:gap-4 gap-y-2 md:gap-y-4">
+      <div className="grid grid-cols-1 gap-y-2 md:grid-cols-3 md:gap-4 md:gap-y-4">
         <div>
           <SettingsUiPageList pages={pages} />
         </div>

--- a/packages/settings/src/ui/settings-ui-network-form-create.tsx
+++ b/packages/settings/src/ui/settings-ui-network-form-create.tsx
@@ -33,11 +33,11 @@ export function SettingsUiNetworkFormCreate({ submit }: { submit: (input: Networ
           control={form.control}
           name="type"
           render={({ field }) => (
-            <FormItem className="flex flex-col gap-2 w-full py-1">
+            <FormItem className="flex w-full flex-col gap-2 py-1">
               <FormLabel>{t(($) => $.networkInputTypeLabel)} *</FormLabel>
               <FormControl>
                 <ToggleGroup
-                  className="flex justify-start items-center flex-wrap"
+                  className="flex flex-wrap items-center justify-start"
                   onValueChange={field.onChange}
                   type="single"
                   value={field.value}
@@ -116,7 +116,7 @@ export function SettingsUiNetworkFormCreate({ submit }: { submit: (input: Networ
           )}
           rules={{ required: false }}
         />
-        <div className="flex justify-end items-center w-full pt-3">
+        <div className="flex w-full items-center justify-end pt-3">
           <Button className="rounded-lg" size="sm">
             {t(($) => $.actionSave)}
           </Button>

--- a/packages/settings/src/ui/settings-ui-network-form-update.tsx
+++ b/packages/settings/src/ui/settings-ui-network-form-update.tsx
@@ -35,11 +35,11 @@ export function SettingsUiNetworkFormUpdate({
   return (
     <Form {...form}>
       <form className="flex flex-col gap-6" onSubmit={form.handleSubmit((input) => submit(input))}>
-        <FormItem className="flex flex-col gap-2 w-full py-1">
+        <FormItem className="flex w-full flex-col gap-2 py-1">
           <FormLabel>{t(($) => $.networkInputTypeLabel)}</FormLabel>
           <FormControl>
             <ToggleGroup
-              className="flex justify-start items-center flex-wrap"
+              className="flex flex-wrap items-center justify-start"
               defaultValue={item.type}
               disabled
               type="single"
@@ -116,7 +116,7 @@ export function SettingsUiNetworkFormUpdate({
           )}
           rules={{ required: true }}
         />
-        <div className="flex justify-end items-center w-full pt-3">
+        <div className="flex w-full items-center justify-end pt-3">
           <Button className="rounded-lg" size="sm">
             {t(($) => $.actionSave)}
           </Button>

--- a/packages/settings/src/ui/settings-ui-network-list.tsx
+++ b/packages/settings/src/ui/settings-ui-network-list.tsx
@@ -21,7 +21,7 @@ export function SettingsUiNetworkList({
     <ItemGroup className="gap-2 md:gap-4">
       {items.map((item) => (
         <Item
-          className="items-stretch flex-row items-center"
+          className="flex-row items-center items-stretch"
           key={item.id}
           role="listitem"
           variant={activeId === item.id ? 'muted' : 'outline'}
@@ -48,7 +48,7 @@ export function SettingsUiNetworkList({
                 title="Are you sure you want to delete this network?"
               >
                 <Button size="icon" variant="outline">
-                  <UiIcon className="text-red-500 size-4" icon="delete" />
+                  <UiIcon className="size-4 text-red-500" icon="delete" />
                 </Button>
               </UiConfirm>
             </UiTooltip>

--- a/packages/settings/src/ui/settings-ui-page-header-title.tsx
+++ b/packages/settings/src/ui/settings-ui-page-header-title.tsx
@@ -1,5 +1,5 @@
 import type { SettingsPage } from '../data-access/settings-page.ts'
 
 export function SettingsUiPageHeaderTitle({ page: { name } }: { page: SettingsPage }) {
-  return <span className="text-lg font-bold">{name}</span>
+  return <span className="font-bold text-lg">{name}</span>
 }

--- a/packages/settings/src/ui/settings-ui-page-header.tsx
+++ b/packages/settings/src/ui/settings-ui-page-header.tsx
@@ -4,7 +4,7 @@ import { SettingsUiPageHeaderTitle } from './settings-ui-page-header-title.tsx'
 
 export function SettingsUiPageHeader({ page }: { page: SettingsPage }) {
   return (
-    <div className="px-2 flex gap-2 items-center">
+    <div className="flex items-center gap-2 px-2">
       <UiIcon icon={page.icon} />
       <SettingsUiPageHeaderTitle page={page} />
     </div>

--- a/packages/settings/src/ui/settings-ui-wallet-form-generate.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-form-generate.tsx
@@ -89,7 +89,7 @@ export function SettingsUiWalletFormGenerate({
           )}
           rules={{ required: false }}
         />
-        <div className="flex justify-end items-center w-full pt-3">
+        <div className="flex w-full items-center justify-end pt-3">
           <Button size="lg">{t(($) => $.actionGenerate)}</Button>
         </div>
       </form>

--- a/packages/settings/src/ui/settings-ui-wallet-form-import.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-form-import.tsx
@@ -82,7 +82,7 @@ export function SettingsUiWalletFormImport({
           )}
           rules={{ required: false }}
         />
-        <div className="flex justify-end items-center w-full pt-3 gap-4">
+        <div className="flex w-full items-center justify-end gap-4 pt-3">
           <div className="flex items-center space-x-2">
             <Switch checked={redirect} id={redirectId} onCheckedChange={setRedirect} />
             <Label htmlFor={redirectId}>{t(($) => $.walletInputRedirectLabel)}</Label>

--- a/packages/settings/src/ui/settings-ui-wallet-form-update.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-form-update.tsx
@@ -52,7 +52,7 @@ export function SettingsUiWalletFormUpdate({
           )}
           rules={{ required: false }}
         />
-        <div className="flex justify-end items-center w-full pt-3">
+        <div className="flex w-full items-center justify-end pt-3">
           <Button className="rounded-lg" size="sm">
             {t(($) => $.actionSave)}
           </Button>

--- a/packages/settings/src/ui/settings-ui-wallet-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-list-item.tsx
@@ -46,7 +46,7 @@ export function SettingsUiWalletListItem({
             title="Are you sure you want to delete this wallet?"
           >
             <Button size="icon" variant="outline">
-              <UiIcon className="text-red-500 size-4" icon="delete" />
+              <UiIcon className="size-4 text-red-500" icon="delete" />
             </Button>
           </UiConfirm>
         </UiTooltip>

--- a/packages/shell/src/ui/shell-ui-layout.tsx
+++ b/packages/shell/src/ui/shell-ui-layout.tsx
@@ -31,10 +31,10 @@ export function ShellUiLayout({ browser, context }: ShellFeatureProps) {
   ]
 
   return (
-    <div className="h-full flex flex-col justify-between items-stretch">
+    <div className="flex h-full flex-col items-stretch justify-between">
       <ShellUiWarningExperimental />
       <ShellUiCommandMenu />
-      <header className="bg-secondary/50 flex items-center justify-between">
+      <header className="flex items-center justify-between bg-secondary/50">
         <ShellUiMenu />
         <div className="pr-2">
           <ShellUiMenuActions browser={browser} context={context} />
@@ -43,12 +43,12 @@ export function ShellUiLayout({ browser, context }: ShellFeatureProps) {
       <main className="flex-1 overflow-y-auto p-1 md:p-2 lg:p-4">
         <Outlet />
       </main>
-      <footer className="bg-secondary/50 flex justify-between items-center">
+      <footer className="flex items-center justify-between bg-secondary/50">
         {links.map(({ icon, label, to }) => (
           <NavLink
             className={({ isActive }) =>
-              cn('items-center truncate text-xs md:text-md gap-1 md:gap-2 pt-2 pb-1 flex flex-col flex-1', {
-                'font-semibold bg-secondary/60': isActive,
+              cn('flex flex-1 flex-col items-center gap-1 truncate pt-2 pb-1 text-xs md:gap-2 md:text-md', {
+                'bg-secondary/60 font-semibold': isActive,
               })
             }
             key={to}

--- a/packages/shell/src/ui/shell-ui-menu-development.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-development.tsx
@@ -7,7 +7,7 @@ export function ShellUiMenuDevelopment({ items }: { items: { label: string; path
   const [developerMode] = useSetting('developerModeEnabled')
   return developerMode === 'true' ? (
     <MenubarMenu>
-      <MenubarTrigger className="gap-2 h-8 md:h-12 px-2 md:px-4">
+      <MenubarTrigger className="h-8 gap-2 px-2 md:h-12 md:px-4">
         <UiIcon className="size-4 md:size-6" icon="bug" />
       </MenubarTrigger>
       <MenubarContent>

--- a/packages/shell/src/ui/shell-ui-menu-network.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-network.tsx
@@ -25,7 +25,7 @@ export function ShellUiMenuNetwork({
   const { t } = useTranslation('shell')
   return (
     <MenubarMenu>
-      <MenubarTrigger className="gap-2 h-8 md:h-12 px-2 md:px-4">
+      <MenubarTrigger className="h-8 gap-2 px-2 md:h-12 md:px-4">
         <UiIcon className="size-4 md:size-6" icon="network" />
         {active.name}
       </MenubarTrigger>

--- a/packages/shell/src/ui/shell-ui-menu-wallets.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-wallets.tsx
@@ -33,7 +33,7 @@ export function ShellUiMenuWallets({
   const { t } = useTranslation('shell')
   return (
     <MenubarMenu>
-      <MenubarTrigger asChild className="py-2 gap-2 h-8 md:h-12 px-1 md:px-2 md:min-w-[150px]">
+      <MenubarTrigger asChild className="h-8 gap-2 px-1 py-2 md:h-12 md:min-w-[150px] md:px-2">
         <div className="flex items-center gap-2">
           <UiAvatar className="size-6 md:size-8" label={activeWallet.name} />
           {activeAccount.name}

--- a/packages/shell/src/ui/shell-ui-menu.tsx
+++ b/packages/shell/src/ui/shell-ui-menu.tsx
@@ -19,7 +19,7 @@ export function ShellUiMenu() {
   const activeNetwork = useMemo(() => items.find((c) => c.id === activeId), [items, activeId])
 
   return (
-    <Menubar className="py-2 h-10 md:h-14 bg-transparent border-none">
+    <Menubar className="h-10 border-none bg-transparent py-2 md:h-14">
       {activeAccount && activeWallet ? (
         <ShellUiMenuWallets
           activeAccount={activeAccount}

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -13,7 +13,7 @@ function Accordion({ ...props }: ComponentProps<typeof AccordionPrimitive.Root>)
 function AccordionContent({ children, className, ...props }: ComponentProps<typeof AccordionPrimitive.Content>) {
   return (
     <AccordionPrimitive.Content
-      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
       data-slot="accordion-content"
       {...props}
     >
@@ -37,14 +37,14 @@ function AccordionTrigger({ children, className, ...props }: ComponentProps<type
     <AccordionPrimitive.Header className="flex">
       <AccordionPrimitive.Trigger
         className={cn(
-          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          'flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left font-medium text-sm outline-none transition-all hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
           className,
         )}
         data-slot="accordion-trigger"
         {...props}
       >
         {children}
-        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   )

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -21,7 +21,7 @@ function AlertDialogOverlay({ className, ...props }: React.ComponentProps<typeof
   return (
     <AlertDialogPrimitive.Overlay
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in',
         className,
       )}
       data-slot="alert-dialog-overlay"
@@ -36,7 +36,7 @@ function AlertDialogContent({ className, ...props }: React.ComponentProps<typeof
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg',
           className,
         )}
         data-slot="alert-dialog-content"
@@ -69,7 +69,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>)
 function AlertDialogTitle({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
   return (
     <AlertDialogPrimitive.Title
-      className={cn('text-lg font-semibold', className)}
+      className={cn('font-semibold text-lg', className)}
       data-slot="alert-dialog-title"
       {...props}
     />

--- a/packages/ui/src/components/alert.tsx
+++ b/packages/ui/src/components/alert.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from 'react'
 import { cn } from '../lib/utils.ts'
 
 const alertVariants = cva(
-  'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
   {
     defaultVariants: {
       variant: 'default',
@@ -13,9 +13,9 @@ const alertVariants = cva(
       variant: {
         default: 'bg-card text-card-foreground',
         destructive:
-          'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+          'bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
         warning:
-          'border-yellow-500 text-yellow-500 bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-yellow-500/90',
+          'border-yellow-500 bg-card text-yellow-500 *:data-[slot=alert-description]:text-yellow-500/90 [&>svg]:text-current',
       },
     },
   },
@@ -29,7 +29,7 @@ function AlertDescription({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+        'col-start-2 grid justify-items-start gap-1 text-muted-foreground text-sm [&_p]:leading-relaxed',
         className,
       )}
       data-slot="alert-description"

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -18,7 +18,7 @@ function Avatar({ className, ...props }: ComponentProps<typeof AvatarPrimitive.R
 function AvatarFallback({ className, ...props }: ComponentProps<typeof AvatarPrimitive.Fallback>) {
   return (
     <AvatarPrimitive.Fallback
-      className={cn('bg-muted flex size-full items-center justify-center rounded-full', className)}
+      className={cn('flex size-full items-center justify-center rounded-full bg-muted', className)}
       data-slot="avatar-fallback"
       {...props}
     />

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps } from 'react'
 import { cn } from '../lib/utils.ts'
 
 const badgeVariants = cva(
-  'inline-flex items-center justify-center rounded-md border px-1 md:px-2 py-0.5 text-[10px] md:text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  'inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden whitespace-nowrap rounded-md border px-1 py-0.5 font-medium text-[10px] transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:px-2 md:text-xs dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3',
   {
     defaultVariants: {
       variant: 'default',
@@ -14,7 +14,7 @@ const badgeVariants = cva(
       variant: {
         default: 'border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
         destructive:
-          'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'border-transparent bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90',
         outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
         secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
       },

--- a/packages/ui/src/components/button-group.tsx
+++ b/packages/ui/src/components/button-group.tsx
@@ -6,7 +6,7 @@ import { cn } from '../lib/utils.ts'
 import { Separator } from './separator.tsx'
 
 const buttonGroupVariants = cva(
-  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2",
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
   {
     defaultVariants: {
       orientation: 'horizontal',
@@ -42,7 +42,7 @@ function ButtonGroup({
 function ButtonGroupSeparator({ className, orientation = 'vertical', ...props }: ComponentProps<typeof Separator>) {
   return (
     <Separator
-      className={cn('bg-input relative !m-0 self-stretch data-[orientation=vertical]:h-auto', className)}
+      className={cn('!m-0 relative self-stretch bg-input data-[orientation=vertical]:h-auto', className)}
       data-slot="button-group-separator"
       orientation={orientation}
       {...props}
@@ -62,7 +62,7 @@ function ButtonGroupText({
   return (
     <Comp
       className={cn(
-        "bg-muted flex items-center gap-2 rounded-md border px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        "flex items-center gap-2 rounded-md border bg-muted px-4 font-medium text-sm shadow-xs [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps } from 'react'
 import { cn } from '../lib/utils.ts'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     defaultVariants: {
       size: 'default',
@@ -13,19 +13,19 @@ const buttonVariants = cva(
     },
     variants: {
       size: {
-        default: 'h-7 md:h-9 px-2 md:px-4 py-1 md:py-2 has-[>svg]:px-3',
+        default: 'h-7 px-2 py-1 has-[>svg]:px-3 md:h-9 md:px-4 md:py-2',
         icon: 'size-7 md:size-9',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        sm: 'h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5',
       },
       variant: {
         default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
         destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
       },
     },

--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -51,7 +51,7 @@ function Calendar({
     <DayPicker
       captionLayout={captionLayout}
       className={cn(
-        'bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+        'group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className,
@@ -59,43 +59,43 @@ function Calendar({
       classNames={{
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
+          'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
           defaultClassNames.button_next,
         ),
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
-          'size-(--cell-size) aria-disabled:opacity-50 p-0 select-none',
+          'size-(--cell-size) select-none p-0 aria-disabled:opacity-50',
           defaultClassNames.button_previous,
         ),
         caption_label: cn(
           'select-none font-medium',
           captionLayout === 'label'
             ? 'text-sm'
-            : 'rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5',
+            : 'flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
           defaultClassNames.caption_label,
         ),
         day: cn(
-          'relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none',
+          'group/day relative aspect-square h-full w-full select-none p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md',
           defaultClassNames.day,
         ),
         disabled: cn('text-muted-foreground opacity-50', defaultClassNames.disabled),
-        dropdown: cn('absolute bg-popover inset-0 opacity-0', defaultClassNames.dropdown),
+        dropdown: cn('absolute inset-0 bg-popover opacity-0', defaultClassNames.dropdown),
         dropdown_root: cn(
-          'relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md',
+          'relative rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50',
           defaultClassNames.dropdown_root,
         ),
         dropdowns: cn(
-          'w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5',
+          'flex h-(--cell-size) w-full items-center justify-center gap-1.5 font-medium text-sm',
           defaultClassNames.dropdowns,
         ),
         hidden: cn('invisible', defaultClassNames.hidden),
-        month: cn('flex flex-col w-full gap-4', defaultClassNames.month),
+        month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
         month_caption: cn(
-          'flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)',
+          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
           defaultClassNames.month_caption,
         ),
-        months: cn('flex gap-4 flex-col md:flex-row relative', defaultClassNames.months),
-        nav: cn('flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between', defaultClassNames.nav),
+        months: cn('relative flex flex-col gap-4 md:flex-row', defaultClassNames.months),
+        nav: cn('absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1', defaultClassNames.nav),
         outside: cn('text-muted-foreground aria-selected:text-muted-foreground', defaultClassNames.outside),
         range_end: cn('rounded-r-md bg-accent', defaultClassNames.range_end),
         range_middle: cn('rounded-none', defaultClassNames.range_middle),
@@ -103,14 +103,14 @@ function Calendar({
         root: cn('w-fit', defaultClassNames.root),
         table: 'w-full border-collapse',
         today: cn(
-          'bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none',
+          'rounded-md bg-accent text-accent-foreground data-[selected=true]:rounded-none',
           defaultClassNames.today,
         ),
-        week: cn('flex w-full mt-2', defaultClassNames.week),
-        week_number: cn('text-[0.8rem] select-none text-muted-foreground', defaultClassNames.week_number),
-        week_number_header: cn('select-none w-(--cell-size)', defaultClassNames.week_number_header),
+        week: cn('mt-2 flex w-full', defaultClassNames.week),
+        week_number: cn('select-none text-[0.8rem] text-muted-foreground', defaultClassNames.week_number),
+        week_number_header: cn('w-(--cell-size) select-none', defaultClassNames.week_number_header),
         weekday: cn(
-          'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',
+          'flex-1 select-none rounded-md font-normal text-[0.8rem] text-muted-foreground',
           defaultClassNames.weekday,
         ),
         weekdays: cn('flex', defaultClassNames.weekdays),
@@ -141,7 +141,7 @@ function CalendarDayButton({ className, day, modifiers, ...props }: ComponentPro
   return (
     <Button
       className={cn(
-        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70',
+        'flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-start=true]:rounded-l-md data-[range-end=true]:bg-primary data-[range-middle=true]:bg-accent data-[range-start=true]:bg-primary data-[selected-single=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:text-accent-foreground data-[range-start=true]:text-primary-foreground data-[selected-single=true]:text-primary-foreground group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground [&>span]:text-xs [&>span]:opacity-70',
         defaultClassNames.day,
         className,
       )}

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -5,7 +5,7 @@ function Card({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-2 md:gap-6 rounded-xl border py-2 md:py-6 shadow-sm',
+        'flex flex-col gap-2 rounded-xl border bg-card py-2 text-card-foreground shadow-sm md:gap-6 md:py-6',
         className,
       )}
       data-slot="card"
@@ -35,7 +35,7 @@ function CardDescription({ className, ...props }: ComponentProps<'div'>) {
 function CardFooter({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
-      className={cn('flex items-center mx-2 md:px-6 [.border-t]:pt-6', className)}
+      className={cn('mx-2 flex items-center md:px-6 [.border-t]:pt-6', className)}
       data-slot="card-footer"
       {...props}
     />
@@ -46,7 +46,7 @@ function CardHeader({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 mx-2 md:px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        '@container/card-header mx-2 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 has-data-[slot=card-action]:grid-cols-[1fr_auto] md:px-6 [.border-b]:pb-6',
         className,
       )}
       data-slot="card-header"
@@ -56,7 +56,7 @@ function CardHeader({ className, ...props }: ComponentProps<'div'>) {
 }
 
 function CardTitle({ className, ...props }: ComponentProps<'div'>) {
-  return <div className={cn('leading-none font-semibold', className)} data-slot="card-title" {...props} />
+  return <div className={cn('font-semibold leading-none', className)} data-slot="card-title" {...props} />
 }
 
 export { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -10,7 +10,7 @@ function Checkbox({ className, ...props }: ComponentProps<typeof CheckboxPrimiti
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:data-[state=checked]:bg-primary dark:aria-invalid:ring-destructive/40',
         className,
       )}
       data-slot="checkbox"

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -11,7 +11,7 @@ function Command({ className, ...props }: ComponentProps<typeof CommandPrimitive
   return (
     <CommandPrimitive
       className={cn(
-        'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
         className,
       )}
       data-slot="command"
@@ -40,7 +40,7 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent className={cn('overflow-hidden p-0', className)} showCloseButton={showCloseButton}>
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -56,7 +56,7 @@ function CommandGroup({ className, ...props }: ComponentProps<typeof CommandPrim
   return (
     <CommandPrimitive.Group
       className={cn(
-        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:text-xs',
         className,
       )}
       data-slot="command-group"
@@ -71,7 +71,7 @@ function CommandInput({ className, ...props }: ComponentProps<typeof CommandPrim
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         className={cn(
-          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         data-slot="command-input"
@@ -85,7 +85,7 @@ function CommandItem({ className, ...props }: ComponentProps<typeof CommandPrimi
   return (
     <CommandPrimitive.Item
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="command-item"
@@ -97,7 +97,7 @@ function CommandItem({ className, ...props }: ComponentProps<typeof CommandPrimi
 function CommandList({ className, ...props }: ComponentProps<typeof CommandPrimitive.List>) {
   return (
     <CommandPrimitive.List
-      className={cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
+      className={cn('max-h-[300px] scroll-py-1 overflow-y-auto overflow-x-hidden', className)}
       data-slot="command-list"
       {...props}
     />
@@ -107,7 +107,7 @@ function CommandList({ className, ...props }: ComponentProps<typeof CommandPrimi
 function CommandSeparator({ className, ...props }: ComponentProps<typeof CommandPrimitive.Separator>) {
   return (
     <CommandPrimitive.Separator
-      className={cn('bg-border -mx-1 h-px', className)}
+      className={cn('-mx-1 h-px bg-border', className)}
       data-slot="command-separator"
       {...props}
     />
@@ -117,7 +117,7 @@ function CommandSeparator({ className, ...props }: ComponentProps<typeof Command
 function CommandShortcut({ className, ...props }: ComponentProps<'span'>) {
   return (
     <span
-      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      className={cn('ml-auto text-muted-foreground text-xs tracking-widest', className)}
       data-slot="command-shortcut"
       {...props}
     />

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -20,7 +20,7 @@ function ContextMenuCheckboxItem({
     <ContextMenuPrimitive.CheckboxItem
       checked={checked}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="context-menu-checkbox-item"
@@ -41,7 +41,7 @@ function ContextMenuContent({ className, ...props }: ComponentProps<typeof Conte
     <ContextMenuPrimitive.Portal>
       <ContextMenuPrimitive.Content
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in',
           className,
         )}
         data-slot="context-menu-content"
@@ -67,7 +67,7 @@ function ContextMenuItem({
   return (
     <ContextMenuPrimitive.Item
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[variant=destructive]:*:[svg]:!text-destructive relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-inset={inset}
@@ -87,7 +87,7 @@ function ContextMenuLabel({
 } & ComponentProps<typeof ContextMenuPrimitive.Label>) {
   return (
     <ContextMenuPrimitive.Label
-      className={cn('text-foreground px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      className={cn('px-2 py-1.5 font-medium text-foreground text-sm data-[inset]:pl-8', className)}
       data-inset={inset}
       data-slot="context-menu-label"
       {...props}
@@ -111,7 +111,7 @@ function ContextMenuRadioItem({
   return (
     <ContextMenuPrimitive.RadioItem
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="context-menu-radio-item"
@@ -130,7 +130,7 @@ function ContextMenuRadioItem({
 function ContextMenuSeparator({ className, ...props }: ComponentProps<typeof ContextMenuPrimitive.Separator>) {
   return (
     <ContextMenuPrimitive.Separator
-      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       data-slot="context-menu-separator"
       {...props}
     />
@@ -140,7 +140,7 @@ function ContextMenuSeparator({ className, ...props }: ComponentProps<typeof Con
 function ContextMenuShortcut({ className, ...props }: ComponentProps<'span'>) {
   return (
     <span
-      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      className={cn('ml-auto text-muted-foreground text-xs tracking-widest', className)}
       data-slot="context-menu-shortcut"
       {...props}
     />
@@ -155,7 +155,7 @@ function ContextMenuSubContent({ className, ...props }: ComponentProps<typeof Co
   return (
     <ContextMenuPrimitive.SubContent
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in',
         className,
       )}
       data-slot="context-menu-sub-content"
@@ -175,7 +175,7 @@ function ContextMenuSubTrigger({
   return (
     <ContextMenuPrimitive.SubTrigger
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-inset={inset}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -27,7 +27,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg',
           className,
         )}
         data-slot="dialog-content"
@@ -36,7 +36,7 @@ function DialogContent({
         {children}
         {showCloseButton && (
           <DialogPrimitive.Close
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
             data-slot="dialog-close"
           >
             <XIcon />
@@ -82,7 +82,7 @@ function DialogOverlay({ className, ...props }: ComponentProps<typeof DialogPrim
   return (
     <DialogPrimitive.Overlay
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in',
         className,
       )}
       data-slot="dialog-overlay"
@@ -98,7 +98,7 @@ function DialogPortal({ ...props }: ComponentProps<typeof DialogPrimitive.Portal
 function DialogTitle({ className, ...props }: ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
-      className={cn('text-lg leading-none font-semibold', className)}
+      className={cn('font-semibold text-lg leading-none', className)}
       data-slot="dialog-title"
       {...props}
     />

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -20,7 +20,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       checked={checked}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="dropdown-menu-checkbox-item"
@@ -45,7 +45,7 @@ function DropdownMenuContent({
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in',
           className,
         )}
         data-slot="dropdown-menu-content"
@@ -72,7 +72,7 @@ function DropdownMenuItem({
   return (
     <DropdownMenuPrimitive.Item
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[variant=destructive]:*:[svg]:!text-destructive relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-inset={inset}
@@ -92,7 +92,7 @@ function DropdownMenuLabel({
 } & ComponentProps<typeof DropdownMenuPrimitive.Label>) {
   return (
     <DropdownMenuPrimitive.Label
-      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      className={cn('px-2 py-1.5 font-medium text-sm data-[inset]:pl-8', className)}
       data-inset={inset}
       data-slot="dropdown-menu-label"
       {...props}
@@ -116,7 +116,7 @@ function DropdownMenuRadioItem({
   return (
     <DropdownMenuPrimitive.RadioItem
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="dropdown-menu-radio-item"
@@ -135,7 +135,7 @@ function DropdownMenuRadioItem({
 function DropdownMenuSeparator({ className, ...props }: ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
   return (
     <DropdownMenuPrimitive.Separator
-      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       data-slot="dropdown-menu-separator"
       {...props}
     />
@@ -145,7 +145,7 @@ function DropdownMenuSeparator({ className, ...props }: ComponentProps<typeof Dr
 function DropdownMenuShortcut({ className, ...props }: ComponentProps<'span'>) {
   return (
     <span
-      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      className={cn('ml-auto text-muted-foreground text-xs tracking-widest', className)}
       data-slot="dropdown-menu-shortcut"
       {...props}
     />
@@ -160,7 +160,7 @@ function DropdownMenuSubContent({ className, ...props }: ComponentProps<typeof D
   return (
     <DropdownMenuPrimitive.SubContent
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in',
         className,
       )}
       data-slot="dropdown-menu-sub-content"
@@ -180,7 +180,7 @@ function DropdownMenuSubTrigger({
   return (
     <DropdownMenuPrimitive.SubTrigger
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+        'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground',
         className,
       )}
       data-inset={inset}

--- a/packages/ui/src/components/empty.tsx
+++ b/packages/ui/src/components/empty.tsx
@@ -6,7 +6,7 @@ function Empty({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-2 md:p-6 text-center text-balance lg:p-12',
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-2 text-center md:p-6 lg:p-12',
         className,
       )}
       data-slot="empty"
@@ -18,7 +18,7 @@ function Empty({ className, ...props }: ComponentProps<'div'>) {
 function EmptyHeader({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
-      className={cn('flex max-w-sm flex-col items-center md:gap-2 text-center', className)}
+      className={cn('flex max-w-sm flex-col items-center text-center md:gap-2', className)}
       data-slot="empty-header"
       {...props}
     />
@@ -34,7 +34,7 @@ const emptyMediaVariants = cva(
     variants: {
       variant: {
         default: 'bg-transparent',
-        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
       },
     },
   },
@@ -43,7 +43,7 @@ const emptyMediaVariants = cva(
 function EmptyContent({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
-      className={cn('flex w-full md:max-w-md min-w-0 flex-col items-center gap-4 text-sm text-balance', className)}
+      className={cn('flex w-full min-w-0 flex-col items-center gap-4 text-balance text-sm md:max-w-md', className)}
       data-slot="empty-content"
       {...props}
     />
@@ -54,7 +54,7 @@ function EmptyDescription({ className, ...props }: ComponentProps<'p'>) {
   return (
     <div
       className={cn(
-        'text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4',
+        'text-muted-foreground text-sm/relaxed [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
         className,
       )}
       data-slot="empty-description"
@@ -79,7 +79,7 @@ function EmptyMedia({
 }
 
 function EmptyTitle({ className, ...props }: ComponentProps<'div'>) {
-  return <div className={cn('text-lg font-medium tracking-tight', className)} data-slot="empty-title" {...props} />
+  return <div className={cn('font-medium text-lg tracking-tight', className)} data-slot="empty-title" {...props} />
 }
 
 export { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle }

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -62,7 +62,7 @@ const fieldVariants = cva('group/field flex w-full gap-3 data-[invalid=true]:tex
         'has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
       ],
       responsive: [
-        'flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto',
+        '@md/field-group:flex-row flex-col @md/field-group:items-center @md/field-group:[&>*]:w-auto [&>*]:w-full [&>.sr-only]:w-auto',
         '@md/field-group:[&>[data-slot=field-label]]:flex-auto',
         '@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
       ],
@@ -102,8 +102,8 @@ function FieldDescription({ className, ...props }: ComponentProps<'p'>) {
   return (
     <p
       className={cn(
-        'text-muted-foreground text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance',
-        'last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5',
+        'font-normal text-muted-foreground text-sm leading-normal group-has-[[data-orientation=horizontal]]/field:text-balance',
+        'nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5 last:mt-0',
         '[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
         className,
       )}
@@ -149,7 +149,7 @@ function FieldError({
 
   return (
     <div
-      className={cn('text-destructive text-sm font-normal', className)}
+      className={cn('font-normal text-destructive text-sm', className)}
       data-slot="field-error"
       role="alert"
       {...props}
@@ -165,7 +165,7 @@ function FieldLabel({ className, ...props }: ComponentProps<typeof Label>) {
       className={cn(
         'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50',
         'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4',
-        'has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10',
+        'has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10',
         className,
       )}
       data-slot="field-label"
@@ -183,7 +183,7 @@ function FieldSeparator({
 } & ComponentProps<'div'>) {
   return (
     <div
-      className={cn('relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2', className)}
+      className={cn('-my-2 group-data-[variant=outline]/field-group:-mb-2 relative h-5 text-sm', className)}
       data-content={!!children}
       data-slot="field-separator"
       {...props}
@@ -191,7 +191,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}
@@ -205,7 +205,7 @@ function FieldTitle({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50',
+        'flex w-fit items-center gap-2 font-medium text-sm leading-snug group-data-[disabled=true]/field:opacity-50',
         className,
       )}
       data-slot="field-label"

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -13,7 +13,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
     // biome-ignore lint/a11y/useSemanticElements: this should not be a fieldset
     <div
       className={cn(
-        'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none',
+        'group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs outline-none transition-[color,box-shadow] dark:bg-input/30',
         'h-9 min-w-0 has-[>textarea]:h-auto',
 
         // Variants based on alignment.
@@ -23,10 +23,10 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
         'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
         // Focus state.
-        'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]',
+        'has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
+        'has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
 
         className,
       )}
@@ -38,16 +38,16 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 const inputGroupAddonVariants = cva(
-  "text-muted-foreground flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium select-none [&>svg:not([class*='size-'])]:size-4 [&>kbd]:rounded-[calc(var(--radius)-5px)] group-data-[disabled=true]/input-group:opacity-50",
+  "flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 font-medium text-muted-foreground text-sm group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
   {
     defaultVariants: {
       align: 'inline-start',
     },
     variants: {
       align: {
-        'block-end': 'order-last w-full justify-start px-3 pb-3 [.border-t]:pt-3 group-has-[>input]/input-group:pb-2.5',
+        'block-end': 'order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3',
         'block-start':
-          'order-first w-full justify-start px-3 pt-3 [.border-b]:pb-3 group-has-[>input]/input-group:pt-2.5',
+          'order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3',
         'inline-end': 'order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]',
         'inline-start': 'order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]',
       },
@@ -81,7 +81,7 @@ function InputGroupAddon({
   )
 }
 
-const inputGroupButtonVariants = cva('text-sm shadow-none flex gap-2 items-center', {
+const inputGroupButtonVariants = cva('flex items-center gap-2 text-sm shadow-none', {
   defaultVariants: {
     size: 'xs',
   },
@@ -89,8 +89,8 @@ const inputGroupButtonVariants = cva('text-sm shadow-none flex gap-2 items-cente
     size: {
       'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
       'icon-xs': 'size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0',
-      sm: 'h-8 px-2.5 gap-1.5 rounded-md has-[>svg]:px-2.5',
-      xs: "h-6 gap-1 px-2 rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-3.5 has-[>svg]:px-2",
+      sm: 'h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5',
+      xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
     },
   },
 })
@@ -117,7 +117,7 @@ function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       className={cn(
-        "text-muted-foreground flex items-center gap-2 text-sm [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        "flex items-center gap-2 text-muted-foreground text-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -5,9 +5,9 @@ function Input({ className, type, ...props }: ComponentProps<'input'>) {
   return (
     <input
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        'flex h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs outline-none transition-[color,box-shadow] selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30',
+        'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       data-slot="input"

--- a/packages/ui/src/components/item.tsx
+++ b/packages/ui/src/components/item.tsx
@@ -17,7 +17,7 @@ function ItemSeparator({ className, ...props }: ComponentProps<typeof Separator>
 }
 
 const itemVariants = cva(
-  'group/item flex items-center border border-transparent text-sm rounded-md transition-colors [a]:hover:bg-accent/50 [a]:transition-colors duration-100 flex-wrap outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+  'group/item flex flex-wrap items-center rounded-md border border-transparent text-sm outline-none transition-colors duration-100 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors [a]:hover:bg-accent/50',
   {
     defaultVariants: {
       size: 'default',
@@ -25,8 +25,8 @@ const itemVariants = cva(
     },
     variants: {
       size: {
-        default: 'p-2 md:p-4 gap-2 md:gap-4',
-        sm: 'py-3 px-4 gap-2.5',
+        default: 'gap-2 p-2 md:gap-4 md:p-4',
+        sm: 'gap-2.5 px-4 py-3',
       },
       variant: {
         default: 'bg-transparent',
@@ -57,7 +57,7 @@ function Item({
 }
 
 const itemMediaVariants = cva(
-  'flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none group-has-[[data-slot=item-description]]/item:translate-y-0.5',
+  'flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none',
   {
     defaultVariants: {
       variant: 'default',
@@ -65,8 +65,8 @@ const itemMediaVariants = cva(
     variants: {
       variant: {
         default: 'bg-transparent',
-        icon: "size-8 border rounded-sm bg-muted [&_svg:not([class*='size-'])]:size-4",
-        image: 'size-10 rounded-sm overflow-hidden [&_img]:size-full [&_img]:object-cover',
+        icon: "size-8 rounded-sm border bg-muted [&_svg:not([class*='size-'])]:size-4",
+        image: 'size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover',
       },
     },
   },
@@ -90,7 +90,7 @@ function ItemDescription({ className, ...props }: ComponentProps<'p'>) {
   return (
     <p
       className={cn(
-        'text-muted-foreground line-clamp-2 text-sm leading-normal font-normal text-balance',
+        'line-clamp-2 text-balance font-normal text-muted-foreground text-sm leading-normal',
         '[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
         className,
       )}
@@ -138,7 +138,7 @@ function ItemMedia({
 function ItemTitle({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
-      className={cn('flex w-fit items-center gap-2 text-sm leading-snug font-medium', className)}
+      className={cn('flex w-fit items-center gap-2 font-medium text-sm leading-snug', className)}
       data-slot="item-title"
       {...props}
     />

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -9,7 +9,7 @@ function Label({ className, ...props }: ComponentProps<typeof LabelPrimitive.Roo
   return (
     <LabelPrimitive.Root
       className={cn(
-        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        'flex select-none items-center gap-2 font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50',
         className,
       )}
       data-slot="label"

--- a/packages/ui/src/components/menubar.tsx
+++ b/packages/ui/src/components/menubar.tsx
@@ -9,7 +9,7 @@ import { cn } from '../lib/utils.ts'
 function Menubar({ className, ...props }: ComponentProps<typeof MenubarPrimitive.Root>) {
   return (
     <MenubarPrimitive.Root
-      className={cn('bg-background flex h-9 items-center gap-1 rounded-md border p-1 shadow-xs', className)}
+      className={cn('flex h-9 items-center gap-1 rounded-md border bg-background p-1 shadow-xs', className)}
       data-slot="menubar"
       {...props}
     />
@@ -26,7 +26,7 @@ function MenubarCheckboxItem({
     <MenubarPrimitive.CheckboxItem
       checked={checked}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="menubar-checkbox-item"
@@ -55,7 +55,7 @@ function MenubarContent({
         align={align}
         alignOffset={alignOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in',
           className,
         )}
         data-slot="menubar-content"
@@ -82,7 +82,7 @@ function MenubarItem({
   return (
     <MenubarPrimitive.Item
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[variant=destructive]:*:[svg]:!text-destructive relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-inset={inset}
@@ -102,7 +102,7 @@ function MenubarLabel({
 } & ComponentProps<typeof MenubarPrimitive.Label>) {
   return (
     <MenubarPrimitive.Label
-      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      className={cn('px-2 py-1.5 font-medium text-sm data-[inset]:pl-8', className)}
       data-inset={inset}
       data-slot="menubar-label"
       {...props}
@@ -126,7 +126,7 @@ function MenubarRadioItem({ children, className, ...props }: ComponentProps<type
   return (
     <MenubarPrimitive.RadioItem
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default select-none items-center gap-2 rounded-xs py-1.5 pr-2 pl-8 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="menubar-radio-item"
@@ -145,7 +145,7 @@ function MenubarRadioItem({ children, className, ...props }: ComponentProps<type
 function MenubarSeparator({ className, ...props }: ComponentProps<typeof MenubarPrimitive.Separator>) {
   return (
     <MenubarPrimitive.Separator
-      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
       data-slot="menubar-separator"
       {...props}
     />
@@ -155,7 +155,7 @@ function MenubarSeparator({ className, ...props }: ComponentProps<typeof Menubar
 function MenubarShortcut({ className, ...props }: ComponentProps<'span'>) {
   return (
     <span
-      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      className={cn('ml-auto text-muted-foreground text-xs tracking-widest', className)}
       data-slot="menubar-shortcut"
       {...props}
     />
@@ -170,7 +170,7 @@ function MenubarSubContent({ className, ...props }: ComponentProps<typeof Menuba
   return (
     <MenubarPrimitive.SubContent
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=open]:animate-in',
         className,
       )}
       data-slot="menubar-sub-content"
@@ -190,7 +190,7 @@ function MenubarSubTrigger({
   return (
     <MenubarPrimitive.SubTrigger
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[inset]:pl-8',
+        'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground',
         className,
       )}
       data-inset={inset}
@@ -207,7 +207,7 @@ function MenubarTrigger({ className, ...props }: ComponentProps<typeof MenubarPr
   return (
     <MenubarPrimitive.Trigger
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex items-center rounded-sm px-2 py-1 text-sm font-medium outline-hidden select-none',
+        'flex select-none items-center rounded-sm px-2 py-1 font-medium text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
         className,
       )}
       data-slot="menubar-trigger"

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -24,7 +24,7 @@ function PopoverContent({
       <PopoverPrimitive.Content
         align={align}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in',
           className,
         )}
         data-slot="popover-content"

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -14,7 +14,7 @@ function RadioGroupItem({ className, ...props }: ComponentProps<typeof RadioGrou
   return (
     <RadioGroupPrimitive.Item
       className={cn(
-        'border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       data-slot="radio-group-item"
@@ -24,7 +24,7 @@ function RadioGroupItem({ className, ...props }: ComponentProps<typeof RadioGrou
         className="relative flex items-center justify-center"
         data-slot="radio-group-indicator"
       >
-        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+        <CircleIcon className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 size-2 fill-primary" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )

--- a/packages/ui/src/components/resizable.tsx
+++ b/packages/ui/src/components/resizable.tsx
@@ -17,14 +17,14 @@ function ResizableHandle({
   return (
     <ResizablePrimitive.PanelResizeHandle
       className={cn(
-        'bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+        'after:-translate-x-1/2 data-[panel-group-direction=vertical]:after:-translate-y-1/2 relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',
         className,
       )}
       data-slot="resizable-handle"
       {...props}
     >
       {withHandle && (
-        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+        <div className="z-10 flex h-4 w-3 items-center justify-center rounded-xs border bg-border">
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -9,7 +9,7 @@ function ScrollArea({ children, className, ...props }: ComponentProps<typeof Scr
   return (
     <ScrollAreaPrimitive.Root className={cn('relative', className)} data-slot="scroll-area" {...props}>
       <ScrollAreaPrimitive.Viewport
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="size-full rounded-[inherit] outline-none transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px] focus-visible:ring-ring/50"
         data-slot="scroll-area-viewport"
       >
         {children}
@@ -28,7 +28,7 @@ function ScrollBar({
   return (
     <ScrollAreaPrimitive.ScrollAreaScrollbar
       className={cn(
-        'flex touch-none p-px transition-colors select-none',
+        'flex touch-none select-none p-px transition-colors',
         orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent',
         orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent',
         className,
@@ -38,7 +38,7 @@ function ScrollBar({
       {...props}
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
-        className="bg-border relative flex-1 rounded-full"
+        className="relative flex-1 rounded-full bg-border"
         data-slot="scroll-area-thumb"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -20,9 +20,9 @@ function SelectContent({
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in',
           position === 'popper' &&
-            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+            'data-[side=left]:-translate-x-1 data-[side=top]:-translate-y-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1',
           className,
         )}
         data-slot="select-content"
@@ -53,7 +53,7 @@ function SelectItem({ children, className, ...props }: ComponentProps<typeof Sel
   return (
     <SelectPrimitive.Item
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       data-slot="select-item"
@@ -72,7 +72,7 @@ function SelectItem({ children, className, ...props }: ComponentProps<typeof Sel
 function SelectLabel({ className, ...props }: ComponentProps<typeof SelectPrimitive.Label>) {
   return (
     <SelectPrimitive.Label
-      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      className={cn('px-2 py-1.5 text-muted-foreground text-xs', className)}
       data-slot="select-label"
       {...props}
     />
@@ -106,7 +106,7 @@ function SelectScrollUpButton({ className, ...props }: ComponentProps<typeof Sel
 function SelectSeparator({ className, ...props }: ComponentProps<typeof SelectPrimitive.Separator>) {
   return (
     <SelectPrimitive.Separator
-      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      className={cn('-mx-1 pointer-events-none my-1 h-px bg-border', className)}
       data-slot="select-separator"
       {...props}
     />
@@ -124,7 +124,7 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex w-fit items-center justify-between gap-2 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[size=default]:h-9 data-[size=sm]:h-8 data-[placeholder]:text-muted-foreground *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:hover:bg-input/50 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-size={size}

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -14,7 +14,7 @@ function Separator({
   return (
     <SeparatorPrimitive.Root
       className={cn(
-        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        'shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=vertical]:h-full data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px',
         className,
       )}
       data-slot="separator"

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -27,7 +27,7 @@ function SheetContent({
       <SheetOverlay />
       <SheetPrimitive.Content
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          'fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500',
           side === 'right' &&
             'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
           side === 'left' &&
@@ -42,7 +42,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
@@ -73,7 +73,7 @@ function SheetOverlay({ className, ...props }: ComponentProps<typeof SheetPrimit
   return (
     <SheetPrimitive.Overlay
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in',
         className,
       )}
       data-slot="sheet-overlay"
@@ -89,7 +89,7 @@ function SheetPortal({ ...props }: ComponentProps<typeof SheetPrimitive.Portal>)
 function SheetTitle({ className, ...props }: ComponentProps<typeof SheetPrimitive.Title>) {
   return (
     <SheetPrimitive.Title
-      className={cn('text-foreground font-semibold', className)}
+      className={cn('font-semibold text-foreground', className)}
       data-slot="sheet-title"
       {...props}
     />

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -57,7 +57,7 @@ function Sidebar({
   if (collapsible === 'none') {
     return (
       <div
-        className={cn('bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col', className)}
+        className={cn('flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground', className)}
         data-slot="sidebar"
         {...props}
       >
@@ -70,7 +70,7 @@ function Sidebar({
     return (
       <Sheet onOpenChange={setOpenMobile} open={openMobile} {...props}>
         <SheetContent
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
           data-mobile="true"
           data-sidebar="sidebar"
           data-slot="sidebar"
@@ -93,7 +93,7 @@ function Sidebar({
 
   return (
     <div
-      className="group peer text-sidebar-foreground hidden md:block"
+      className="group peer hidden text-sidebar-foreground md:block"
       data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-side={side}
       data-slot="sidebar"
@@ -128,7 +128,7 @@ function Sidebar({
         {...props}
       >
         <div
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
         >
@@ -185,9 +185,9 @@ function SidebarGroupAction({
   return (
     <Comp
       className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
-        'after:absolute after:-inset-2 md:after:hidden',
+        'after:-inset-2 after:absolute md:after:hidden',
         'group-data-[collapsible=icon]:hidden',
         className,
       )}
@@ -215,7 +215,7 @@ function SidebarGroupLabel({ asChild = false, className, ...props }: { asChild?:
   return (
     <Comp
       className={cn(
-        'text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'flex h-8 shrink-0 items-center rounded-md px-2 font-medium text-sidebar-foreground/70 text-xs outline-hidden ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}
@@ -240,7 +240,7 @@ function SidebarHeader({ className, ...props }: ComponentProps<'div'>) {
 function SidebarInput({ className, ...props }: ComponentProps<typeof Input>) {
   return (
     <Input
-      className={cn('bg-background h-8 w-full shadow-none', className)}
+      className={cn('h-8 w-full bg-background shadow-none', className)}
       data-sidebar="input"
       data-slot="sidebar-input"
       {...props}
@@ -252,8 +252,8 @@ function SidebarInset({ className, ...props }: ComponentProps<'main'>) {
   return (
     <main
       className={cn(
-        'bg-background relative flex w-full flex-1 flex-col',
-        'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+        'relative flex w-full flex-1 flex-col bg-background',
+        'md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
         className,
       )}
       data-slot="sidebar-inset"
@@ -355,7 +355,7 @@ function SidebarProvider({
     <SidebarContext.Provider value={contextValue}>
       <TooltipProvider delayDuration={0}>
         <div
-          className={cn('group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full', className)}
+          className={cn('group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar', className)}
           data-slot="sidebar-wrapper"
           style={
             {
@@ -380,10 +380,10 @@ function SidebarRail({ className, ...props }: ComponentProps<'button'>) {
     <button
       aria-label="Toggle Sidebar"
       className={cn(
-        'hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex',
+        '-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex',
         'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
         '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
-        'hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full',
+        'group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full',
         '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
         '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
         className,
@@ -401,7 +401,7 @@ function SidebarRail({ className, ...props }: ComponentProps<'button'>) {
 function SidebarSeparator({ className, ...props }: ComponentProps<typeof Separator>) {
   return (
     <Separator
-      className={cn('bg-sidebar-border mx-2 w-auto', className)}
+      className={cn('mx-2 w-auto bg-sidebar-border', className)}
       data-sidebar="separator"
       data-slot="sidebar-separator"
       {...props}
@@ -476,15 +476,15 @@ function SidebarMenuAction({
   return (
     <Comp
       className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
-        'after:absolute after:-inset-2 md:after:hidden',
+        'after:-inset-2 after:absolute md:after:hidden',
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
         'peer-data-[size=lg]/menu-button:top-2.5',
         'group-data-[collapsible=icon]:hidden',
         showOnHover &&
-          'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
+          'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
         className,
       )}
       data-sidebar="menu-action"
@@ -498,7 +498,7 @@ function SidebarMenuBadge({ className, ...props }: ComponentProps<'div'>) {
   return (
     <div
       className={cn(
-        'text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none',
+        'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 font-medium text-sidebar-foreground text-xs tabular-nums',
         'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
@@ -596,7 +596,7 @@ function SidebarMenuSub({ className, ...props }: ComponentProps<'ul'>) {
   return (
     <ul
       className={cn(
-        'border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5',
+        'mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-sidebar-border border-l px-2.5 py-0.5',
         'group-data-[collapsible=icon]:hidden',
         className,
       )}
@@ -623,7 +623,7 @@ function SidebarMenuSubButton({
   return (
     <Comp
       className={cn(
-        'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+        '-translate-x-px flex h-7 min-w-0 items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -2,7 +2,7 @@ import type { ComponentProps } from 'react'
 import { cn } from '../lib/utils.ts'
 
 function Skeleton({ className, ...props }: ComponentProps<'div'>) {
-  return <div className={cn('bg-accent animate-pulse rounded-md', className)} data-slot="skeleton" {...props} />
+  return <div className={cn('animate-pulse rounded-md bg-accent', className)} data-slot="skeleton" {...props} />
 }
 
 export { Skeleton }

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -9,7 +9,7 @@ function Switch({ className, ...props }: ComponentProps<typeof SwitchPrimitive.R
   return (
     <SwitchPrimitive.Root
       className={cn(
-        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'peer inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80',
         className,
       )}
       data-slot="switch"
@@ -17,7 +17,7 @@ function Switch({ className, ...props }: ComponentProps<typeof SwitchPrimitive.R
     >
       <SwitchPrimitive.Thumb
         className={cn(
-          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+          'pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground',
         )}
         data-slot="switch-thumb"
       />

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -17,7 +17,7 @@ function TableBody({ className, ...props }: ComponentProps<'tbody'>) {
 
 function TableCaption({ className, ...props }: ComponentProps<'caption'>) {
   return (
-    <caption className={cn('text-muted-foreground mt-4 text-sm', className)} data-slot="table-caption" {...props} />
+    <caption className={cn('mt-4 text-muted-foreground text-sm', className)} data-slot="table-caption" {...props} />
   )
 }
 
@@ -25,7 +25,7 @@ function TableCell({ className, ...props }: ComponentProps<'td'>) {
   return (
     <td
       className={cn(
-        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
       data-slot="table-cell"
@@ -37,7 +37,7 @@ function TableCell({ className, ...props }: ComponentProps<'td'>) {
 function TableFooter({ className, ...props }: ComponentProps<'tfoot'>) {
   return (
     <tfoot
-      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
       data-slot="table-footer"
       {...props}
     />
@@ -48,7 +48,7 @@ function TableHead({ className, ...props }: ComponentProps<'th'>) {
   return (
     <th
       className={cn(
-        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        'h-10 whitespace-nowrap px-2 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
         className,
       )}
       data-slot="table-head"
@@ -64,7 +64,7 @@ function TableHeader({ className, ...props }: ComponentProps<'thead'>) {
 function TableRow({ className, ...props }: ComponentProps<'tr'>) {
   return (
     <tr
-      className={cn('hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors', className)}
+      className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)}
       data-slot="table-row"
       {...props}
     />

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -17,7 +17,7 @@ function TabsList({ className, ...props }: ComponentProps<typeof TabsPrimitive.L
   return (
     <TabsPrimitive.List
       className={cn(
-        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground',
         className,
       )}
       data-slot="tabs-list"
@@ -30,7 +30,7 @@ function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsPrimitiv
   return (
     <TabsPrimitive.Trigger
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1 font-medium text-foreground text-sm transition-[color,box-shadow] focus-visible:border-ring focus-visible:outline-1 focus-visible:outline-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:shadow-sm dark:text-muted-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="tabs-trigger"

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -5,7 +5,7 @@ function Textarea({ className, ...props }: ComponentProps<'textarea'>) {
   return (
     <textarea
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'field-sizing-content flex min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
         className,
       )}
       data-slot="textarea"

--- a/packages/ui/src/components/toggle.tsx
+++ b/packages/ui/src/components/toggle.tsx
@@ -7,7 +7,7 @@ import type { ComponentProps } from 'react'
 import { cn } from '../lib/utils.ts'
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-[color,box-shadow] hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     defaultVariants: {
       size: 'default',
@@ -15,9 +15,9 @@ const toggleVariants = cva(
     },
     variants: {
       size: {
-        default: 'h-9 px-2 min-w-9',
-        lg: 'h-10 px-2.5 min-w-10',
-        sm: 'h-8 px-1.5 min-w-8',
+        default: 'h-9 min-w-9 px-2',
+        lg: 'h-10 min-w-10 px-2.5',
+        sm: 'h-8 min-w-8 px-1.5',
       },
       variant: {
         default: 'bg-transparent',

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -23,7 +23,7 @@ function TooltipContent({
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
         className={cn(
-          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          'fade-in-0 zoom-in-95 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in text-balance rounded-md bg-primary px-3 py-1.5 text-primary-foreground text-xs data-[state=closed]:animate-out',
           className,
         )}
         data-slot="tooltip-content"
@@ -31,7 +31,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-primary fill-primary" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/packages/ui/src/components/ui-bottom-sheet.tsx
+++ b/packages/ui/src/components/ui-bottom-sheet.tsx
@@ -16,12 +16,12 @@ export function UiBottomSheet({
   return (
     <Sheet>
       <SheetTrigger asChild>{trigger}</SheetTrigger>
-      <SheetContent className="w-full sm:w-[400px] sm:left-1/2 sm:-translate-x-1/2" side="bottom">
+      <SheetContent className="sm:-translate-x-1/2 w-full sm:left-1/2 sm:w-[400px]" side="bottom">
         <SheetHeader>
           <SheetTitle>{title}</SheetTitle>
           <SheetDescription>{description}</SheetDescription>
         </SheetHeader>
-        <div className="flex flex-col gap-6 pb-10 items-center md:aspect-square">{children}</div>
+        <div className="flex flex-col items-center gap-6 pb-10 md:aspect-square">{children}</div>
       </SheetContent>
     </Sheet>
   )

--- a/packages/ui/src/components/ui-empty.tsx
+++ b/packages/ui/src/components/ui-empty.tsx
@@ -18,7 +18,7 @@ export function UiEmpty({
   title: ReactNode
 }) {
   return (
-    <Empty className={cn('border border-dashed gap-3', className)}>
+    <Empty className={cn('gap-3 border border-dashed', className)}>
       {icon ? (
         <EmptyMedia variant="icon">
           <UiIcon icon={icon} />

--- a/packages/ui/src/components/ui-error-boundary.tsx
+++ b/packages/ui/src/components/ui-error-boundary.tsx
@@ -20,7 +20,7 @@ export function UiErrorBoundary() {
   const title = `${isError ? 'A route' : 'An unknown'} error occurred`
 
   return (
-    <div className={cn('flex items-center justify-center h-full w-full px-6')}>
+    <div className={cn('flex h-full w-full items-center justify-center px-6')}>
       <UiEmpty className="" description={description} icon="bug" title={title}>
         <UiErrorBoundarySupport />
         {stack ? <UiErrorBoundaryStack stack={stack} /> : null}
@@ -41,7 +41,7 @@ function UiErrorBoundaryStack({ stack }: { stack: string }) {
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="pt-6">
-        <pre className="text-[9px] overflow-auto w-full text-left">{stack}</pre>
+        <pre className="w-full overflow-auto text-left text-[9px]">{stack}</pre>
       </CollapsibleContent>
     </Collapsible>
   )

--- a/packages/ui/src/components/ui-loader-full.tsx
+++ b/packages/ui/src/components/ui-loader-full.tsx
@@ -9,7 +9,7 @@ export function UiLoaderFull({
   classNameSpinner?: string | undefined
 }) {
   return (
-    <div className={cn('flex items-center justify-center h-full w-full', className)}>
+    <div className={cn('flex h-full w-full items-center justify-center', className)}>
       <UiLoader className={classNameSpinner} />
     </div>
   )

--- a/packages/ui/src/components/ui-page.tsx
+++ b/packages/ui/src/components/ui-page.tsx
@@ -5,7 +5,7 @@ export function UiPage({ children, className, ...props }: ComponentProps<'div'>)
   return (
     <div
       className={cn(
-        'container lg:max-w-5xl lg:p-6 md:max-w-4xl md:p-4 mx-auto p-0 sm:max-w-3xl sm:p-2 xl:max-w-6xl xl:p-8',
+        'container mx-auto p-0 sm:max-w-3xl sm:p-2 md:max-w-4xl md:p-4 lg:max-w-5xl lg:p-6 xl:max-w-6xl xl:p-8',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Description

This enables the [useSortedClasses](https://biomejs.dev/linter/rules/use-sorted-classes/) rule.

It's currently unsafe, in order to get the IDE's to apply it on save, I followed [this guide](https://github.com/biomejs/biome/issues/1274#issuecomment-3490774696).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enables `useSortedClasses` linter rule to enforce sorted class names in JSX components, affecting multiple files and components for consistent styling.
> 
>   - **Linter Configuration**:
>     - Enables `useSortedClasses` rule in `biome.json` with `fix: safe` and `level: error`.
>     - Targets attributes `classList` and functions `cn`, `clsx`, `cva`, `tw`.
>   - **Code Changes**:
>     - Sorts class names in JSX components across multiple files, including `connect.tsx`, `sign-and-send-transaction.tsx`, and `loading-feature-index.tsx`.
>     - Affects components like `Button`, `Card`, `Dialog`, `Sheet`, `Sidebar`, and `Tooltip`.
>   - **Behavior**:
>     - Automatically fixes class name order where possible.
>     - Ensures consistent styling and reduces potential CSS conflicts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 18b239f2f92014141ec24e52b25a36a0767edbb8. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->