### PR TITLE
feat(tools): improve account dropdown in Airdrop form

### DIFF
--- a/packages/tools/src/tools-feature-airdrop.tsx
+++ b/packages/tools/src/tools-feature-airdrop.tsx
@@ -10,12 +10,11 @@ import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { ToolsUiAirdropForm } from './ui/tools-ui-airdrop-form.tsx'
 
 export default function ToolsFeatureAirdrop(props: { account: Account; network: Network }) {
-  const accounts = useAccountOptions()
+  const wallets = useWalletLive()
   const { isPending, mutateAsync } = useRequestAirdrop(props.network)
   return (
     <UiCard backButtonTo="/tools" title="Airdrop">
       <ToolsUiAirdropForm
-        accounts={accounts}
         disabled={isPending}
         submit={async (input) => {
           const signature = await mutateAsync({
@@ -31,15 +30,8 @@ export default function ToolsFeatureAirdrop(props: { account: Account; network: 
             />,
           )
         }}
+        wallets={wallets}
       />
     </UiCard>
   )
-}
-
-export function useAccountOptions() {
-  const wallets = useWalletLive()
-  const accounts = wallets.flatMap((wallet) => wallet.accounts)
-  return [...new Map(accounts.map((item) => [item.publicKey, item])).values()]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map((i) => ({ label: i.name, value: i.publicKey }))
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves Airdrop form by replacing account dropdown with wallet-based selection using `Select` components.
> 
>   - **Behavior**:
>     - Replaces account dropdown with wallet-based selection in `ToolsUiAirdropForm`.
>     - Uses `useWalletLive()` to fetch wallets instead of `useAccountOptions()`.
>     - Updates form to handle wallet and account selection using `Select` components.
>   - **Form Changes**:
>     - `ToolsUiAirdropForm` now accepts `wallets` prop instead of `accounts`.
>     - Initializes form with empty `address` and `amount` set to 0.
>     - Validates `amount` as integer and non-negative.
>   - **UI Components**:
>     - Replaces `Popover` and `Command` components with `Select` components for account selection.
>     - Updates placeholder text for amount input to "Enter the amount of SOL to airdrop".
>     - Disables submit button if form is invalid or disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 6a927b89001649552a4d8ab39922c886d18250e6. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->