### PR TITLE
feat: add walletReadMnemonic helper

### DIFF
--- a/packages/db-react/src/options-wallet.tsx
+++ b/packages/db-react/src/options-wallet.tsx
@@ -6,6 +6,7 @@ import { walletDelete } from '@workspace/db/wallet/wallet-delete'
 import { walletFindMany } from '@workspace/db/wallet/wallet-find-many'
 import type { WalletFindManyInput } from '@workspace/db/wallet/wallet-find-many-input'
 import { walletFindUnique } from '@workspace/db/wallet/wallet-find-unique'
+import { walletReadMnemonic } from '@workspace/db/wallet/wallet-read-mnemonic'
 import { walletSetActive } from '@workspace/db/wallet/wallet-set-active'
 import { walletUpdate } from '@workspace/db/wallet/wallet-update'
 import type { WalletUpdateInput } from '@workspace/db/wallet/wallet-update-input'
@@ -14,6 +15,7 @@ import { queryClient } from './query-client.tsx'
 
 export type WalletCreateMutateOptions = MutateOptions<string, Error, { input: WalletCreateInput }>
 export type WalletDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
+export type WalletReadMnemonicMutateOptions = MutateOptions<string, Error, { id: string }>
 export type WalletSetActiveMutateOptions = MutateOptions<void, Error, { id: string }>
 export type WalletUpdateMutateOptions = MutateOptions<number, Error, { input: WalletUpdateInput }>
 
@@ -41,6 +43,11 @@ export const optionsWallet = {
     queryOptions({
       queryFn: () => walletFindUnique(db, id),
       queryKey: ['walletFindUnique', id],
+    }),
+  readMnemonic: (props: WalletReadMnemonicMutateOptions = {}) =>
+    mutationOptions({
+      mutationFn: ({ id }: { id: string }) => walletReadMnemonic(db, id),
+      ...props,
     }),
   setActive: (props: WalletSetActiveMutateOptions = {}) =>
     mutationOptions({

--- a/packages/db-react/src/use-wallet-read-mnemonic.tsx
+++ b/packages/db-react/src/use-wallet-read-mnemonic.tsx
@@ -1,0 +1,7 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { optionsWallet, type WalletReadMnemonicMutateOptions } from './options-wallet.tsx'
+
+export function useWalletReadMnemonic(props: WalletReadMnemonicMutateOptions = {}) {
+  return useMutation(optionsWallet.readMnemonic(props))
+}

--- a/packages/db/src/wallet/wallet-read-mnemonic.ts
+++ b/packages/db/src/wallet/wallet-read-mnemonic.ts
@@ -1,0 +1,17 @@
+import { tryCatch } from '@workspace/core/try-catch'
+import type { Database } from '../database.ts'
+
+export function walletReadMnemonic(db: Database, id: string) {
+  return db.transaction('r', db.wallets, async () => {
+    const { data: wallet, error } = await tryCatch(db.wallets.get(id))
+    if (error) {
+      console.log(error)
+      throw new Error(`Error finding wallet with id ${id}`)
+    }
+    if (!wallet) {
+      throw new Error(`Wallet with id ${id} not found`)
+    }
+    // TODO: Decrypt wallet.secret here and use it to decrypt wallet.mnemonic
+    return wallet.mnemonic
+  })
+}

--- a/packages/db/test/wallet-read-mnemonic.test.ts
+++ b/packages/db/test/wallet-read-mnemonic.test.ts
@@ -1,0 +1,60 @@
+import type { PromiseExtended } from 'dexie'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Wallet } from '../src/wallet/wallet.ts'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import { walletReadMnemonic } from '../src/wallet/wallet-read-mnemonic.ts'
+import { createDbTest, testWalletCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('wallet-read-mnemonic', () => {
+  beforeEach(async () => {
+    await db.wallets.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should read the mnemonic of a wallet', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput()
+      const id = await walletCreate(db, input)
+
+      // ACT
+      const result = await walletReadMnemonic(db, id)
+
+      // ASSERT
+      expect(result).toBe(input.mnemonic)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error if the wallet is not found', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = 'non-existent-id'
+
+      // ACT & ASSERT
+      await expect(walletReadMnemonic(db, id)).rejects.toThrow(`Wallet with id ${id} not found`)
+    })
+
+    it('should throw an error when reading the mnemonic fails', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = 'test-id'
+      vi.spyOn(db.wallets, 'get').mockImplementationOnce(
+        () => Promise.reject(new Error('Test error')) as PromiseExtended<Wallet | undefined>,
+      )
+
+      // ACT & ASSERT
+      await expect(walletReadMnemonic(db, id)).rejects.toThrow(`Error finding wallet with id ${id}`)
+    })
+  })
+})

