### PR TITLE
style(linter): enable no useless else rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -68,6 +68,7 @@
       },
       "recommended": true,
       "style": {
+        "noUselessElse": "error",
         "useComponentExportOnlyModules": {
           "options": {
             "allowConstantExport": true

--- a/packages/db/src/bookmark-account/bookmark-account-toggle.ts
+++ b/packages/db/src/bookmark-account/bookmark-account-toggle.ts
@@ -11,9 +11,8 @@ export async function bookmarkAccountToggle(db: Database, address: Address): Pro
     if (existing) {
       await bookmarkAccountDelete(db, existing.id)
       return 'deleted'
-    } else {
-      await bookmarkAccountCreate(db, { address })
-      return 'created'
     }
+    await bookmarkAccountCreate(db, { address })
+    return 'created'
   })
 }

--- a/packages/db/src/bookmark-transaction/bookmark-transaction-toggle.ts
+++ b/packages/db/src/bookmark-transaction/bookmark-transaction-toggle.ts
@@ -11,9 +11,8 @@ export async function bookmarkTransactionToggle(db: Database, signature: Signatu
     if (existing) {
       await bookmarkTransactionDelete(db, existing.id)
       return 'deleted'
-    } else {
-      await bookmarkTransactionCreate(db, { signature })
-      return 'created'
     }
+    await bookmarkTransactionCreate(db, { signature })
+    return 'created'
   })
 }


### PR DESCRIPTION
## Description

2 useless `else` cases sneaked in and I figured this should have been caught by our linter.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable `noUselessElse` linter rule and refactor code to remove unnecessary `else` statements in toggle functions.
> 
>   - **Linter**:
>     - Enable `noUselessElse` rule in `biome.json` to catch unnecessary `else` statements.
>   - **Refactoring**:
>     - Remove useless `else` in `bookmarkAccountToggle()` in `bookmark-account-toggle.ts`.
>     - Remove useless `else` in `bookmarkTransactionToggle()` in `bookmark-transaction-toggle.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 73be740c646aef009623302e699a4438e3aaa77c. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->