### PR TITLE
feat: add `accountReadSecretKey` helper

### DIFF
--- a/packages/db-react/src/options-account.tsx
+++ b/packages/db-react/src/options-account.tsx
@@ -6,6 +6,7 @@ import { accountFindByWalletId } from '@workspace/db/account/account-find-by-wal
 import { accountFindMany } from '@workspace/db/account/account-find-many'
 import type { AccountFindManyInput } from '@workspace/db/account/account-find-many-input'
 import { accountFindUnique } from '@workspace/db/account/account-find-unique'
+import { accountReadSecretKey } from '@workspace/db/account/account-read-secret-key'
 import { accountSetActive } from '@workspace/db/account/account-set-active'
 import { accountUpdate } from '@workspace/db/account/account-update'
 import type { AccountUpdateInput } from '@workspace/db/account/account-update-input'
@@ -15,6 +16,7 @@ import { queryClient } from './query-client.tsx'
 
 export type AccountCreateMutateOptions = MutateOptions<string, Error, { input: AccountCreateInput }>
 export type AccountDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
+export type AccountReadSecretKeyMutateOptions = MutateOptions<string | undefined, Error, { id: string }>
 export type AccountSetActiveMutateOptions = MutateOptions<void, Error, { id: string }>
 export type AccountUpdateMutateOptions = MutateOptions<number, Error, { input: AccountUpdateInput }>
 
@@ -47,6 +49,11 @@ export const optionsAccount = {
     queryOptions({
       queryFn: () => accountFindUnique(db, id),
       queryKey: ['accountFindUnique', id],
+    }),
+  readSecretKey: (props: AccountReadSecretKeyMutateOptions = {}) =>
+    mutationOptions({
+      mutationFn: ({ id }: { id: string }) => accountReadSecretKey(db, id),
+      ...props,
     }),
   setActive: (props: AccountSetActiveMutateOptions = {}) =>
     mutationOptions({

--- a/packages/db-react/src/use-account-read-secret-key.tsx
+++ b/packages/db-react/src/use-account-read-secret-key.tsx
@@ -1,0 +1,7 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { type AccountReadSecretKeyMutateOptions, optionsAccount } from './options-account.tsx'
+
+export function useAccountReadSecretKey(props: AccountReadSecretKeyMutateOptions = {}) {
+  return useMutation(optionsAccount.readSecretKey(props))
+}

--- a/packages/db/src/account/account-create.ts
+++ b/packages/db/src/account/account-create.ts
@@ -21,6 +21,7 @@ export async function accountCreate(db: Database, input: AccountCreateInput): Pr
         derivationIndex: parsedInput.derivationIndex ?? 0,
         id: randomId(),
         order: order,
+        secretKey: parsedInput.secretKey,
         updatedAt: now,
       }),
     )

--- a/packages/db/src/account/account-read-secret-key.ts
+++ b/packages/db/src/account/account-read-secret-key.ts
@@ -1,0 +1,20 @@
+import { tryCatch } from '@workspace/core/try-catch'
+import type { Database } from '../database.ts'
+
+export function accountReadSecretKey(db: Database, id: string) {
+  return db.transaction('r', db.accounts, async () => {
+    const { data: account, error } = await tryCatch(db.accounts.get(id))
+    if (error) {
+      console.log(error)
+      throw new Error(`Error finding account with id ${id}`)
+    }
+    if (!account) {
+      throw new Error(`Account with id ${id} not found`)
+    }
+    if (account.type === 'Watched') {
+      throw new Error(`Account with id ${id} does not have a secret key`)
+    }
+    // TODO: Decrypt account.secretKey here
+    return account.secretKey
+  })
+}

