### PR TITLE
refactor: move react and react-dom to peer dependencies in packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -256,8 +256,6 @@
         "@workspace/db": "workspace:*",
         "@workspace/ui": "workspace:*",
         "dexie-react-hooks": "^4.2.0",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-router": "catalog:",
       },
       "devDependencies": {
@@ -268,6 +266,10 @@
         "@workspace/config-vitest": "workspace:*",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/dev": {
@@ -283,8 +285,6 @@
         "@workspace/settings": "workspace:*",
         "@workspace/solana-client-react": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
         "zod": "catalog:",
@@ -295,6 +295,10 @@
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/env": {
@@ -322,8 +326,6 @@
         "@workspace/solana-client": "workspace:*",
         "@workspace/solana-client-react": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
         "zod": "catalog:",
@@ -335,6 +337,10 @@
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
       },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
+      },
     },
     "packages/i18n": {
       "name": "@workspace/i18n",
@@ -342,14 +348,16 @@
       "dependencies": {
         "i18next": "^25.6.0",
         "i18next-cli": "^1.19.1",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-i18next": "^16.2.3",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/keypair": {
@@ -383,8 +391,6 @@
         "@workspace/solana-client": "workspace:*",
         "@workspace/solana-client-react": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-router": "catalog:",
       },
       "devDependencies": {
@@ -393,6 +399,10 @@
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/portfolio": {
@@ -411,8 +421,6 @@
         "@workspace/solana-client": "workspace:*",
         "@workspace/solana-client-react": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
         "zod": "catalog:",
@@ -423,6 +431,10 @@
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/settings": {
@@ -439,8 +451,6 @@
         "@workspace/keypair": "workspace:*",
         "@workspace/solana-client": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
         "zod": "catalog:",
@@ -451,6 +461,10 @@
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/shell": {
@@ -468,8 +482,6 @@
         "@workspace/settings": "workspace:*",
         "@workspace/tools": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-router": "catalog:",
         "wxt": "catalog:",
       },
@@ -479,6 +491,10 @@
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/solana-client": {
@@ -510,8 +526,6 @@
         "@workspace/keypair": "workspace:*",
         "@workspace/solana-client": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -519,6 +533,10 @@
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/tools": {
@@ -536,8 +554,6 @@
         "@workspace/solana-client": "workspace:*",
         "@workspace/solana-client-react": "workspace:*",
         "@workspace/ui": "workspace:*",
-        "react": "catalog:",
-        "react-dom": "catalog:",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
         "zod": "catalog:",
@@ -549,6 +565,10 @@
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
       },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
+      },
     },
     "packages/tui": {
       "name": "@workspace/tui",
@@ -556,7 +576,6 @@
       "dependencies": {
         "@opentui/core": "^0.1.31",
         "@opentui/react": "^0.1.31",
-        "react": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -564,6 +583,9 @@
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
         "typescript": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
       },
     },
     "packages/ui": {
@@ -599,9 +621,7 @@
         "date-fns": "^4.1.0",
         "lucide-react": "catalog:",
         "next-themes": "^0.4.6",
-        "react": "catalog:",
         "react-day-picker": "^9.11.0",
-        "react-dom": "catalog:",
         "react-hook-form": "^7.65.0",
         "react-qrcode-logo": "^4.0.0",
         "react-resizable-panels": "^3.0.6",
@@ -623,6 +643,10 @@
         "tailwindcss": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/wallet-standard": {

--- a/packages/db-react/package.json
+++ b/packages/db-react/package.json
@@ -5,8 +5,6 @@
     "@workspace/db": "workspace:*",
     "@workspace/ui": "workspace:*",
     "dexie-react-hooks": "^4.2.0",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-router": "catalog:"
   },
   "devDependencies": {
@@ -23,6 +21,10 @@
   },
   "license": "MIT",
   "name": "@workspace/db-react",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -9,8 +9,6 @@
     "@workspace/settings": "workspace:*",
     "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",
     "zod": "catalog:"
@@ -27,6 +25,10 @@
   },
   "license": "MIT",
   "name": "@workspace/dev",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -9,8 +9,6 @@
     "@workspace/solana-client": "workspace:*",
     "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",
     "zod": "catalog:"
