### PR TITLE
fix(settings): make sure we use dark mode by default

### DIFF
--- a/packages/settings/src/data-access/use-themes.tsx
+++ b/packages/settings/src/data-access/use-themes.tsx
@@ -12,7 +12,7 @@ export function useThemes() {
 
   const [theme, setTheme] = useSetting('theme')
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark')
+    document.documentElement.classList.toggle('dark', theme !== 'light')
   }, [theme])
 
   return {


### PR DESCRIPTION
## Description

We need to reverse the logic here so that we'll have a dark theme when the value is not set.

Bug introduced in #588 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes logic in `useThemes()` to default to dark mode when theme is not set.
> 
>   - **Behavior**:
>     - Fixes logic in `useThemes()` in `use-themes.tsx` to default to dark mode when theme is not set.
>     - Changes `document.documentElement.classList.toggle('dark', theme !== 'light')` to ensure dark mode is default.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 84f84813c4b92fbb97dc702d0e113dfac903c6d1. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->