--- a/packages/db/test/account-read-secret-key.test.ts
+++ b/packages/db/test/account-read-secret-key.test.ts
@@ -1,0 +1,75 @@
+import type { PromiseExtended } from 'dexie'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Account } from '../src/account/account.ts'
+import { accountCreate } from '../src/account/account-create.ts'
+import { accountReadSecretKey } from '../src/account/account-read-secret-key.ts'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('account-read-secret-key', () => {
+  beforeEach(async () => {
+    await db.accounts.clear()
+    await db.wallets.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should read the secret key of an account', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletInput = testWalletCreateInput()
+      const walletId = await walletCreate(db, walletInput)
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const id = await accountCreate(db, accountInput)
+
+      // ACT
+      const result = await accountReadSecretKey(db, id)
+
+      // ASSERT
+      expect(result).toBe(accountInput.secretKey)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error if the account is not found', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = 'non-existent-id'
+
+      // ACT & ASSERT
+      await expect(accountReadSecretKey(db, id)).rejects.toThrow(`Account with id ${id} not found`)
+    })
+
+    it('should throw an error if the account is of type Watched', async () => {
+      // ARRANGE
+      const walletInput = testWalletCreateInput()
+      const walletId = await walletCreate(db, walletInput)
+      const accountInput = testAccountCreateInput({ type: 'Watched', walletId })
+      const id = await accountCreate(db, accountInput)
+
+      // ACT & ASSERT
+      await expect(accountReadSecretKey(db, id)).rejects.toThrow(`Account with id ${id} does not have a secret key`)
+    })
+
+    it('should throw an error when reading the secret key fails', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = 'test-id'
+      vi.spyOn(db.accounts, 'get').mockImplementationOnce(
+        () => Promise.reject(new Error('Test error')) as PromiseExtended<Account | undefined>,
+      )
+
+      // ACT & ASSERT
+      await expect(accountReadSecretKey(db, id)).rejects.toThrow(`Error finding account with id ${id}`)
+    })
+  })
+})

--- a/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
@@ -1,15 +1,13 @@
+import type { KeyPairSigner } from '@solana/kit'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
-import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
 import { createAndSendSplTransaction } from '@workspace/solana-client/create-and-send-spl-transaction'
 import { getAccountInfoQueryOptions } from '@workspace/solana-client-react/use-get-account-info'
 import { getBalanceQueryOptions } from '@workspace/solana-client-react/use-get-balance'
 import { getTokenAccountsQueryOptions } from '@workspace/solana-client-react/use-get-token-accounts'
 import { useSolanaClient } from '@workspace/solana-client-react/use-solana-client'
 
