### PR TITLE
feat(portfolio): add skeleton to activity tab

### DIFF
--- a/packages/portfolio/src/portfolio-feature-tab-activity.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-activity.tsx
@@ -5,9 +5,9 @@ import { useGetActivity } from '@workspace/solana-client-react/use-get-activity'
 import { Button } from '@workspace/ui/components/button'
 import { Spinner } from '@workspace/ui/components/spinner'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
-import { UiLoader } from '@workspace/ui/components/ui-loader'
 import { useLocation } from 'react-router'
 import { PortfolioUiActivityList } from './ui/portfolio-ui-activity-list.tsx'
+import { PortfolioUiActivityListSkeleton } from './ui/portfolio-ui-activity-list-skeleton.tsx'
 
 export function PortfolioFeatureTabActivity() {
   const { t } = useTranslation('portfolio')
@@ -29,8 +29,8 @@ export function PortfolioFeatureTabActivity() {
           </Button>
         </div>
       </div>
-      {isLoading ? <UiLoader /> : null}
       {isError ? <pre className="alert alert-error">{error?.message.toString() ?? 'Unknown error'}</pre> : null}
+      {isLoading ? <PortfolioUiActivityListSkeleton /> : null}
       {isSuccess ? <PortfolioUiActivityList from={from} items={data} network={network} /> : null}
     </div>
   )

--- a/packages/portfolio/src/ui/portfolio-ui-activity-item-skeleton.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-activity-item-skeleton.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from '@workspace/ui/components/skeleton'
+
+export function PortfolioUiActivityItemSkeleton() {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <Skeleton className="size-4" />
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="size-3" />
+      </div>
+      <Skeleton className="h-3.5 w-16" />
+    </div>
+  )
+}

--- a/packages/portfolio/src/ui/portfolio-ui-activity-list-skeleton.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-activity-list-skeleton.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from '@workspace/ui/components/skeleton'
+import { PortfolioUiActivityItemSkeleton } from './portfolio-ui-activity-item-skeleton.tsx'
+
+export function PortfolioUiActivityListSkeleton({ length = 5 }: { length?: number }) {
+  return (
+    <div>
+      <div className="space-y-4">
+        {Array.from({ length }, (_, i) => i).map((id) => (
+          <div className="space-y-4" key={id}>
+            <div className="flex gap-2">
+              <Skeleton className="size-4" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+            <div className="space-y-2">
+              {Array.from({ length }, (_, i) => i).map((id) => (
+                <PortfolioUiActivityItemSkeleton key={id} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

Adds a skeleton to the activity tab of the portfolio

## Screenshots / Video

<!-- Please include screenshots or video if UI changes are made. -->

<img width="663" height="841" alt="image" src="https://github.com/user-attachments/assets/eed7ed26-c744-4134-843a-29b4fb513af1" />

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add skeleton loading state to the activity tab in the portfolio feature, replacing the existing loader with new skeleton components.
> 
>   - **Behavior**:
>     - Replaces `UiLoader` with `PortfolioUiActivityListSkeleton` in `portfolio-feature-tab-activity.tsx` for loading state.
>     - Displays `PortfolioUiActivityListSkeleton` when `isLoading` is true.
>   - **Components**:
>     - Adds `PortfolioUiActivityItemSkeleton` for individual activity item skeletons.
>     - Adds `PortfolioUiActivityListSkeleton` to render a list of skeleton items, default length 5.
>   - **Imports**:
>     - Adds import for `PortfolioUiActivityListSkeleton` in `portfolio-feature-tab-activity.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 823ac7a8b35a53d67de54a07cab6bfcb62e2651e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->