@@ -27,6 +25,10 @@
   },
   "license": "MIT",
   "name": "@workspace/explorer",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -2,8 +2,6 @@
   "dependencies": {
     "i18next": "^25.6.0",
     "i18next-cli": "^1.19.1",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-i18next": "^16.2.3"
   },
   "devDependencies": {
@@ -17,6 +15,10 @@
   },
   "license": "MIT",
   "name": "@workspace/i18n",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -9,8 +9,6 @@
     "@workspace/solana-client": "workspace:*",
     "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-router": "catalog:"
   },
   "devDependencies": {
@@ -25,6 +23,10 @@
   },
   "license": "MIT",
   "name": "@workspace/onboarding",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/portfolio/package.json
+++ b/packages/portfolio/package.json
@@ -12,8 +12,6 @@
     "@workspace/solana-client": "workspace:*",
     "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",
     "zod": "catalog:"
@@ -30,6 +28,10 @@
   },
   "license": "MIT",
   "name": "@workspace/portfolio",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -10,8 +10,6 @@
     "@workspace/keypair": "workspace:*",
     "@workspace/solana-client": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",
     "zod": "catalog:"
@@ -28,6 +26,10 @@
   },
   "license": "MIT",
   "name": "@workspace/settings",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -11,8 +11,6 @@
     "@workspace/settings": "workspace:*",
     "@workspace/tools": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-router": "catalog:",
     "wxt": "catalog:"
   },
@@ -28,6 +26,10 @@
   },
   "license": "MIT",
   "name": "@workspace/shell",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/solana-client-react/package.json
+++ b/packages/solana-client-react/package.json
@@ -6,9 +6,7 @@
     "@workspace/db-react": "workspace:*",
     "@workspace/keypair": "workspace:*",
     "@workspace/solana-client": "workspace:*",
-    "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:"
+    "@workspace/ui": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
@@ -23,6 +21,10 @@
   },
   "license": "MIT",
   "name": "@workspace/solana-client-react",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -11,8 +11,6 @@
     "@workspace/solana-client": "workspace:*",
     "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",
     "zod": "catalog:"
@@ -29,6 +27,10 @@
   },
   "license": "MIT",
   "name": "@workspace/tools",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
     "@opentui/core": "^0.1.31",
-    "@opentui/react": "^0.1.31",
-    "react": "catalog:"
+    "@opentui/react": "^0.1.31"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
@@ -18,6 +17,9 @@
   "license": "MIT",
   "module": "src/index.tsx",
   "name": "@workspace/tui",
+  "peerDependencies": {
+    "react": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,9 +29,7 @@
     "date-fns": "^4.1.0",
     "lucide-react": "catalog:",
     "next-themes": "^0.4.6",
-    "react": "catalog:",
     "react-day-picker": "^9.11.0",
-    "react-dom": "catalog:",
     "react-hook-form": "^7.65.0",
     "react-qrcode-logo": "^4.0.0",
     "react-resizable-panels": "^3.0.6",
@@ -61,6 +59,10 @@
     "./lib/*": "./src/lib/*.ts"
   },
   "name": "@workspace/ui",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/turbo/generators/templates/pkg/react-ui/package.json.hbs
+++ b/turbo/generators/templates/pkg/react-ui/package.json.hbs
@@ -1,8 +1,4 @@
 {
-  "dependencies": {
-    "react": "catalog:",
-    "react-dom": "catalog:"
-  },
   "devDependencies": {
     "@types/bun": "catalog:",
     "@types/react": "catalog:",
@@ -15,6 +11,10 @@
   },
   "license": "MIT",
   "name": "@workspace/{{name}}",
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
   "private": false,
   "scripts": {
     "check-types": "tsc --noEmit"


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

This change moves react and react-dom to the peer dependencies of packages. In general packages should not pull in react to avoid different versions of react being loaded. That responsibility should be left to the app that is using the packages.

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move `react` and `react-dom` to peerDependencies in multiple package.json files to prevent version conflicts.
> 
>   - **Dependencies to Peer Dependencies**:
>     - Move `react` and `react-dom` from `dependencies` to `peerDependencies` in `packages/db-react/package.json`, `packages/dev/package.json`, and `packages/explorer/package.json`.
>     - Apply the same change in `packages/i18n/package.json`, `packages/onboarding/package.json`, and `packages/portfolio/package.json`.
>     - Update `packages/settings/package.json`, `packages/shell/package.json`, and `packages/solana-client-react/package.json` similarly.
>     - Modify `packages/tools/package.json`, `packages/tui/package.json`, and `packages/ui/package.json` to reflect this change.
>     - Adjust `turbo/generators/templates/pkg/react-ui/package.json.hbs` to use `peerDependencies` for `react` and `react-dom`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f252fd1af9c74eb59e14454e6b2f55d68eadeb6b. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->