### PR TITLE
feat: add react query persistance storage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -509,7 +509,10 @@
       "name": "@workspace/shell",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/query-async-storage-persister": "5.90.13",
+        "@tanstack/query-sync-storage-persister": "5.90.13",
         "@tanstack/react-query": "catalog:",
+        "@tanstack/react-query-persist-client": "5.90.13",
         "@workspace/db": "workspace:*",
         "@workspace/db-react": "workspace:*",
         "@workspace/dev": "workspace:*",
@@ -2051,9 +2054,17 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.16", "", { "dependencies": { "@tailwindcss/node": "4.1.16", "@tailwindcss/oxide": "4.1.16", "tailwindcss": "4.1.16" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-bbguNBcDxsRmi9nnlWJxhfDWamY3lmcyACHcdO1crxfzuLpOhHLLtEIN/nCbbAtj5rchUgQD17QVAKi1f7IsKg=="],
 
+    "@tanstack/query-async-storage-persister": ["@tanstack/query-async-storage-persister@5.90.13", "", { "dependencies": { "@tanstack/query-core": "5.90.11", "@tanstack/query-persist-client-core": "5.91.10" } }, "sha512-72/rRDlfXVJvd1mTyjvsWSU/obj+SoeitKwm1AM5YDId8aIMxGYnJscK7ZDilBFXud2p9DyV6+mRYEzcpPK0VA=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.90.5", "", {}, "sha512-wLamYp7FaDq6ZnNehypKI5fNvxHPfTYylE0m/ZpuuzJfJqhR5Pxg9gvGBHZx4n7J+V5Rg5mZxHHTlv25Zt5u+w=="],
 
