### PR TITLE
chore: add sdk version file

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,2 @@
+java=17.0.17-zulu
+gradle=8.14.3


### PR DESCRIPTION
## Description

This adds a sdkman version file. We can't use latest version of Java or Gradle yet so locking to an older version for consistent builds.

- https://sdkman.io/
- https://mvnrepository.com/artifact/com.android.tools.build/gradle
- https://docs.gradle.org/current/userguide/compatibility.html

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `.sdkmanrc` to lock Java and Gradle versions for consistent builds.
> 
>   - **Configuration**:
>     - Adds `.sdkmanrc` file to lock Java version to `17.0.17-zulu` and Gradle version to `8.14.3` for consistent builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 1e3d99dee14133cfc04af19d40606eb11e18c3a7. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->