### PR TITLE
fix(site): don't use /go/x redirect to prevent metadata from breaking

### DIFF
--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -33,7 +33,7 @@ export default defineConfig({
           label: 'GitHub',
         },
         {
-          href: 'https://samui.build/go/x',
+          href: 'https://x.com/SamuiBuild',
           icon: 'x.com',
           label: 'X / Twitter',
         },


### PR DESCRIPTION
## Description

Turns out that the social links in the Astro config determine how the metadata gets added. Updating it to the full url on X while maintaining the shortcuts so we use that everywhere else to link to our X.

Closes #607

## Screenshots / Video

<img width="721" height="270" alt="image" src="https://github.com/user-attachments/assets/2bb41af0-331f-4741-86d2-a72a9ebb76fa" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update X social link in `astro.config.mjs` to prevent metadata issues by using the full URL.
> 
>   - **Behavior**:
>     - Updates `href` for X in `astro.config.mjs` from `https://samui.build/go/x` to `https://x.com/SamuiBuild` to prevent metadata issues.
>   - **Misc**:
>     - Closes issue #607.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for bde508529a67933edb9307e3b3d9c419f896211b. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->