### PR TITLE
feat: add editorconfig-checker

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,21 @@
+{
+  "AllowedContentTypes": [],
+  "Debug": false,
+  "Disable": {
+    "Charset": false,
+    "EndOfLine": false,
+    "Indentation": false,
+    "IndentSize": false,
+    "InsertFinalNewline": false,
+    "MaxLineLength": true,
+    "TrimTrailingWhitespace": false
+  },
+  "Exclude": ["bun.lock", "\\.sql$"],
+  "Format": "",
+  "IgnoreDefaults": false,
+  "NoColor": false,
+  "PassedFiles": [],
+  "SpacesAfterTabs": false,
+  "Verbose": false,
+  "Version": "v3.6.0"
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,25 @@ jobs:
       - name: Run syncpack
         run: bun syncpack lint
 
-  build:
+  editorconfig:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
 
       - name: Install Dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
+      - name: Run EditorConfig Checker
+        run: bun ec
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+
+      - name: install dependencies
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,8 @@ describe('function-name', () => {
 
 1. **Expected Behavior**: Tests for normal operation and valid inputs
 2. **Unexpected Behavior**: Tests for error handling, invalid inputs, and edge cases
-   - Must mock `console.log` in beforeEach
-   - Must restore mocks in afterEach
+  2.1 Must mock `console.log` in beforeEach
+  2.2 Must restore mocks in afterEach
 
 ### Test Pattern: ARRANGE/ACT/ASSERT
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Avoid including unrelated changes. If you notice something that needs fixing but
 
 Before you start contributing, please make sure you have the following with the correct versions:
 
-- [Node.js](https://nodejs.org) 
+- [Node.js](https://nodejs.org)
 - [Bun](https://bun.sh)
 
 - The project requires the correct Bun version, as specified in [`package.json`](./package.json) or .bun-version.

--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -6,9 +6,9 @@
 
 @theme {
   /*
-	Configure your Tailwind theme that will be used by Starlight.
-	https://starlight.astro.build/guides/css-and-tailwind/#styling-starlight-with-tailwind
-	*/
+  Configure your Tailwind theme that will be used by Starlight.
+  https://starlight.astro.build/guides/css-and-tailwind/#styling-starlight-with-tailwind
+  */
 }
 
 /*

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "cspell": "9.3.2",
+        "editorconfig-checker": "6.1.1",
         "lefthook": "2.0.4",
         "pkg-pr-new": "0.0.61",
         "syncpack": "14.0.0-alpha.29",
@@ -720,6 +721,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "editorconfig-checker",
+  ],
   "catalog": {
     "@eslint/js": "9.38.0",
     "@hookform/resolvers": "5.2.2",
@@ -2780,6 +2784,8 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "editorconfig-checker": ["editorconfig-checker@6.1.1", "", { "bin": { "ec": "dist/index.js", "editorconfig-checker": "dist/index.js" } }, "sha512-kiOb6qaWpMNt7Z/43ba0Pa1Inhr2/t9nKbvEKtCeXJ5AesztoM9AgLOOQVB4QUv/nGjgz3xkbx4pcogVRD2NWw=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -5,6 +5,10 @@ pre-commit:
       run: bun syncpack lint
       glob: "package.json"
 
+    - name: editorconfig checker
+      run: bun ec
+      glob: "*"
+
     - name: lint
       run: bun lint
       glob: "*"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "cspell": "9.3.2",
+    "editorconfig-checker": "6.1.1",
     "lefthook": "2.0.4",
     "pkg-pr-new": "0.0.61",
     "syncpack": "14.0.0-alpha.29",
@@ -74,6 +75,7 @@
     "test:integration:watch": "vitest --watch --config=vitest.integration.config.ts",
     "test:watch": "vitest --watch"
   },
+  "trustedDependencies": ["editorconfig-checker"],
   "type": "module",
   "version": "0.0.0",
   "workspaces": ["apps/*", "packages/*", "turbo/*"]


### PR DESCRIPTION
## Description

We have an `.editorconfig` file but we are not enforcing the editorconfig standards. Biome supports most of them but not all options so this pull request adds `editorconfig-checker` to enforce them.

Max line length is disabled because of tailwindcss and very long classNames. I do prefer short line length for readability but hard to enforce with tailwind.

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~
