### PR TITLE
fix(i18n): special character in text

### DIFF
--- a/packages/i18n/locales/en/settings.json
+++ b/packages/i18n/locales/en/settings.json
@@ -61,7 +61,7 @@
   "pageWalletName": "Wallets",
   "themeDark": "Dark",
   "themeLight": "Light",
-  "walletAddAccountDeriveDescription": "Derive an account from the Wallet&#39;s mnemonic",
+  "walletAddAccountDeriveDescription": "Derive an account from the Wallet's mnemonic",
   "walletAddAccountDeriveTitle": "Derive an account",
   "walletAddAccountImportDescription": "Import an account from a base58 secret key or byte array",
   "walletAddAccountImportLabel": "Enter secret key (base58 or byte array)",

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -125,7 +125,7 @@ interface Resources {
     pageWalletName: 'Wallets'
     themeDark: 'Dark'
     themeLight: 'Light'
-    walletAddAccountDeriveDescription: 'Derive an account from the Wallet&#39;s mnemonic'
+    walletAddAccountDeriveDescription: "Derive an account from the Wallet's mnemonic"
     walletAddAccountDeriveTitle: 'Derive an account'
     walletAddAccountImportDescription: 'Import an account from a base58 secret key or byte array'
     walletAddAccountImportLabel: 'Enter secret key (base58 or byte array)'


### PR DESCRIPTION
fix #643 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes special character display in i18n text by replacing HTML entity with apostrophe in `settings.json` and `resources.d.ts`.
> 
>   - **Fixes**:
>     - Replaces HTML entity `&#39;` with `'` in `walletAddAccountDeriveDescription` in `settings.json` and `resources.d.ts`.
>   - **Files Affected**:
>     - `settings.json`: Corrects text for "Derive an account from the Wallet's mnemonic".
>     - `resources.d.ts`: Updates interface `Resources` to reflect the same text correction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 73c3ffde7f655886c92044a43a4a4cc19528b264. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->