### PR TITLE
fix(portfolio): activity tab local time date parsing

### DIFF
--- a/packages/portfolio/src/ui/group-activity-items.tsx
+++ b/packages/portfolio/src/ui/group-activity-items.tsx
@@ -1,11 +1,10 @@
 import type { GetActivityItem, GetActivityItems } from '@workspace/solana-client/get-activity'
 
-import { unixTimestampToDate } from '@workspace/solana-client/unix-timestamp-to-date'
+import { unixTimestampToIsoDateString } from '@workspace/solana-client/unix-timestamp-to-iso-date-string'
 
 export function groupActivityItems(txs: GetActivityItems): { date: Date; transactions: GetActivityItems }[] {
   const grouped = txs.reduce((acc, tx) => {
-    const timestamp = unixTimestampToDate(tx.blockTime) ?? new Date()
-    const dateKey = timestamp.toLocaleDateString()
+    const dateKey = unixTimestampToIsoDateString(tx.blockTime)
 
     const group = acc.get(dateKey)
     if (!group) {

--- a/packages/solana-client/src/unix-timestamp-to-iso-date-string.ts
+++ b/packages/solana-client/src/unix-timestamp-to-iso-date-string.ts
@@ -1,0 +1,11 @@
+import type { UnixTimestamp } from '@solana/kit'
+import { unixTimestampToDate } from './unix-timestamp-to-date.ts'
+
+export function unixTimestampToIsoDateString(time: null | UnixTimestamp) {
+  const timestamp = unixTimestampToDate(time) ?? new Date()
+  const year = timestamp.getFullYear()
+  const month = (timestamp.getMonth() + 1).toString().padStart(2, '0')
+  const day = timestamp.getDate().toString().padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}

--- a/packages/solana-client/test/unix-timestamp-to-date.test.ts
+++ b/packages/solana-client/test/unix-timestamp-to-date.test.ts
@@ -1,0 +1,32 @@
+import { assertIsUnixTimestamp } from '@solana/kit'
+import { describe, expect, it } from 'vitest'
+import { unixTimestampToDate } from '../src/unix-timestamp-to-date.ts'
+
+describe('unix-timestamp-to-date', () => {
+  describe('expected behavior', () => {
+    it('should convert a Unix timestamp to a Date object', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const timestamp = 1764421483n
+      assertIsUnixTimestamp(timestamp)
+
+      // ACT
+      const result = unixTimestampToDate(timestamp)
+
+      // ASSERT
+      expect(result).toEqual(new Date(1764421483000))
+    })
+
+    it('should return null when input is null', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const timestamp = null
+
+      // ACT
+      const result = unixTimestampToDate(timestamp)
+
+      // ASSERT
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/packages/solana-client/test/unix-timestamp-to-iso-date-string.test.ts
+++ b/packages/solana-client/test/unix-timestamp-to-iso-date-string.test.ts
@@ -1,0 +1,19 @@
+import { assertIsUnixTimestamp } from '@solana/kit'
+import { describe, expect, it } from 'vitest'
+import { unixTimestampToIsoDateString } from '../src/unix-timestamp-to-iso-date-string.ts'
+
+describe('timestamp-to-locale-date-string', () => {
+  describe('expected behavior', () => {
+    it('should format a date as YYYY-MM-DD', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const timestamp = 1764421483n
+      assertIsUnixTimestamp(timestamp)
+      // ACT
+      const result = unixTimestampToIsoDateString(timestamp)
+
+      // ASSERT
+      expect(result).toBe('2025-11-29')
+    })
+  })
+})


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->
fixes issue #620 
## Description

<!-- Please include a summary of the change and the motivation behind it. -->
added a helper function  timestampToLocaleDateString in solana-client with tests and test file for unixTimestampToDate helper function which fixes the date parsing error due to localised date string

## Checklist

- [x] Tests have been added for my change
- [ ] Docs have been updated for my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes date parsing in `groupActivityItems()` by adding `timestampToLocaleDateString()` and includes tests for date formatting functions.
> 
>   - **Behavior**:
>     - Fixes date parsing error in `groupActivityItems()` in `group-activity-items.tsx` by using `timestampToLocaleDateString()`.
>   - **Functions**:
>     - Adds `timestampToLocaleDateString()` in `timestamp-to-locale-date-string.ts` to format dates as `YYYY-MM-DD`.
>   - **Tests**:
>     - Adds tests for `timestampToLocaleDateString()` in `timestamp-to-locale-date-string.test.ts`.
>     - Adds tests for `unixTimestampToDate()` in `unix-timestamp-to-date.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f8664053f7911c4d3bbd1a13d568ec6ecdcd8beb. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->