### PR TITLE
fix(portfolio): token send form validation with zod schema

### DIFF
--- a/packages/portfolio/src/ui/portfolio-ui-send-mint.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-send-mint.tsx
@@ -1,11 +1,23 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { solanaAddressSchema } from '@workspace/db/solana/solana-address-schema'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { Field, FieldGroup, FieldLabel, FieldSet } from '@workspace/ui/components/field'
+import { Form, FormField, FormItem, FormMessage } from '@workspace/ui/components/form'
 import { Input } from '@workspace/ui/components/input'
 import { UiLoader } from '@workspace/ui/components/ui-loader'
-import { useId, useState } from 'react'
+import { useId } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
 import type { TokenBalance } from '../data-access/use-get-token-metadata.ts'
 import { PortfolioUiTokenBalanceItem } from './portfolio-ui-token-balance-item.tsx'
+
+const formSchema = z.object({
+  amount: z.number().positive({ message: 'Amount must be greater than 0' }),
+  destination: solanaAddressSchema,
+})
+
+type PortfolioUiSendMintInput = z.infer<typeof formSchema>
 
 export function PortfolioUiSendMint({
   mint,
@@ -19,60 +31,85 @@ export function PortfolioUiSendMint({
   const { t } = useTranslation('portfolio')
   const destinationId = useId()
   const amountId = useId()
-  const [amount, setAmount] = useState('')
-  const [destination, setDestination] = useState('')
+
+  const form = useForm({
+    defaultValues: {
+      amount: 0,
+      destination: '',
+    },
+    mode: 'all',
+    resolver: zodResolver(formSchema),
+  })
+
+  async function handleSubmit(data: PortfolioUiSendMintInput) {
+    await send({ amount: data.amount.toString(), destination: data.destination, mint })
+  }
 
   return (
     <div className="space-y-6">
-      <form>
-        <FieldGroup>
-          <FieldSet>
-            {mint ? <PortfolioUiTokenBalanceItem item={mint} /> : t(($) => $.searchInputSelect)}
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleSubmit)}>
+          <FieldGroup>
+            <FieldSet>
+              <PortfolioUiTokenBalanceItem item={mint} />
 
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor={destinationId}>{t(($) => $.sendInputDestinationLabel)}</FieldLabel>
-                <Input
-                  id={destinationId}
-                  onChange={(e) => setDestination(e.target.value)}
-                  placeholder={t(($) => $.sendInputDestinationPlaceholder)}
-                  type="text"
-                  value={destination}
+              <FieldGroup>
+                <FormField
+                  control={form.control}
+                  name="destination"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Field>
+                        <FieldLabel htmlFor={destinationId}>{t(($) => $.sendInputDestinationLabel)}</FieldLabel>
+                        <Input
+                          {...field}
+                          autoComplete="off"
+                          id={destinationId}
+                          placeholder={t(($) => $.sendInputDestinationPlaceholder)}
+                          type="text"
+                          value={field.value.toString()}
+                        />
+                      </Field>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor={amountId}>{t(($) => $.sendInputAmountLabel)}</FieldLabel>
-                <Input
-                  id={amountId}
-                  min="1"
-                  onChange={(e) => setAmount(e.target.value)}
-                  placeholder={t(($) => $.sendInputAmountPlaceholder)}
-                  required
-                  step="any"
-                  type="number"
-                  value={amount}
+
+                <FormField
+                  control={form.control}
+                  name="amount"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Field>
+                        <FieldLabel htmlFor={amountId}>{t(($) => $.sendInputAmountLabel)}</FieldLabel>
+                        <Input
+                          {...field}
+                          autoComplete="off"
+                          id={amountId}
+                          min="0"
+                          onChange={(e) => field.onChange(Number(e.target.value))}
+                          placeholder={t(($) => $.sendInputAmountPlaceholder)}
+                          step="any"
+                          type="number"
+                          value={field.value}
+                        />
+                      </Field>
+                      <FormMessage />
+                    </FormItem>
+                  )}
                 />
-              </Field>
-            </FieldGroup>
-          </FieldSet>
-          <Field className="flex justify-end" orientation="horizontal">
-            <Button
-              disabled={!mint || !amount || !destination || isLoading}
-              onClick={async (e) => {
-                e.preventDefault()
-                if (!mint) {
-                  return
-                }
-                await send({ amount, destination, mint })
-              }}
-              type="button"
-            >
-              {isLoading ? <UiLoader className="size-4" /> : null}
-              {t(($) => $.actionSend)}
-            </Button>
-          </Field>
-        </FieldGroup>
-      </form>
+              </FieldGroup>
+            </FieldSet>
+
+            <Field className="flex justify-end" orientation="horizontal">
+              <Button disabled={!form.formState.isValid || isLoading} type="submit">
+                {isLoading ? <UiLoader className="size-4" /> : null}
+                {t(($) => $.actionSend)}
+              </Button>
+            </Field>
+          </FieldGroup>
+        </form>
+      </Form>
     </div>
   )
 }


### PR DESCRIPTION
## Description

validates the amount is positive and entered public key address is a valid solana base58 string for the send and confirm forms using zod schema and react-hook-form

closes #650
part of #270 

## Screenshots / Video

https://github.com/user-attachments/assets/ec5be6e4-9bad-4745-890e-f5d012f8f08d


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Zod schema validation and react-hook-form integration for send and confirm forms in portfolio UI, ensuring positive amount and valid Solana address.
> 
>   - **Validation**:
>     - Adds Zod schema validation for `amount` and `destination` in `portfolio-ui-send-confirm.tsx` and `portfolio-ui-send-mint.tsx`.
>     - Validates `amount` is positive and `destination` is a valid Solana base58 string.
>   - **Form Handling**:
>     - Integrates `react-hook-form` with `zodResolver` for form management in both files.
>     - Updates form submission logic to use `handleSubmit` with validated data.
>   - **UI Changes**:
>     - Disables submit button if form is invalid or loading in both components.
>     - Displays validation messages using `FormMessage` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for e371ef45d858fe3660e084432f948924a4ff8ce2. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->