+    "@tanstack/query-persist-client-core": ["@tanstack/query-persist-client-core@5.91.10", "", { "dependencies": { "@tanstack/query-core": "5.90.11" } }, "sha512-oZQk/kap5jHx2w+JcSI6CvDFXR5jmAldqJsH5IEQizVOEwaRlCyYEBZ3Df56HXNxW4spWX0cjhI/4o+mnCGtHw=="],
+
+    "@tanstack/query-sync-storage-persister": ["@tanstack/query-sync-storage-persister@5.90.13", "", { "dependencies": { "@tanstack/query-core": "5.90.11", "@tanstack/query-persist-client-core": "5.91.10" } }, "sha512-ysJFlPzQat1FyXKiKx+bK1kDiF0zdHgZV5Kc3V7rw6w5Uz7shaiQaAmp3VJoZXl63diE4mErFBSra/z+6iBigg=="],
+
     "@tanstack/react-query": ["@tanstack/react-query@5.90.5", "", { "dependencies": { "@tanstack/query-core": "5.90.5" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-pN+8UWpxZkEJ/Rnnj2v2Sxpx1WFlaa9L6a4UO89p6tTQbeo+m0MS8oYDjbggrR8QcTyjKoYWKS3xJQGr3ExT8Q=="],
+
+    "@tanstack/react-query-persist-client": ["@tanstack/react-query-persist-client@5.90.13", "", { "dependencies": { "@tanstack/query-persist-client-core": "5.91.10" }, "peerDependencies": { "@tanstack/react-query": "^5.90.11", "react": "^18 || ^19" } }, "sha512-04R+o/su8wuqlEvUl6dJLLI8auUCFCCJ2qGfELPSJSE4mF0HOh+ZtmsDRuLXA/jBMyV6X2RZLrZTMRWNgWM4gw=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.9.0", "", {}, "sha512-qD5tMjh7utwBk9/5PrTA/aGr3i5QaJ/Mlt7p8NilQ45WgbifUNPyKWsA63iQ8YfQq6R8ajMapU+/Q8nMcPRLNw=="],
 
@@ -4886,6 +4897,12 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tanstack/query-async-storage-persister/@tanstack/query-core": ["@tanstack/query-core@5.90.11", "", {}, "sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A=="],
+
+    "@tanstack/query-persist-client-core/@tanstack/query-core": ["@tanstack/query-core@5.90.11", "", {}, "sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A=="],
+
+    "@tanstack/query-sync-storage-persister/@tanstack/query-core": ["@tanstack/query-core@5.90.11", "", {}, "sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A=="],
 
     "@turbo/gen/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 

--- a/packages/db-react/src/query-client.tsx
+++ b/packages/db-react/src/query-client.tsx
@@ -1,3 +1,9 @@
 import { QueryClient } from '@tanstack/react-query'
 
-export const queryClient = new QueryClient()
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      gcTime: 1000 * 60 * 60 * 24, // 24 hours
+    },
+  },
+})

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,9 @@
 {
   "dependencies": {
+    "@tanstack/query-async-storage-persister": "5.90.13",
+    "@tanstack/query-sync-storage-persister": "5.90.13",
     "@tanstack/react-query": "catalog:",
+    "@tanstack/react-query-persist-client": "5.90.13",
     "@workspace/db": "workspace:*",
     "@workspace/db-react": "workspace:*",
     "@workspace/dev": "workspace:*",

--- a/packages/shell/src/data-access/shell-providers.tsx
+++ b/packages/shell/src/data-access/shell-providers.tsx
@@ -1,8 +1,10 @@
-import { QueryClientProvider } from '@tanstack/react-query'
+import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
+import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { queryClient } from '@workspace/db-react/query-client'
 import { Toaster } from '@workspace/ui/components/sonner'
 import type { ReactNode } from 'react'
 import { lazy } from 'react'
+import { browser } from 'wxt/browser'
 import type { ShellContext } from '../shell-feature.tsx'
 
 const RequestFeatureDialog = lazy(() =>
@@ -14,13 +16,30 @@ interface ShellProviderProps {
   children: ReactNode
 }
 
+const persister = createAsyncStoragePersister({
+  storage: browser?.storage?.local
+    ? {
+        getItem: async (key: string) => {
+          const result = await browser.storage.local.get(key)
+          return result[key] ?? null
+        },
+        removeItem: async (key: string) => {
+          await browser.storage.local.remove(key)
+        },
+        setItem: async (key: string, value: string) => {
+          await browser.storage.local.set({ [key]: value })
+        },
+      }
+    : window.localStorage,
+})
+
 export function ShellProviders({ children, context }: ShellProviderProps) {
   return (
-    <QueryClientProvider client={queryClient}>
+    <PersistQueryClientProvider client={queryClient} persistOptions={{ persister }}>
       {children}
       <Toaster closeButton richColors />
       {context === 'Sidebar' ? <RequestFeatureDialog /> : null}
-    </QueryClientProvider>
+    </PersistQueryClientProvider>
   )
 }
 

--- a/packages/shell/src/shell-routes.tsx
+++ b/packages/shell/src/shell-routes.tsx
@@ -30,13 +30,6 @@ function getRoutes({ browser, context }: ShellFeatureProps) {
 }
 
 function createRouter({ browser, context }: ShellFeatureProps) {
-  let children = getAppRoutes({ browser, context })
-  if (context === 'Request') {
-    children = getRequestRoutes()
-  } else if (context === 'Onboarding') {
-    children = getOnboardingRoutes()
-  }
-
   return createHashRouter([
     {
       children: getRoutes({ browser, context }),


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

Adds a persistent storage to the wallet. This means when you come back to the web or extension (or switch between popup and sidepanel) you will see stale data from the last fetch

## Screenshots / Video

<!-- Please include screenshots or video if UI changes are made. -->

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds persistent storage for React Query in the wallet, enabling data persistence across sessions and views.
> 
>   - **Behavior**:
>     - Adds persistent storage to the wallet using `PersistQueryClientProvider` in `shell-providers.tsx`.
>     - Configures `queryClient` in `query-client.tsx` with a 24-hour garbage collection time.
>   - **Dependencies**:
>     - Adds `@tanstack/query-async-storage-persister`, `@tanstack/query-sync-storage-persister`, and `@tanstack/react-query-persist-client` to `package.json`.
>   - **Storage Implementation**:
>     - Implements `createAsyncStoragePersister` in `shell-providers.tsx` using `browser.storage.local` or `window.localStorage` as fallback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f3650dbc972607ee0e33a83170c2fd0b8b524bc3. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->