### PR TITLE
feat(env): add get runtime function

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -322,6 +322,7 @@
       "name": "@workspace/env",
       "version": "0.0.0",
       "dependencies": {
+        "@wxt-dev/browser": "0.1.4",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@wxt-dev/browser": "0.1.4",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/env/src/get-runtime.ts
+++ b/packages/env/src/get-runtime.ts
@@ -1,0 +1,47 @@
+import { browser } from '@wxt-dev/browser'
+
+type Runtime = 'cli' | 'desktop' | 'extension' | 'mobile' | 'web'
+
+export function getRuntime(): Runtime {
+  if (typeof process !== 'undefined' && process.versions) {
+    return 'cli'
+  }
+
+  if (typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window) {
+    return 'desktop'
+  }
+
+  if (browser?.runtime) {
+    return 'extension'
+  }
+
+  if (typeof window !== 'undefined' && 'expo' in window) {
+    return 'mobile'
+  }
+
+  if (typeof document !== 'undefined' && document) {
+    return 'web'
+  }
+
+  throw new Error('Unable to determine environment')
+}
+
+export function isCli(): boolean {
+  return getRuntime() === 'cli'
+}
+
+export function isDesktop(): boolean {
+  return getRuntime() === 'desktop'
+}
+
+export function isExtension(): boolean {
+  return getRuntime() === 'extension'
+}
+
+export function isMobile(): boolean {
+  return getRuntime() === 'mobile'
+}
+
+export function isWeb(): boolean {
+  return getRuntime() === 'web'
+}


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

Adds a function to get the current runtime. This will allow us to conditionally enable / disable function on a per runtime basis.

Closes https://github.com/samui-build/samui-wallet/issues/397

## Screenshots / Video

<!-- Please include screenshots or video if UI changes are made. -->

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `getRuntime()` and helper functions in `get-runtime.ts` to determine and check runtime environments, with `@wxt-dev/browser` as a new dependency.
> 
>   - **Functionality**:
>     - Adds `getRuntime()` in `get-runtime.ts` to determine runtime environment: 'cli', 'desktop', 'extension', 'mobile', 'web'.
>     - Adds helper functions `isCli()`, `isDesktop()`, `isExtension()`, `isMobile()`, `isWeb()` in `get-runtime.ts` for specific runtime checks.
>   - **Dependencies**:
>     - Adds `@wxt-dev/browser` as a dependency in `package.json` for runtime detection.
>   - **Error Handling**:
>     - Throws error in `getRuntime()` if environment cannot be determined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 223408978fd0d218fbc37ce8f4deea160e5a0ce2. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->