### PR TITLE
chore: remove vite-tsconfig-paths dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,6 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vite-bundle-analyzer": "catalog:",
-    "vite-tsconfig-paths": "catalog:",
     "wrangler": "4.50.0"
   },
   "name": "web",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,7 +3,6 @@ import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import { analyzer } from 'vite-bundle-analyzer'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
   plugins: [
@@ -17,6 +16,5 @@ export default defineConfig({
       },
     }),
     tailwindcss(),
-    tsconfigPaths(),
   ],
 })

--- a/bun.lock
+++ b/bun.lock
@@ -177,7 +177,6 @@
         "typescript": "catalog:",
         "vite": "catalog:",
         "vite-bundle-analyzer": "catalog:",
-        "vite-tsconfig-paths": "catalog:",
         "wrangler": "4.50.0",
       },
     },
@@ -678,7 +677,6 @@
     "typescript-eslint": "8.46.2",
     "vite": "7.2.4",
     "vite-bundle-analyzer": "1.2.3",
-    "vite-tsconfig-paths": "5.1.4",
     "vitest": "4.0.7",
     "ws": "8.18.3",
     "wxt": "^0.20.6",
@@ -2939,8 +2937,6 @@
 
     "globby": ["globby@10.0.2", "", { "dependencies": { "@types/glob": "^7.1.1", "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.0.3", "glob": "^7.1.3", "ignore": "^5.1.1", "merge2": "^1.2.3", "slash": "^3.0.0" } }, "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg=="],
 
-    "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
-
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -4368,8 +4364,6 @@
     "vite-bundle-analyzer": ["vite-bundle-analyzer@1.2.3", "", { "bin": { "analyze": "dist/bin.js" } }, "sha512-8nhwDGHWMKKgg6oegAOpDgTT7/yzTVzeYzLF4y8WBJoYu9gO7h29UpHiQnXD2rAvfQzDy5Wqe/Za5cgqhnxi5g=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
-
-    "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "typescript-eslint": "8.46.2",
     "vite": "7.2.4",
     "vite-bundle-analyzer": "1.2.3",
-    "vite-tsconfig-paths": "5.1.4",
     "vitest": "4.0.7",
     "ws": "8.18.3",
     "wxt": "^0.20.6",


### PR DESCRIPTION
## Description

Turns out this is not needed in our setup.

> @beeman I am pretty sure this dependency although is in the vite config isn't actually setup / being used 

 _Originally posted by @tobeycodes in [#591](https://github.com/samui-build/samui-wallet/pull/591/files#r2557920309)_


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `vite-tsconfig-paths` dependency from the project.
> 
>   - **Dependency Removal**:
>     - Remove `vite-tsconfig-paths` from `package.json` dependencies.
>     - Remove `tsconfigPaths` import and usage from `vite.config.ts`.
>     - Remove `vite-tsconfig-paths` entries from `bun.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3dd9c3ad3b349170c65e3a7f5fd6a18cd279646f. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->