-export function useCreateAndSendSplTransaction(props: { network: Network }) {
-  const { network } = props
+export function useCreateAndSendSplTransaction({ network }: { network: Network }) {
   const queryClient = useQueryClient()
   const client = useSolanaClient({ network })
 
@@ -19,22 +17,17 @@ export function useCreateAndSendSplTransaction(props: { network: Network }) {
       decimals,
       destination,
       mint,
-      account,
+      sender,
     }: {
       amount: string
       decimals: number
       destination: string
       mint: string
-      account: Account
+      sender: KeyPairSigner
     }) => {
-      if (!account.secretKey) {
-        throw new Error(`No secret key for this account`)
-      }
-      const sender = await createKeyPairSignerFromJson({ json: account.secretKey })
-
       return createAndSendSplTransaction(client, { amount, decimals, destination, mint, sender })
     },
-    onSuccess: (_, { account: { publicKey: address } }) => {
+    onSuccess: (_, { sender: { address } }) => {
       queryClient.invalidateQueries({
         queryKey: getBalanceQueryOptions({ address, client, network }).queryKey,
       })

--- a/packages/settings/src/ui/settings-ui-export-account-secret-key.tsx
+++ b/packages/settings/src/ui/settings-ui-export-account-secret-key.tsx
@@ -1,4 +1,5 @@
 import type { Account } from '@workspace/db/account/account'
+import { useAccountReadSecretKey } from '@workspace/db-react/use-account-read-secret-key'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { Textarea } from '@workspace/ui/components/textarea'
@@ -11,27 +12,32 @@ import { SettingsUiExportConfirm } from './settings-ui-export-confirm.tsx'
 
 export function SettingsUiExportAccountSecretKey({ account }: { account: Account }) {
   const { t } = useTranslation('settings')
-  const [confirmed, setConfirmed] = useState(false)
   const [revealed, setRevealed] = useState(false)
+  const readSecretKeyMutation = useAccountReadSecretKey()
 
   return (
     <UiBottomSheet
       description={t(($) => $.exportSecretKeyCopyConfirmDescription)}
       title={t(($) => $.exportSecretKeyCopyConfirmTitle)}
       trigger={
-        <Button disabled={!account.secretKey} size="icon" title={t(($) => $.exportSecretKeyCopy)} variant="outline">
+        <Button
+          disabled={account.type === 'Watched'}
+          size="icon"
+          title={t(($) => $.exportSecretKeyCopy)}
+          variant="outline"
+        >
           <UiIcon className="size-4" icon="key" />
         </Button>
       }
     >
       <div className="px-4 pb-4">
-        {confirmed ? (
+        {readSecretKeyMutation?.data?.length ? (
           <div className="space-y-2 text-center">
             <Textarea
               className={cn('w-full overflow-auto', {
                 'blur-sm': !revealed,
               })}
-              defaultValue={account.secretKey}
+              defaultValue={readSecretKeyMutation.data}
               readOnly
             />
             <div className="space-x-2">
@@ -41,13 +47,16 @@ export function SettingsUiExportAccountSecretKey({ account }: { account: Account
               </Button>
               <UiTextCopyButton
                 label={t(($) => $.exportSecretKeyCopy)}
-                text={account.secretKey ?? ''}
+                text={readSecretKeyMutation.data}
                 toast={t(($) => $.exportSecretKeyCopyCopied)}
               />
             </div>
           </div>
         ) : (
-          <SettingsUiExportConfirm confirm={() => setConfirmed(true)} label={t(($) => $.exportSecretKeyShow)} />
+          <SettingsUiExportConfirm
+            confirm={() => readSecretKeyMutation.mutateAsync({ id: account.id })}
+            label={t(($) => $.exportSecretKeyShow)}
+          />
         )}
       </div>
     </UiBottomSheet>

--- a/packages/solana-client-react/src/use-spl-token-create-token-mint.tsx
+++ b/packages/solana-client-react/src/use-spl-token-create-token-mint.tsx
@@ -1,7 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
-import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
 import type { SplTokenCreateTokenMintOptions } from '@workspace/solana-client/spl-token-create-token-mint'
 import { splTokenCreateTokenMint } from '@workspace/solana-client/spl-token-create-token-mint'
 import { toastError } from '@workspace/ui/lib/toast-error'
@@ -12,13 +11,7 @@ export function useSplTokenCreateTokenMint(props: { account: Account; network: N
   const client = useSolanaClient({ network: props.network })
 
   return useMutation({
-    mutationFn: async (input: Omit<SplTokenCreateTokenMintOptions, 'feePayer'>) => {
-      if (!props.account.secretKey) {
-        throw new Error('Missing account secret key')
-      }
-      const feePayer = await createKeyPairSignerFromJson({ json: props.account.secretKey })
-      return splTokenCreateTokenMint(client, { ...input, feePayer })
-    },
+    mutationFn: async (input: SplTokenCreateTokenMintOptions) => splTokenCreateTokenMint(client, input),
     onError: () => {
       toastError('Failed to create token mint.')
     },


### PR DESCRIPTION
## Description

Part of #545

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `accountReadSecretKey` helper and integrate it across the codebase for secure secret key handling.
> 
>   - **New Functionality**:
>     - Add `accountReadSecretKey` function in `account-read-secret-key.ts` to read secret keys from accounts, with error handling for non-existent accounts and 'Watched' type accounts.
>     - Add `useAccountReadSecretKey` hook in `use-account-read-secret-key.tsx` to use the `accountReadSecretKey` function with React Query.
>   - **Integration**:
>     - Integrate `useAccountReadSecretKey` in `portfolio-feature-tab-tokens.tsx` for handling SOL and SPL token transactions.
>     - Use `useAccountReadSecretKey` in `settings-ui-export-account-secret-key.tsx` to export account secret keys.
>     - Modify `use-create-and-send-spl-transaction.tsx` to use `KeyPairSigner` instead of `Account` for transactions.
>   - **Testing**:
>     - Add `account-read-secret-key.test.ts` to test `accountReadSecretKey` function for various scenarios, including error cases.
>   - **Miscellaneous**:
>     - Update `account-create.ts` to include `secretKey` in account creation.
>     - Adjust `tools-feature-create-token.tsx` to use `useAccountReadSecretKey` for token creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for db69ef6d6dd23db84b925c613c915a4f837ca592. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->