--- a/packages/settings/src/data-access/use-derive-and-create-account.tsx
+++ b/packages/settings/src/data-access/use-derive-and-create-account.tsx
@@ -1,20 +1,21 @@
 import { useMutation } from '@tanstack/react-query'
 import type { Wallet } from '@workspace/db/wallet/wallet'
 import { useAccountCreate } from '@workspace/db-react/use-account-create'
+import { useWalletReadMnemonic } from '@workspace/db-react/use-wallet-read-mnemonic'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
-
 import { useDeriveFromMnemonic } from './use-derive-from-mnemonic.tsx'
 
 export function useDeriveAndCreateAccount() {
   const createAccountMutation = useAccountCreate()
   const deriveFromMnemonicMutation = useDeriveFromMnemonic()
-
+  const readMnemonicMutation = useWalletReadMnemonic()
   return useMutation({
     mutationFn: async ({ index, item }: { index: number; item: Wallet }) => {
+      const mnemonic = await readMnemonicMutation.mutateAsync({ id: item.id })
       const derivedAccount = await deriveFromMnemonicMutation.mutateAsync({
         derivationIndex: index,
         derivationPath: item.derivationPath,
-        mnemonic: item.mnemonic,
+        mnemonic,
       })
       await createAccountMutation.mutateAsync({
         input: {

--- a/packages/settings/src/ui/settings-ui-export-wallet-mnemonic.tsx
+++ b/packages/settings/src/ui/settings-ui-export-wallet-mnemonic.tsx
@@ -1,4 +1,5 @@
 import type { Wallet } from '@workspace/db/wallet/wallet'
+import { useWalletReadMnemonic } from '@workspace/db-react/use-wallet-read-mnemonic'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { Textarea } from '@workspace/ui/components/textarea'
@@ -11,27 +12,27 @@ import { SettingsUiExportConfirm } from './settings-ui-export-confirm.tsx'
 
 export function SettingsUiExportWalletMnemonic({ wallet }: { wallet: Wallet }) {
   const { t } = useTranslation('settings')
-  const [confirmed, setConfirmed] = useState(false)
   const [revealed, setRevealed] = useState(false)
+  const readMnemonicMutation = useWalletReadMnemonic()
 
   return (
     <UiBottomSheet
       description={t(($) => $.exportMnemonicCopyConfirmDescription)}
       title={t(($) => $.exportMnemonicCopyConfirmTitle)}
       trigger={
-        <Button disabled={!wallet.mnemonic} size="icon" title={t(($) => $.exportMnemonicCopy)} variant="outline">
+        <Button size="icon" title={t(($) => $.exportMnemonicCopy)} variant="outline">
           <UiIcon className="size-4" icon="mnemonic" />
         </Button>
       }
     >
       <div className="px-4 pb-4">
-        {confirmed ? (
+        {readMnemonicMutation.data?.length ? (
           <div className="space-y-2 text-center">
             <Textarea
               className={cn('w-full overflow-auto', {
                 'blur-sm': !revealed,
               })}
-              defaultValue={wallet.mnemonic}
+              defaultValue={readMnemonicMutation.data}
               readOnly
             />
             <div className="space-x-2">
@@ -41,13 +42,16 @@ export function SettingsUiExportWalletMnemonic({ wallet }: { wallet: Wallet }) {
               </Button>
               <UiTextCopyButton
                 label={t(($) => $.exportMnemonicCopy)}
-                text={wallet.mnemonic ?? ''}
+                text={readMnemonicMutation.data}
                 toast={t(($) => $.exportMnemonicCopyCopied)}
               />
             </div>
           </div>
         ) : (
-          <SettingsUiExportConfirm confirm={() => setConfirmed(true)} label={t(($) => $.exportMnemonicShow)} />
+          <SettingsUiExportConfirm
+            confirm={() => readMnemonicMutation.mutateAsync({ id: wallet.id })}
+            label={t(($) => $.exportMnemonicShow)}
+          />
         )}
       </div>
     </UiBottomSheet>


### PR DESCRIPTION
## Description

First part of #545


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `walletReadMnemonic` helper to read wallet mnemonics, integrates it into components, and includes tests for functionality and error handling.
> 
>   - **New Functionality**:
>     - Adds `walletReadMnemonic` function in `wallet-read-mnemonic.ts` to read wallet mnemonics from the database.
>     - Introduces `useWalletReadMnemonic` hook in `use-wallet-read-mnemonic.tsx` for React components to use the mnemonic reading functionality.
>   - **Integration**:
>     - Updates `options-wallet.tsx` to include `readMnemonic` mutation option.
>     - Modifies `use-derive-and-create-account.tsx` to use `useWalletReadMnemonic` for deriving accounts.
>     - Updates `settings-ui-export-wallet-mnemonic.tsx` to use `useWalletReadMnemonic` for exporting mnemonics.
>   - **Testing**:
>     - Adds `wallet-read-mnemonic.test.ts` to test reading mnemonics, including error handling for non-existent wallets and read failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ba5a07d0b83974dd071adba5b313b2a45851e3c5. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->