### PR TITLE
feat: load wallets in root loader

### DIFF
--- a/packages/db-react/src/options-network.tsx
+++ b/packages/db-react/src/options-network.tsx
@@ -30,7 +30,7 @@ export const optionsNetwork = {
       onSuccess: () => toastSuccess('Network deleted'),
       ...props,
     }),
-  findMany: (input: NetworkFindManyInput) =>
+  findMany: (input: NetworkFindManyInput = {}) =>
     queryOptions({
       queryFn: () => networkFindMany(db, input),
       queryKey: ['networkFindMany', input],

--- a/packages/db-react/src/options-wallet.tsx
+++ b/packages/db-react/src/options-wallet.tsx
@@ -34,7 +34,7 @@ export const optionsWallet = {
       mutationFn: ({ id }: { id: string }) => walletDelete(db, id),
       ...props,
     }),
-  findMany: (input: WalletFindManyInput) =>
+  findMany: (input: WalletFindManyInput = {}) =>
     queryOptions({
       queryFn: () => walletFindMany(db, input),
       queryKey: ['walletFindMany', input],

--- a/packages/db-react/src/root-loader.tsx
+++ b/packages/db-react/src/root-loader.tsx
@@ -1,22 +1,26 @@
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
 import type { Setting } from '@workspace/db/setting/setting'
+import type { Wallet } from '@workspace/db/wallet/wallet'
 import { getOrFetchQuery } from './get-or-fetch.tsx'
 import { optionsAccount } from './options-account.tsx'
 import { optionsNetwork } from './options-network.tsx'
 import { optionsSetting } from './options-setting.tsx'
+import { optionsWallet } from './options-wallet.tsx'
 import { queryClient } from './query-client.tsx'
 
 export interface RootLoaderData {
   accounts: Account[]
   networks: Network[]
   settings: Setting[]
+  wallets: Wallet[]
 }
 
 export async function rootLoader() {
-  const [networks, settings] = await Promise.all([
-    getOrFetchQuery(queryClient, optionsNetwork.findMany({})),
+  const [networks, settings, wallets] = await Promise.all([
+    getOrFetchQuery(queryClient, optionsNetwork.findMany()),
     getOrFetchQuery(queryClient, optionsSetting.getAll()),
+    getOrFetchQuery(queryClient, optionsWallet.findMany()),
   ])
 
   const activeWalletId = settings.find((s) => s.key === 'activeWalletId')?.value
@@ -28,5 +32,6 @@ export async function rootLoader() {
     accounts,
     networks,
     settings,
+    wallets,
   }
 }

--- a/packages/db-react/src/use-wallet-live.tsx
+++ b/packages/db-react/src/use-wallet-live.tsx
@@ -2,7 +2,13 @@ import { db } from '@workspace/db/db'
 import type { Wallet } from '@workspace/db/wallet/wallet'
 import { walletFindMany } from '@workspace/db/wallet/wallet-find-many'
 import { useLiveQuery } from 'dexie-react-hooks'
+import { useRootLoaderData } from './use-root-loader-data.tsx'
 
 export function useWalletLive() {
-  return useLiveQuery<Wallet[], Wallet[]>(() => walletFindMany(db), [], [])
+  const data = useRootLoaderData()
+  if (!data?.wallets) {
+    throw new Error('Root loader not called.')
+  }
+
+  return useLiveQuery<Wallet[], Wallet[]>(() => walletFindMany(db), [], data.wallets)
 }


### PR DESCRIPTION
## Description

This loads the wallets in the `rootLoader` so they're loaded in the cache when we need them.

Potentially related to #628



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Load wallets in `rootLoader` for caching and update `useWalletLive` to utilize cached data.
> 
>   - **Behavior**:
>     - Load wallets in `rootLoader()` in `root-loader.tsx` to cache them for later use.
>     - Update `useWalletLive()` in `use-wallet-live.tsx` to use cached wallets from `useRootLoaderData()`.
>   - **Functions**:
>     - Change `findMany()` in `options-network.tsx` and `options-wallet.tsx` to accept default empty input objects.
>   - **Error Handling**:
>     - Throw error in `useWalletLive()` if `rootLoader` is not called.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 9298f3a28da9ae9e373c7fa3b7ae2a7b07011b8c. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->