### PR TITLE
feat: implement ui-text-copy-icon

### DIFF
--- a/packages/explorer/src/ui/explorer-ui-link-address.tsx
+++ b/packages/explorer/src/ui/explorer-ui-link-address.tsx
@@ -1,12 +1,12 @@
 import type { Address } from '@solana/kit'
-import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
+import { UiTextCopyIcon } from '@workspace/ui/components/ui-text-copy-icon'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
 import { Link, useLocation } from 'react-router'
 
 export function ExplorerUiLinkAddress({ basePath, address }: { basePath: string; address: Address }) {
   const { pathname: from } = useLocation()
   return (
-    <span className="flex items-center gap-1">
+    <span className="flex items-center gap-2">
       <Link
         className="cursor-pointer font-mono text-sm"
         state={{ from }}
@@ -15,13 +15,7 @@ export function ExplorerUiLinkAddress({ basePath, address }: { basePath: string;
       >
         {ellipsify(address, 8)}
       </Link>
-      <UiTextCopyButton
-        size="icon"
-        text={address}
-        title="Copy address to clipboard"
-        toast="Address copied to clipboard"
-        variant="ghost"
-      />
+      <UiTextCopyIcon text={address} title="Copy address to clipboard" toast="Address copied to clipboard" />
     </span>
   )
 }

--- a/packages/explorer/src/ui/explorer-ui-link-tx.tsx
+++ b/packages/explorer/src/ui/explorer-ui-link-tx.tsx
@@ -1,12 +1,12 @@
 import type { Signature } from '@solana/kit'
-import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
+import { UiTextCopyIcon } from '@workspace/ui/components/ui-text-copy-icon'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
 import { Link, useLocation } from 'react-router'
 
 export function ExplorerUiLinkTx({ basePath, signature }: { basePath: string; signature: Signature }) {
   const { pathname: from } = useLocation()
   return (
-    <span className="flex items-center gap-1">
+    <span className="flex items-center gap-2">
       <Link
         className="cursor-pointer font-mono text-sm"
         state={{ from }}
@@ -15,13 +15,7 @@ export function ExplorerUiLinkTx({ basePath, signature }: { basePath: string; si
       >
         {ellipsify(signature, 8)}
       </Link>
-      <UiTextCopyButton
-        size="icon"
-        text={signature}
-        title="Copy signature to clipboard"
-        toast="Signature copied to clipboard"
-        variant="ghost"
-      />
+      <UiTextCopyIcon text={signature} title="Copy signature to clipboard" toast="Signature copied to clipboard" />
     </span>
   )
 }

--- a/packages/shell/src/ui/shell-ui-menu-wallets.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-wallets.tsx
@@ -15,7 +15,7 @@ import {
 } from '@workspace/ui/components/menubar'
 import { UiAvatar } from '@workspace/ui/components/ui-avatar'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
-import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
+import { UiTextCopyIcon } from '@workspace/ui/components/ui-text-copy-icon'
 import { cn } from '@workspace/ui/lib/utils'
 import { Link } from 'react-router'
 
@@ -37,14 +37,12 @@ export function ShellUiMenuWallets({
         <div className="flex items-center gap-2">
           <UiAvatar className="size-6 md:size-8" label={activeWallet.name} />
           {activeAccount.name}
-          <UiTextCopyButton
+          <UiTextCopyIcon
             onPointerDown={(e) => e.stopPropagation()}
-            size="icon"
             text={activeAccount.publicKey}
             title={t(($) => $.accountPublicKeyCopy)}
             toast={t(($) => $.accountPublicKeyCopySuccess)}
             toastFailed={t(($) => $.accountPublicKeyCopyFailed)}
-            variant="ghost"
           />
         </div>
       </MenubarTrigger>
@@ -58,7 +56,7 @@ export function ShellUiMenuWallets({
             <MenubarSubContent>
               <MenubarRadioGroup onValueChange={(id) => setActiveAccount(id)} value={activeAccount.id}>
                 {wallet.accounts.map((account) => (
-                  <div className="flex items-center" key={account.id}>
+                  <div className="flex items-center gap-1 pr-1" key={account.id}>
                     <MenubarRadioItem
                       className={cn('font-mono', {
                         'font-bold': account.id === activeAccount.id,
@@ -67,13 +65,11 @@ export function ShellUiMenuWallets({
                     >
                       {account.name}
                     </MenubarRadioItem>
-                    <UiTextCopyButton
-                      size="icon"
+                    <UiTextCopyIcon
                       text={account.publicKey}
                       title={t(($) => $.accountPublicKeyCopy)}
                       toast={t(($) => $.accountPublicKeyCopySuccess)}
                       toastFailed={t(($) => $.accountPublicKeyCopyFailed)}
-                      variant="ghost"
                     />
                   </div>
                 ))}

--- a/packages/ui/src/components/ui-icon-map.tsx
+++ b/packages/ui/src/components/ui-icon-map.tsx
@@ -12,6 +12,7 @@ import {
   LucideCircleX,
   LucideCoins,
   LucideCopy,
+  LucideCopyCheck,
   LucideExternalLink,
   LucideEye,
   LucideGlobe,
@@ -60,6 +61,7 @@ export type UiIconName =
   | 'circleX'
   | 'coins'
   | 'copy'
+  | 'copyCheck'
   | 'delete'
   | 'derive'
   | 'edit'
@@ -101,6 +103,7 @@ const uiIconMap = new Map<UiIconName, UiIconLucide>()
   .set('circleX', LucideCircleX)
   .set('coins', LucideCoins)
   .set('copy', LucideCopy)
+  .set('copyCheck', LucideCopyCheck)
   .set('delete', LucideTrash)
   .set('derive', LucideLetterText)
   .set('edit', LucidePencil)

--- a/packages/ui/src/components/ui-text-copy-button.tsx
+++ b/packages/ui/src/components/ui-text-copy-button.tsx
@@ -1,10 +1,8 @@
-import { useTranslation } from '@workspace/i18n'
 import type { ComponentProps } from 'react'
-import { handleCopyText } from '../lib/handle-copy-text.ts'
-import { toastError } from '../lib/toast-error.ts'
-import { toastSuccess } from '../lib/toast-success.ts'
+import { cn } from '../lib/utils.ts'
 import { Button } from './button.tsx'
 import { UiIcon } from './ui-icon.tsx'
+import { type HandleCopyTextProps, useHandleCopyText } from './use-handle-copy-text.tsx'
 
 export function UiTextCopyButton({
   label,
@@ -12,26 +10,12 @@ export function UiTextCopyButton({
   toast,
   toastFailed,
   ...props
-}: ComponentProps<typeof Button> & { label?: string; text: string; toast?: string; toastFailed?: string }) {
-  const { t } = useTranslation('ui')
+}: ComponentProps<typeof Button> & HandleCopyTextProps & { label: string }) {
+  const { copied, handleCopy } = useHandleCopyText({ text, toast, toastFailed })
+
   return (
-    <Button
-      className="cursor-pointer"
-      onClick={async () => {
-        try {
-          await handleCopyText(text)
-          if (toast) {
-            toastSuccess(toast)
-          }
-        } catch (error) {
-          toastError(error instanceof Error ? error.message : (toastFailed ?? t(($) => $.textCopyFailed)))
-        }
-      }}
-      type="button"
-      variant="secondary"
-      {...props}
-    >
-      <UiIcon icon="copy" />
+    <Button className="cursor-pointer" onClick={handleCopy} type="button" variant="secondary" {...props}>
+      <UiIcon className={cn({ 'text-green-500': copied })} icon={copied ? 'copyCheck' : 'copy'} />
       {label}
     </Button>
   )

--- a/packages/ui/src/components/ui-text-copy-icon.tsx
+++ b/packages/ui/src/components/ui-text-copy-icon.tsx
@@ -1,0 +1,15 @@
+import type { ComponentProps } from 'react'
+import { cn } from '../lib/utils.ts'
+import { UiIcon } from './ui-icon.tsx'
+import type { HandleCopyTextProps } from './use-handle-copy-text.tsx'
+import { useHandleCopyText } from './use-handle-copy-text.tsx'
+
+export function UiTextCopyIcon({ text, toast, toastFailed, ...props }: ComponentProps<'button'> & HandleCopyTextProps) {
+  const { copied, handleCopy } = useHandleCopyText({ text, toast, toastFailed })
+
+  return (
+    <button className="cursor-pointer" onClick={handleCopy} type="button" {...props}>
+      <UiIcon className={cn('size-3', { 'text-green-500': copied })} icon={copied ? 'copyCheck' : 'copy'} />
+    </button>
+  )
+}

--- a/packages/ui/src/components/use-handle-copy-text.tsx
+++ b/packages/ui/src/components/use-handle-copy-text.tsx
@@ -1,0 +1,55 @@
+/*
+ * Uses logic from https://github.com/mantinedev/mantine
+ * https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/hooks/src/use-clipboard/use-clipboard.ts
+ * MIT License
+ * Copyright (c) 2021 Vitaly Rtishchev
+ */
+import { useTranslation } from '@workspace/i18n'
+import { useEffect, useState } from 'react'
+import { handleCopyText } from '../lib/handle-copy-text.ts'
+import { toastError } from '../lib/toast-error.ts'
+import { toastSuccess } from '../lib/toast-success.ts'
+
+export interface HandleCopyTextProps {
+  text: string
+  timeout?: number
+  toast: string
+  toastFailed?: string | undefined
+}
+
+export function useHandleCopyText({ text, timeout = 2000, toast, toastFailed }: HandleCopyTextProps) {
+  const { t } = useTranslation('ui')
+  const [copyTimeout, setCopyTimeout] = useState<number | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  function handleCopySuccess() {
+    if (copyTimeout) {
+      window.clearTimeout(copyTimeout)
+    }
+    setCopyTimeout(window.setTimeout(() => setCopied(false), timeout))
+    setCopied(true)
+    toastSuccess(toast)
+  }
+
+  async function handleCopy() {
+    try {
+      await handleCopyText(text)
+      handleCopySuccess()
+    } catch (error) {
+      toastError(error instanceof Error ? error.message : (toastFailed ?? t(($) => $.textCopyFailed)))
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeout) {
+        window.clearTimeout(copyTimeout)
+      }
+    }
+  }, [copyTimeout])
+
+  return {
+    copied,
+    handleCopy,
+  }
+}


### PR DESCRIPTION
## Description

This is an alternative for `ui-text-copy-button` to be used inline as can be seen in the screenshots.

It takes only the size of the icon without padding, background, etc.

It extracts the logic to a hook shared between the 2 components and gives an option to visually indicate that the copy action just happened. This may at some point supersede the 'toast' on success.

Closes #

## Screenshots / Video
![chrome-capture-2025-11-24 (1)](https://github.com/user-attachments/assets/a7857aa3-8d45-41dc-8601-33a512b84f5e)

<img width="457" height="215" alt="image" src="https://github.com/user-attachments/assets/32ebd1b8-a4b4-4907-8c36-a5922518ecfc" />
<img width="814" height="541" alt="image" src="https://github.com/user-attachments/assets/3142cdfa-7fd2-4f73-b1df-3b98b355fec7" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce `UiTextCopyIcon` for inline use, refactor copy logic into a hook, and update components to use the new icon.
> 
>   - **Components**:
>     - Add `UiTextCopyIcon` in `ui-text-copy-icon.tsx` for inline use without padding or background.
>     - Refactor copy logic into `useHandleCopyText` hook in `use-handle-copy-text.tsx`.
>     - Update `UiTextCopyButton` to use `useHandleCopyText`.
>   - **UI Updates**:
>     - Replace `UiTextCopyButton` with `UiTextCopyIcon` in `explorer-ui-link-address.tsx`, `explorer-ui-link-tx.tsx`, and `shell-ui-menu-wallets.tsx`.
>     - Adjust icon gap in `explorer-ui-link-address.tsx` and `explorer-ui-link-tx.tsx`.
>   - **Icons**:
>     - Add `copyCheck` icon to `ui-icon-map.tsx` for visual feedback on copy success.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 5bee4c5190c622434f7731cd4231e140415dd145. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->