### PR TITLE
feat: ensure account.secretKey is only available internally to the database

### DIFF
--- a/packages/background/src/services/db.ts
+++ b/packages/background/src/services/db.ts
@@ -4,6 +4,7 @@ import { defineProxyService } from '@webext-core/proxy-service'
 import type { Account } from '@workspace/db/account/account'
 import { accountCreate } from '@workspace/db/account/account-create'
 import { accountFindUnique } from '@workspace/db/account/account-find-unique'
+import { accountReadSecretKey } from '@workspace/db/account/account-read-secret-key'
 import { db } from '@workspace/db/db'
 import { settingGetValue } from '@workspace/db/setting/setting-get-value'
 import { walletCreate } from '@workspace/db/wallet/wallet-create'
@@ -26,6 +27,19 @@ export const [registerDbService, getDbService] = defineProxyService('DbService',
       }
 
       return account
+    },
+    secretKey: async (): Promise<string> => {
+      const accountId = await settingGetValue(db, 'activeAccountId')
+      if (!accountId) {
+        throw new Error('No active account set')
+      }
+
+      const secretKey = await accountReadSecretKey(db, accountId)
+      if (!secretKey) {
+        throw new Error('Active account secretKey not found')
+      }
+
+      return secretKey
     },
     walletAccounts: async (): Promise<StandardConnectOutput> => {
       const account = await getDbService().account.active()

--- a/packages/background/src/services/sign.ts
+++ b/packages/background/src/services/sign.ts
@@ -40,12 +40,12 @@ export const [registerSignService, getSignService] = defineProxyService('SignSer
     inputs: SolanaSignAndSendTransactionInput[],
   ): Promise<SolanaSignAndSendTransactionOutput[]> => {
     const results: SolanaSignAndSendTransactionOutput[] = []
-    const active = await getDbService().account.active()
-    if (!active.secretKey) {
+    const activeSecretKey = await getDbService().account.secretKey()
+    if (!activeSecretKey) {
       throw new Error('Active account has no secret key')
     }
 
-    const bytes = new Uint8Array(JSON.parse(active.secretKey))
+    const bytes = new Uint8Array(JSON.parse(activeSecretKey))
     const key = await createKeyPairFromBytes(bytes)
 
     for (const input of inputs) {
@@ -66,8 +66,9 @@ export const [registerSignService, getSignService] = defineProxyService('SignSer
   signIn: async (inputs: SolanaSignInInput[]): Promise<SolanaSignInOutput[]> => {
     const results: SolanaSignInOutput[] = []
     const active = await getDbService().account.active()
+    const activeSecretKey = await getDbService().account.secretKey()
     const accounts = await getDbService().account.walletAccounts()
-    if (!active.secretKey) {
+    if (!activeSecretKey) {
       throw new Error('Active account has no secret key')
     }
 
@@ -75,7 +76,7 @@ export const [registerSignService, getSignService] = defineProxyService('SignSer
       throw new Error('No wallet account found')
     }
 
-    const bytes = new Uint8Array(JSON.parse(active.secretKey))
+    const bytes = new Uint8Array(JSON.parse(activeSecretKey))
     const { privateKey } = await createKeyPairFromBytes(bytes)
 
     for (const input of inputs) {
@@ -98,12 +99,12 @@ export const [registerSignService, getSignService] = defineProxyService('SignSer
   },
   signMessage: async (inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> => {
     const results: SolanaSignMessageOutput[] = []
-    const active = await getDbService().account.active()
-    if (!active.secretKey) {
+    const activeSecretKey = await getDbService().account.secretKey()
+    if (!activeSecretKey) {
       throw new Error('Active account has no secret key')
     }
 
-    const bytes = new Uint8Array(JSON.parse(active.secretKey))
+    const bytes = new Uint8Array(JSON.parse(activeSecretKey))
     const { privateKey } = await createKeyPairFromBytes(bytes)
 
     for (const input of inputs) {
@@ -121,12 +122,12 @@ export const [registerSignService, getSignService] = defineProxyService('SignSer
   },
   signTransaction: async (inputs: SolanaSignTransactionInput[]): Promise<SolanaSignTransactionOutput[]> => {
     const results: SolanaSignTransactionOutput[] = []
-    const active = await getDbService().account.active()
-    if (!active.secretKey) {
+    const activeSecretKey = await getDbService().account.secretKey()
+    if (!activeSecretKey) {
       throw new Error('Active account has no secret key')
     }
 
-    const bytes = new Uint8Array(JSON.parse(active.secretKey))
+    const bytes = new Uint8Array(JSON.parse(activeSecretKey))
     const key = await createKeyPairFromBytes(bytes)
 
     for (const input of inputs) {

--- a/packages/db/src/account/account-create-schema.ts
+++ b/packages/db/src/account/account-create-schema.ts
@@ -1,6 +1,6 @@
-import { accountSchema } from './account-schema.ts'
+import { accountInternalSchema } from './account-internal-schema.ts'
 
-export const accountCreateSchema = accountSchema
+export const accountCreateSchema = accountInternalSchema
   .omit({
     createdAt: true,
     id: true,

--- a/packages/db/src/account/account-find-by-wallet-id.ts
+++ b/packages/db/src/account/account-find-by-wallet-id.ts
@@ -1,9 +1,19 @@
+import { tryCatch } from '@workspace/core/try-catch'
 import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
+import { accountSanitizer } from './account-sanitizer.ts'
 
 export async function accountFindByWalletId(db: Database, id?: string | null): Promise<Account[]> {
-  return db.accounts
-    .orderBy('derivationIndex')
-    .filter(({ walletId }) => (id ? walletId === id : true))
-    .toArray()
+  const { data, error } = await tryCatch(
+    db.accounts
+      .orderBy('derivationIndex')
+      .filter(({ walletId }) => (id ? walletId === id : true))
+      .toArray(),
+  )
+  if (error) {
+    console.log(error)
+    throw new Error(`Error finding account with id ${id}`)
+  }
+
+  return data?.map((item) => accountSanitizer(item))
 }

--- a/packages/db/src/account/account-find-many.ts
+++ b/packages/db/src/account/account-find-many.ts
@@ -3,6 +3,7 @@ import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
 import type { AccountFindManyInput } from './account-find-many-input.ts'
 import { accountFindManySchema } from './account-find-many-schema.ts'
+import { accountSanitizer } from './account-sanitizer.ts'
 
 export async function accountFindMany(db: Database, input: AccountFindManyInput): Promise<Account[]> {
   const parsedInput = accountFindManySchema.parse(input)
@@ -24,5 +25,5 @@ export async function accountFindMany(db: Database, input: AccountFindManyInput)
     console.log(error)
     throw new Error(`Error finding accounts for wallet id ${parsedInput.walletId}`)
   }
-  return data
+  return data?.map((item) => accountSanitizer(item))
 }

--- a/packages/db/src/account/account-find-unique.ts
+++ b/packages/db/src/account/account-find-unique.ts
@@ -1,6 +1,7 @@
 import { tryCatch } from '@workspace/core/try-catch'
 import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
+import { accountSanitizer } from './account-sanitizer.ts'
 
 export async function accountFindUnique(db: Database, id: string): Promise<null | Account> {
   const { data, error } = await tryCatch(db.accounts.get(id))
@@ -8,5 +9,5 @@ export async function accountFindUnique(db: Database, id: string): Promise<null 
     console.log(error)
     throw new Error(`Error finding account with id ${id}`)
   }
-  return data ? data : null
+  return data ? accountSanitizer(data) : null
 }

--- a/packages/db/src/account/account-internal-schema.ts
+++ b/packages/db/src/account/account-internal-schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { solanaAddressSchema } from '../solana/solana-address-schema.ts'
+import { accountTypeSchema } from './account-type-schema.ts'
+
+export const accountInternalSchema = z.object({
+  createdAt: z.date(),
+  derivationIndex: z.number(),
+  id: z.string(),
+  name: z.string(),
+  order: z.number(),
+  publicKey: solanaAddressSchema,
+  secretKey: z.string().optional(),
+  type: accountTypeSchema,
+  updatedAt: z.date(),
+  walletId: z.string(),
+})

--- a/packages/db/src/account/account-internal.ts
+++ b/packages/db/src/account/account-internal.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { accountInternalSchema } from './account-internal-schema.ts'
+
+export type AccountInternal = z.infer<typeof accountInternalSchema>

--- a/packages/db/src/account/account-sanitizer.ts
+++ b/packages/db/src/account/account-sanitizer.ts
@@ -1,0 +1,7 @@
+import type { Account } from './account.ts'
+import type { AccountInternal } from './account-internal.ts'
+import { accountSchema } from './account-schema.ts'
+
+export function accountSanitizer(internal: AccountInternal): Account {
+  return accountSchema.parse(internal)
+}

--- a/packages/db/src/account/account-schema.ts
+++ b/packages/db/src/account/account-schema.ts
@@ -1,16 +1,5 @@
-import { z } from 'zod'
-import { solanaAddressSchema } from '../solana/solana-address-schema.ts'
-import { accountTypeSchema } from './account-type-schema.ts'
+import { accountInternalSchema } from './account-internal-schema.ts'
 
-export const accountSchema = z.object({
-  createdAt: z.date(),
-  derivationIndex: z.number(),
-  id: z.string(),
-  name: z.string(),
-  order: z.number(),
-  publicKey: solanaAddressSchema,
-  secretKey: z.string().optional(),
-  type: accountTypeSchema,
-  updatedAt: z.date(),
-  walletId: z.string(),
+export const accountSchema = accountInternalSchema.omit({
+  secretKey: true,
 })

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -1,5 +1,5 @@
 import { Dexie, type Table } from 'dexie'
-import type { Account } from './account/account.ts'
+import type { AccountInternal } from './account/account-internal.ts'
 import type { BookmarkAccount } from './bookmark-account/bookmark-account.ts'
 import type { BookmarkTransaction } from './bookmark-transaction/bookmark-transaction.ts'
 import type { Network } from './network/network.ts'
@@ -12,7 +12,7 @@ export interface DatabaseConfig {
 }
 
 export class Database extends Dexie {
-  accounts!: Table<Account>
+  accounts!: Table<AccountInternal>
   bookmarkAccounts!: Table<BookmarkAccount>
   bookmarkTransactions!: Table<BookmarkTransaction>
   networks!: Table<Network>

--- a/packages/db/test/account-create.test.ts
+++ b/packages/db/test/account-create.test.ts
@@ -19,16 +19,18 @@ describe('account-create', () => {
   describe('expected behavior', () => {
     it('should create an account', async () => {
       // ARRANGE
-      expect.assertions(1)
+      expect.assertions(2)
       const walletId = randomId()
       const input = testAccountCreateInput({ walletId })
 
       // ACT
-      await accountCreate(db, input)
+      const result = await accountCreate(db, input)
 
       // ASSERT
-      const items = await accountFindMany(db, { walletId })
-      expect(items.map((i) => i.name)).toContain(input.name)
+      const item = await accountFindUnique(db, result)
+      expect(item?.name).toEqual(input.name)
+      // @ts-expect-error secretKey does not exist on the type. Here we ensure it's sanitized.
+      expect(item?.secretKey).toBeUndefined()
     })
 
     it('should create an account with a default derivationIndex of 0', async () => {

--- a/packages/db/test/account-find-many.test.ts
+++ b/packages/db/test/account-find-many.test.ts
@@ -17,7 +17,7 @@ describe('account-find-many', () => {
   describe('expected behavior', () => {
     it('should find many accounts for a wallet', async () => {
       // ARRANGE
-      expect.assertions(2)
+      expect.assertions(3)
       const walletId1 = randomId()
       const walletId2 = randomId()
       const account1 = testAccountCreateInput({ walletId: walletId1 })
@@ -33,6 +33,8 @@ describe('account-find-many', () => {
       // ASSERT
       expect(items).toHaveLength(2)
       expect(items.map((i) => i.name)).toEqual(expect.arrayContaining([account1.name, account2.name]))
+      // @ts-expect-error secretKey does not exist on the type. Here we ensure it's sanitized.
+      expect(items.map((i) => i.secretKey).filter(Boolean).length).toEqual(0)
     })
 
     it('should find many accounts for a wallet by a partial name', async () => {

--- a/packages/db/test/account-find-unique.test.ts
+++ b/packages/db/test/account-find-unique.test.ts
@@ -17,7 +17,7 @@ describe('account-find-unique', () => {
   describe('expected behavior', () => {
     it('should find a unique account', async () => {
       // ARRANGE
-      expect.assertions(2)
+      expect.assertions(3)
       const input = testAccountCreateInput({ walletId: randomId() })
       const id = await accountCreate(db, input)
 
@@ -27,6 +27,8 @@ describe('account-find-unique', () => {
       // ASSERT
       expect(item).toBeDefined()
       expect(item?.name).toBe(input.name)
+      // @ts-expect-error secretKey does not exist on the type. Here we ensure it's sanitized.
+      expect(item?.secretKey).toBe(undefined)
     })
   })
 

--- a/packages/db/test/test-helpers.ts
+++ b/packages/db/test/test-helpers.ts
@@ -22,6 +22,7 @@ export function testAccountCreateInput(input: { walletId: string } & Partial<Acc
   return {
     name: randomName('account'),
     publicKey: address('So11111111111111111111111111111111111111112'),
+    secretKey: input?.type === 'Watched' ? '' : 'not-so-secret-key',
     type: 'Derived',
     ...input,
   }


### PR DESCRIPTION
## Description

Part of #545 

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure `secretKey` is only accessible internally by introducing internal schema and sanitizer, updating database functions, and modifying tests.
> 
>   - **Behavior**:
>     - Introduces `accountInternalSchema` in `account-internal-schema.ts` to include `secretKey`.
>     - Adds `accountSanitizer` in `account-sanitizer.ts` to remove `secretKey` from external access.
>     - Updates `accountFindByWalletId`, `accountFindMany`, and `accountFindUnique` to use `accountSanitizer`.
>     - Adds `secretKey` method in `db.ts` to fetch `secretKey` internally.
>   - **Schema**:
>     - Changes `accountCreateSchema` to use `accountInternalSchema`.
>     - Updates `accountSchema` to omit `secretKey`.
>   - **Database**:
>     - Changes `Database` class in `database.ts` to use `AccountInternal` for `accounts` table.
>   - **Tests**:
>     - Updates tests in `account-create.test.ts`, `account-find-many.test.ts`, and `account-find-unique.test.ts` to ensure `secretKey` is not exposed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 5b069f05249939dda5802dee938ddd4b192de347. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->