### PR TITLE
refactor: use use-handle-copy-text hook

### DIFF
--- a/packages/portfolio/src/ui/portfolio-ui-account-sheet-receive.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-account-sheet-receive.tsx
@@ -4,12 +4,16 @@ import { Button } from '@workspace/ui/components/button'
 import { UiBottomSheet } from '@workspace/ui/components/ui-bottom-sheet'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiQrCode } from '@workspace/ui/components/ui-qr-code'
-import { handleCopyText } from '@workspace/ui/lib/handle-copy-text'
-import { toastError } from '@workspace/ui/lib/toast-error'
-import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { useHandleCopyText } from '@workspace/ui/components/use-handle-copy-text'
 
 export function PortfolioUiAccountSheetReceive({ account }: { account: Account }) {
   const { t } = useTranslation('portfolio')
+  const { handleCopy } = useHandleCopyText({
+    text: account.publicKey,
+    toast: t(($) => $.actionCopyPublicKeySuccess),
+    toastFailed: t(($) => $.actionCopyPublicKeyError),
+  })
+
   return (
     <UiBottomSheet
       description={t(($) => $.pageReceiveDescription)}
@@ -20,17 +24,7 @@ export function PortfolioUiAccountSheetReceive({ account }: { account: Account }
         </Button>
       }
     >
-      <Button
-        onClick={async () => {
-          try {
-            await handleCopyText(account.publicKey)
-            toastSuccess(t(($) => $.actionCopyPublicKeySuccess))
-          } catch (error) {
-            toastError(error instanceof Error ? error.message : t(($) => $.actionCopyPublicKeyError))
-          }
-        }}
-        variant="outline"
-      >
+      <Button onClick={() => handleCopy()} variant="outline">
         <UiIcon icon="copy" />
         {t(($) => $.actionCopyPublicKey)}
       </Button>

--- a/packages/shell/src/ui/use-shell-command-group-suggestions.tsx
+++ b/packages/shell/src/ui/use-shell-command-group-suggestions.tsx
@@ -1,24 +1,20 @@
 import { useAccountActive } from '@workspace/db-react/use-account-active'
 import { useTranslation } from '@workspace/i18n'
-import { handleCopyText } from '@workspace/ui/lib/handle-copy-text'
-import { toastError } from '@workspace/ui/lib/toast-error'
-import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { useHandleCopyText } from '@workspace/ui/components/use-handle-copy-text'
 import type { ShellCommandGroup } from './use-shell-command-groups.tsx'
 
 export function useShellCommandGroupSuggestions(): ShellCommandGroup {
   const { t } = useTranslation('shell')
   const { publicKey } = useAccountActive()
+  const { handleCopy } = useHandleCopyText({
+    text: publicKey,
+    toast: t(($) => $.accountPublicKeyCopySuccess),
+    toastFailed: t(($) => $.accountPublicKeyCopyFailed),
+  })
   return {
     commands: [
       {
-        handler: async () => {
-          try {
-            await handleCopyText(publicKey)
-            toastSuccess(t(($) => $.accountPublicKeyCopySuccess))
-          } catch (error) {
-            toastError(error instanceof Error ? error.message : t(($) => $.accountPublicKeyCopyFailed))
-          }
-        },
+        handler: () => handleCopy(),
         label: t(($) => $.accountPublicKeyCopy),
       },
     ],


### PR DESCRIPTION
## Description


Replaces the usage of the plain function wrapped in a try/catch with the hook introduced in #587 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to use `useHandleCopyText` hook for text copy operations in `portfolio-ui-account-sheet-receive.tsx` and `use-shell-command-group-suggestions.tsx`.
> 
>   - **Refactor**:
>     - Replace `handleCopyText` with `useHandleCopyText` hook in `portfolio-ui-account-sheet-receive.tsx` and `use-shell-command-group-suggestions.tsx`.
>     - Simplifies copy operation by removing try/catch blocks and directly using `handleCopy()` from the hook.
>   - **Behavior**:
>     - In `portfolio-ui-account-sheet-receive.tsx`, `handleCopy` now uses `account.publicKey` with success and error toasts.
>     - In `use-shell-command-group-suggestions.tsx`, `handleCopy` uses `publicKey` with localized success and error messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f3439d6375b98aa4d85a121b47089d08d142daa1. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->