### PR TITLE
feat: add stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,29 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          start-date: '2025-12-01T00:00:00Z'
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10
+


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

Adds a stale action for issues and pull requests. Starts from today so current issues are effected.

It has sensible defaults from https://github.com/actions/stale?tab=readme-ov-file readme but we can adjust as needed once we see this working.

Closes #296

## Screenshots / Video

<!-- Please include screenshots or video if UI changes are made. -->

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to automatically mark and close stale issues and PRs with specific configurations and permissions.
> 
>   - **Workflow**:
>     - Adds `stale.yaml` to `.github/workflows` to automate closing stale issues and PRs.
>     - Scheduled to run daily at 01:30 UTC and can be manually triggered.
>   - **Configuration**:
>     - Uses `actions/stale@v10` with start date `2025-12-01T00:00:00Z`.
>     - Marks issues stale after 30 days, PRs after 45 days.
>     - Closes issues 5 days after being marked stale, PRs after 10 days.
>     - Custom messages for stale and closed issues/PRs.
>   - **Permissions**:
>     - Grants write permissions for actions, contents, issues, and pull requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 910880208407bba4a1df545e7c404c60e7743d08. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->