### PR TITLE
feat: ensure wallet.mnemonic is only available internally to the database

### DIFF
--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -5,7 +5,7 @@ import type { BookmarkTransaction } from './bookmark-transaction/bookmark-transa
 import type { Network } from './network/network.ts'
 import { populate } from './populate.ts'
 import type { Setting } from './setting/setting.ts'
-import type { Wallet } from './wallet/wallet.ts'
+import type { WalletInternal } from './wallet/wallet-internal.ts'
 
 export interface DatabaseConfig {
   name: string
@@ -17,7 +17,7 @@ export class Database extends Dexie {
   bookmarkTransactions!: Table<BookmarkTransaction>
   networks!: Table<Network>
   settings!: Table<Setting>
-  wallets!: Table<Wallet>
+  wallets!: Table<WalletInternal>
 
   constructor(config: DatabaseConfig) {
     super(config.name)

--- a/packages/db/src/wallet/wallet-create-schema.ts
+++ b/packages/db/src/wallet/wallet-create-schema.ts
@@ -1,6 +1,6 @@
-import { walletSchema } from './wallet-schema.ts'
+import { walletInternalSchema } from './wallet-internal-schema.ts'
 
-export const walletCreateSchema = walletSchema.omit({
+export const walletCreateSchema = walletInternalSchema.omit({
   accounts: true,
   createdAt: true,
   id: true,

--- a/packages/db/src/wallet/wallet-find-many.ts
+++ b/packages/db/src/wallet/wallet-find-many.ts
@@ -5,6 +5,7 @@ import type { Wallet } from './wallet.ts'
 import type { WalletFindManyInput } from './wallet-find-many-input.ts'
 
 import { walletFindManySchema } from './wallet-find-many-schema.ts'
+import { walletSanitizer } from './wallet-sanitizer.ts'
 
 export async function walletFindMany(db: Database, input: WalletFindManyInput = {}): Promise<Wallet[]> {
   const parsedInput = walletFindManySchema.parse(input)
@@ -36,7 +37,7 @@ export async function walletFindMany(db: Database, input: WalletFindManyInput = 
     return [
       ...dataWallets.map((wallet) => {
         return {
-          ...wallet,
+          ...walletSanitizer(wallet),
           accounts: [...dataAccounts.filter((account) => account.walletId === wallet.id)],
         }
       }),

--- a/packages/db/src/wallet/wallet-find-unique.ts
+++ b/packages/db/src/wallet/wallet-find-unique.ts
@@ -2,6 +2,7 @@ import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from '../database.ts'
 import type { Wallet } from './wallet.ts'
+import { walletSanitizer } from './wallet-sanitizer.ts'
 
 export async function walletFindUnique(db: Database, id: string): Promise<Wallet | null> {
   const { data, error } = await tryCatch(db.wallets.get(id))
@@ -9,5 +10,5 @@ export async function walletFindUnique(db: Database, id: string): Promise<Wallet
     console.log(error)
     throw new Error(`Error finding wallet with id ${id}`)
   }
-  return data ? data : null
+  return data ? walletSanitizer(data) : null
 }

--- a/packages/db/src/wallet/wallet-internal-schema.ts
+++ b/packages/db/src/wallet/wallet-internal-schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+import { accountSchema } from '../account/account-schema.ts'
+
+export const walletInternalSchema = z.object({
+  accounts: z.array(accountSchema).optional().default([]),
+  createdAt: z.date(),
+  derivationPath: z.string(),
+  id: z.string(),
+  mnemonic: z.string(),
+  name: z.string(),
+  order: z.number(),
+  secret: z.string(),
+  updatedAt: z.date(),
+})

--- a/packages/db/src/wallet/wallet-internal.ts
+++ b/packages/db/src/wallet/wallet-internal.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { walletInternalSchema } from './wallet-internal-schema.ts'
+
+export type WalletInternal = z.infer<typeof walletInternalSchema>

--- a/packages/db/src/wallet/wallet-sanitizer.ts
+++ b/packages/db/src/wallet/wallet-sanitizer.ts
@@ -1,0 +1,7 @@
+import type { Wallet } from './wallet.ts'
+import type { WalletInternal } from './wallet-internal.ts'
+import { walletSchema } from './wallet-schema.ts'
+
+export function walletSanitizer(internal: WalletInternal): Wallet {
+  return walletSchema.parse(internal)
+}

--- a/packages/db/src/wallet/wallet-schema.ts
+++ b/packages/db/src/wallet/wallet-schema.ts
@@ -1,15 +1,5 @@
-import { z } from 'zod'
+import { walletInternalSchema } from './wallet-internal-schema.ts'
 
-import { accountSchema } from '../account/account-schema.ts'
-
-export const walletSchema = z.object({
-  accounts: z.array(accountSchema).optional().default([]),
-  createdAt: z.date(),
-  derivationPath: z.string(),
-  id: z.string(),
-  mnemonic: z.string(),
-  name: z.string(),
-  order: z.number(),
-  secret: z.string(),
-  updatedAt: z.date(),
+export const walletSchema = walletInternalSchema.omit({
+  mnemonic: true,
 })

--- a/packages/db/test/wallet-create.test.ts
+++ b/packages/db/test/wallet-create.test.ts
@@ -26,7 +26,8 @@ describe('wallet-create', () => {
 
       // ASSERT
       const item = await walletFindUnique(db, result)
-      expect(item?.mnemonic).toBe(input.mnemonic)
+      // @ts-expect-error mnemonic does not exist on the type. Here we ensure it's sanitized.
+      expect(item?.mnemonic).toBe(undefined)
       expect(item?.name).toBe(input.name)
       expect(item?.order).toBe(0)
     })

--- a/packages/db/test/wallet-find-many.test.ts
+++ b/packages/db/test/wallet-find-many.test.ts
@@ -75,7 +75,7 @@ describe('wallet-find-many', () => {
 
     it('should find many wallets by id', async () => {
       // ARRANGE
-      expect.assertions(2)
+      expect.assertions(3)
       const wallet1 = testWalletCreateInput({ name: 'Test Wallet Alpha' })
       const wallet2 = testWalletCreateInput({ name: 'Test Wallet Beta' })
       const id1 = await walletCreate(db, wallet1)
@@ -87,6 +87,8 @@ describe('wallet-find-many', () => {
       // ASSERT
       expect(items).toHaveLength(1)
       expect(items[0]?.name).toEqual(wallet1.name)
+      // @ts-expect-error mnemonic does not exist on the type. Here we ensure it's sanitized.
+      expect(items[0]?.mnemonic).toEqual(undefined)
     })
   })
 
@@ -103,8 +105,8 @@ describe('wallet-find-many', () => {
       // ARRANGE
       expect.assertions(1)
       vi.spyOn(db.wallets, 'orderBy').mockImplementation(() => ({
-        // @ts-expect-error - Mocking Dexie's chained methods confuses Vitest's type inference.
         filter: () => ({
+          // @ts-expect-error - Mocking Dexie's chained methods confuses Vitest's type inference.
           toArray: () => Promise.reject(new Error('Test error')) as PromiseExtended<Wallet[]>,
         }),
       }))

--- a/packages/db/test/wallet-find-unique.test.ts
+++ b/packages/db/test/wallet-find-unique.test.ts
@@ -16,7 +16,7 @@ describe('wallet-find-unique', () => {
   describe('expected behavior', () => {
     it('should find a unique wallet', async () => {
       // ARRANGE
-      expect.assertions(2)
+      expect.assertions(3)
       const input = testWalletCreateInput()
       const id = await walletCreate(db, input)
 
@@ -26,6 +26,8 @@ describe('wallet-find-unique', () => {
       // ASSERT
       expect(item).toBeDefined()
       expect(item?.name).toBe(input.name)
+      // @ts-expect-error mnemonic does not exist on the type. Here we ensure it's sanitized.
+      expect(item?.mnemonic).toBe(undefined)
     })
   })
 


### PR DESCRIPTION
## Description

Second part #545

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `mnemonic` in `Wallet` is internal to the database by using `WalletInternal` and `walletSanitizer`.
> 
>   - **Behavior**:
>     - Introduces `WalletInternal` type in `wallet-internal.ts` to include `mnemonic`.
>     - Adds `walletSanitizer` function in `wallet-sanitizer.ts` to remove `mnemonic` from `WalletInternal`.
>     - Updates `walletFindMany()` in `wallet-find-many.ts` and `walletFindUnique()` in `wallet-find-unique.ts` to use `walletSanitizer`.
>   - **Schema**:
>     - Creates `walletInternalSchema` in `wallet-internal-schema.ts` with `mnemonic`.
>     - Updates `walletSchema` in `wallet-schema.ts` to omit `mnemonic`.
>     - Updates `walletCreateSchema` in `wallet-create-schema.ts` to use `walletInternalSchema`.
>   - **Database**:
>     - Changes `Wallet` to `WalletInternal` in `database.ts`.
>   - **Tests**:
>     - Updates tests in `wallet-create.test.ts`, `wallet-find-many.test.ts`, and `wallet-find-unique.test.ts` to check `mnemonic` is undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ecff3a166523215b040cfd21863bfc6891316f25. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->