### PR TITLE
feat: improve ui-error-boundary

### DIFF
--- a/packages/ui/src/components/ui-empty.tsx
+++ b/packages/ui/src/components/ui-empty.tsx
@@ -28,7 +28,7 @@ export function UiEmpty({
         {title ? <EmptyTitle>{title}</EmptyTitle> : null}
         <EmptyDescription>{description}</EmptyDescription>
       </EmptyHeader>
-      {children ? <EmptyContent>{children}</EmptyContent> : null}
+      {children ? <EmptyContent className="md:max-w-2xl lg:max-w-3xl">{children}</EmptyContent> : null}
     </Empty>
   )
 }

--- a/packages/ui/src/components/ui-error-boundary.tsx
+++ b/packages/ui/src/components/ui-error-boundary.tsx
@@ -23,6 +23,11 @@ export function UiErrorBoundary() {
     <div className={cn('flex h-full w-full items-center justify-center px-6')}>
       <UiEmpty className="" description={description} icon="bug" title={title}>
         <UiErrorBoundarySupport />
+        <Button onClick={() => window.location.reload()} variant="secondary">
+          <span>Refresh</span>
+          <UiIcon className="size-3" icon="refresh" />
+        </Button>
+
         {stack ? <UiErrorBoundaryStack stack={stack} /> : null}
       </UiEmpty>
     </div>
@@ -33,7 +38,7 @@ function UiErrorBoundaryStack({ stack }: { stack: string }) {
   const [showStack, setShowStack] = useState(false)
 
   return (
-    <Collapsible className="max-w-2xl" onOpenChange={setShowStack} open={showStack}>
+    <Collapsible className="w-full" onOpenChange={setShowStack} open={showStack}>
       <CollapsibleTrigger asChild>
         <Button variant="secondary">
           <span>{showStack ? 'Hide' : 'Show'} stack trace</span>
@@ -41,7 +46,7 @@ function UiErrorBoundaryStack({ stack }: { stack: string }) {
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="pt-6">
-        <pre className="w-full overflow-auto text-left text-[9px]">{stack}</pre>
+        <pre className="w-full whitespace-pre-wrap text-left text-[9px]">{stack}</pre>
       </CollapsibleContent>
     </Collapsible>
   )
@@ -49,7 +54,7 @@ function UiErrorBoundaryStack({ stack }: { stack: string }) {
 
 function UiErrorBoundarySupport() {
   return (
-    <div className="whitespace-nowrap">
+    <div>
       Please{' '}
       <a
         className="hover:underline"
@@ -57,10 +62,10 @@ function UiErrorBoundarySupport() {
         rel="noopener noreferrer"
         target="_blank"
       >
-        create an issue
+        create a GitHub issue
       </a>{' '}
       or{' '}
-      <a className="hover:underline" href="http://samui.build/go/discord" rel="noopener noreferrer" target="_blank">
+      <a className="hover:underline" href="https://samui.build/go/discord" rel="noopener noreferrer" target="_blank">
         join our Discord
       </a>{' '}
       if the issue persists.


### PR DESCRIPTION
## Description

This PR improves our error boundary:
- ensure the stack trace is wrapped so no context gets lost in a screenshot, even on small viewports
- add a refresh button so that you can trigger a retry in places where there's no refresh button (eg, the extension) 

## Screenshots / Video

<img width="376" height="777" alt="image" src="https://github.com/user-attachments/assets/12bcad5c-c7f5-4b6b-990f-1c1ea687beab" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `UiErrorBoundary` with a refresh button and improved stack trace visibility.
> 
>   - **UI Enhancements**:
>     - Add a refresh button in `UiErrorBoundary` to reload the page on error.
>     - Ensure stack trace in `UiErrorBoundaryStack` wraps correctly with `whitespace-pre-wrap`.
>   - **Layout Adjustments**:
>     - Update `UiEmpty` to use `md:max-w-2xl lg:max-w-3xl` for `EmptyContent`.
>     - Change `Collapsible` in `UiErrorBoundaryStack` to `w-full` for full width.
>   - **Misc**:
>     - Update link text in `UiErrorBoundarySupport` to "create a GitHub issue" and correct Discord link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 21bb47c89466b952d7a52d9daba9223e55f3072e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->