### PR TITLE
fix(settings): network deletion crash

### DIFF
--- a/packages/db/src/network/network-delete.ts
+++ b/packages/db/src/network/network-delete.ts
@@ -1,12 +1,19 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from '../database.ts'
+import { settingGetValue } from '../setting/setting-get-value.ts'
 
 export async function networkDelete(db: Database, id: string): Promise<void> {
-  const { data, error } = await tryCatch(db.networks.delete(id))
-  if (error) {
-    console.log(error)
-    throw new Error(`Error deleting network with id ${id}`)
-  }
-  return data
+  return db.transaction('rw', db.networks, db.settings, async () => {
+    const activeNetworkId = await settingGetValue(db, 'activeNetworkId')
+    if (id === activeNetworkId) {
+      throw new Error('You cannot delete the active network. Please change networks and try again.')
+    }
+    const { data, error } = await tryCatch(db.networks.delete(id))
+    if (error) {
+      console.log(error)
+      throw new Error(`Error deleting network with id ${id}`)
+    }
+    return data
+  })
 }

--- a/packages/settings/src/settings-feature-network-list.tsx
+++ b/packages/settings/src/settings-feature-network-list.tsx
@@ -14,7 +14,7 @@ export function SettingsFeatureNetworkList() {
   const { t } = useTranslation('settings')
   const page = useSettingsPage({ pageId: 'networks' })
   const deleteMutation = useNetworkDelete({
-    onError: () => toastError('Error deleting network'),
+    onError: (error) => toastError(error.message),
     onSuccess: () => toastSuccess('Network deleted'),
   })
   const items = useNetworkLive()


### PR DESCRIPTION
fix #618 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevents deletion of active network in `networkDelete()` and updates error message in `SettingsFeatureNetworkList`.
> 
>   - **Behavior**:
>     - Prevents deletion of active network in `networkDelete()` in `network-delete.ts` by checking `activeNetworkId`.
>     - Updates error message in `SettingsFeatureNetworkList` to inform user they cannot delete active network.
>   - **Tests**:
>     - Adds test in `network-delete.test.ts` to verify active network cannot be deleted.
>     - Clears `db.settings` in `beforeEach` to ensure clean test state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for ba57454ceb7bebf7f36ba874a10c969b7ff2f602. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->