### PR TITLE
feat(extension): track open entrypoint

### DIFF
--- a/apps/extension/src/entrypoints/background.ts
+++ b/apps/extension/src/entrypoints/background.ts
@@ -1,7 +1,9 @@
 import { handlers } from '@workspace/background/background'
+import { entrypointListeners } from '@workspace/background/entrypoint'
 import { services } from '@workspace/background/services'
 
 export default defineBackground(() => {
   services()
   handlers()
+  entrypointListeners()
 })

--- a/apps/extension/src/entrypoints/onboarding/main.tsx
+++ b/apps/extension/src/entrypoints/onboarding/main.tsx
@@ -1,3 +1,4 @@
+import { setEntrypoint } from '@workspace/background/entrypoint'
 import { ShellFeature } from '@workspace/shell/shell-feature'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -6,6 +7,8 @@ const root = document.getElementById('root')
 if (!root) {
   throw new Error('Root element not found')
 }
+
+setEntrypoint('onboarding')
 
 // TODO: Extension not secure until https://github.com/samui-build/samui-wallet/issues/161 is resolved
 // Use at your own risk

--- a/apps/extension/src/entrypoints/popup/main.tsx
+++ b/apps/extension/src/entrypoints/popup/main.tsx
@@ -1,3 +1,4 @@
+import { setEntrypoint } from '@workspace/background/entrypoint'
 import { ShellFeature } from '@workspace/shell/shell-feature'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -7,6 +8,8 @@ const root = document.getElementById('root')
 if (!root) {
   throw new Error('Root element not found')
 }
+
+setEntrypoint('popup')
 
 // TODO: Extension not secure until https://github.com/samui-build/samui-wallet/issues/161 is resolved
 // Use at your own risk

--- a/apps/extension/src/entrypoints/request/main.tsx
+++ b/apps/extension/src/entrypoints/request/main.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRoot } from 'react-dom/client'
 import '@workspace/ui/globals.css'
 
+import { setEntrypoint } from '@workspace/background/entrypoint'
 import { StrictMode } from 'react'
 import { App } from './app.tsx'
 
@@ -11,6 +12,8 @@ const root = document.getElementById('root')
 if (!root) {
   throw new Error('Root element not found')
 }
+
+setEntrypoint('request')
 
 createRoot(root).render(
   <StrictMode>

--- a/apps/extension/src/entrypoints/sidepanel/main.tsx
+++ b/apps/extension/src/entrypoints/sidepanel/main.tsx
@@ -1,3 +1,4 @@
+import { setEntrypoint } from '@workspace/background/entrypoint'
 import { ShellFeature } from '@workspace/shell/shell-feature'
 
 import { StrictMode } from 'react'
@@ -7,6 +8,8 @@ const root = document.getElementById('root')
 if (!root) {
   throw new Error('Root element not found')
 }
+
+setEntrypoint('sidepanel')
 
 // TODO: Extension not secure until https://github.com/samui-build/samui-wallet/issues/161 is resolved
 // Use at your own risk

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'wxt'
 export default defineConfig({
   manifest: {
     name: 'Samui',
+    permissions: ['storage'],
     web_accessible_resources: [
       {
         matches: ['*://*/*'],

--- a/bun.lock
+++ b/bun.lock
@@ -197,6 +197,7 @@
         "@wallet-standard/core": "^1.1.1",
         "@webext-core/messaging": "^2.3.0",
         "@webext-core/proxy-service": "^1.2.1",
+        "@webext-core/storage": "1.2.0",
         "@workspace/db": "workspace:*",
         "@workspace/keypair": "workspace:*",
         "@workspace/ui": "workspace:*",
@@ -2187,6 +2188,8 @@
     "@webext-core/messaging": ["@webext-core/messaging@2.3.0", "", { "dependencies": { "serialize-error": "^11.0.0", "uid": "^2.0.2", "webextension-polyfill": "^0.10.0" } }, "sha512-gChSVKdRs7JEq5hFH0jVROSvTq+sKq9afXTA/gBswep3RWNLhXyDsXFlvPMkYbmML1XZ8QKKC9ou2MlCKRZwSQ=="],
 
     "@webext-core/proxy-service": ["@webext-core/proxy-service@1.2.1", "", { "dependencies": { "get-value": "^3.0.1", "webextension-polyfill": "^0.10.0" }, "peerDependencies": { "@webext-core/messaging": ">=1.3.1" } }, "sha512-MTs/7o8dZ8q7ySO0Kkkz9DYKPdTvMZqCYi7VVj1onzIHVy7m9b/OesQ8c3rrPzu8ZaljuZQJKfO3GITI6tSj6A=="],
+
+    "@webext-core/storage": ["@webext-core/storage@1.2.0", "", { "dependencies": { "webextension-polyfill": "^0.10.0" } }, "sha512-XI86HJUhugVdAQZLcj3EH/rZv08ByVn2riX3YI4HCJ86NOH5K3OwGi0ClFa/kq5U5hIVDMG6hwOBwgEgI2G5GQ=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.66", "", {}, "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA=="],
 

--- a/cspell.config.mts
+++ b/cspell.config.mts
@@ -56,6 +56,7 @@ const config: CSpellSettings = {
     'rtishchev',
     'samui',
     'seti',
+    'sidepanel',
     'skia',
     'solscan',
     'surfpool',

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -6,6 +6,7 @@
     "@wallet-standard/core": "^1.1.1",
     "@webext-core/messaging": "^2.3.0",
     "@webext-core/proxy-service": "^1.2.1",
+    "@webext-core/storage": "1.2.0",
     "@workspace/db": "workspace:*",
     "@workspace/keypair": "workspace:*",
     "@workspace/ui": "workspace:*",

--- a/packages/background/src/entrypoint.ts
+++ b/packages/background/src/entrypoint.ts
@@ -1,0 +1,21 @@
+import { localExtStorage } from '@webext-core/storage'
+import { browser } from '@wxt-dev/browser'
+
+export async function getEntrypoint(): Promise<string> {
+  return (await localExtStorage.getItem('entrypoint')) ?? ''
+}
+
+export function setEntrypoint(name: string) {
+  localExtStorage.setItem('entrypoint', name)
+  browser.runtime.connect({ name })
+}
+
+export function entrypointListeners() {
+  browser.runtime.onConnect.addListener((entrypoint) => {
+    localExtStorage.setItem('entrypoint', entrypoint.name)
+
+    entrypoint.onDisconnect.addListener(async () => {
+      localExtStorage.removeItem('entrypoint')
+    })
+  })
+}


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

This change will track the current open extension entrypoint so we know whether to use the sidebar if it is open for requests.

## Screenshots / Video

<!-- Please include screenshots or video if UI changes are made. -->

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Track open extension entrypoint using local storage and browser runtime connections, with integration across multiple entrypoints and added storage permission.
> 
>   - **Behavior**:
>     - Track open extension entrypoint using `setEntrypoint()` and `entrypointListeners()` in `entrypoint.ts`.
>     - Integrate `setEntrypoint()` in `onboarding/main.tsx`, `popup/main.tsx`, `request/main.tsx`, and `sidepanel/main.tsx`.
>   - **Permissions**:
>     - Add `storage` permission in `wxt.config.ts`.
>   - **Dependencies**:
>     - Add `@webext-core/storage` dependency in `package.json` and `bun.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c9d21043025125eb11de1fbed695473641b4d2b4. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->