### PR TITLE
fix: ensure wallet details screens hows accounts for selected wallet

### DIFF
--- a/packages/db-react/src/use-account-active.tsx
+++ b/packages/db-react/src/use-account-active.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react'
-import { useAccountLive } from './use-account-live.tsx'
+import { useAccountsForActiveWalletLive } from './use-accounts-for-active-wallet-live.tsx'
 import { useSetting } from './use-setting.tsx'
 
 export function useAccountActive() {
   const [accountId] = useSetting('activeAccountId')
-  const accountLive = useAccountLive()
-  const account = useMemo(() => accountLive.find((item) => item.id === accountId), [accountId, accountLive])
+  const accounts = useAccountsForActiveWalletLive()
+  const account = useMemo(() => accounts.find((item) => item.id === accountId), [accountId, accounts])
   if (!account) {
     throw new Error('No active account set.')
   }

--- a/packages/db-react/src/use-accounts-for-active-wallet-live.tsx
+++ b/packages/db-react/src/use-accounts-for-active-wallet-live.tsx
@@ -1,0 +1,11 @@
+import { useAccountsForWalletLive } from './use-accounts-for-wallet-live.tsx'
+import { useSetting } from './use-setting.tsx'
+
+export function useAccountsForActiveWalletLive() {
+  const [walletId] = useSetting('activeWalletId')
+  if (!walletId) {
+    throw new Error('No active wallet set.')
+  }
+
+  return useAccountsForWalletLive({ walletId })
+}

--- a/packages/db-react/src/use-accounts-for-wallet-live.tsx
+++ b/packages/db-react/src/use-accounts-for-wallet-live.tsx
@@ -3,14 +3,8 @@ import { accountFindMany } from '@workspace/db/account/account-find-many'
 import { db } from '@workspace/db/db'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { useRootLoaderData } from './use-root-loader-data.tsx'
-import { useSetting } from './use-setting.tsx'
 
-export function useAccountLive() {
-  const [walletId] = useSetting('activeWalletId')
-  if (!walletId) {
-    throw new Error('No active wallet set.')
-  }
-
+export function useAccountsForWalletLive({ walletId }: { walletId: string }) {
   const data = useRootLoaderData()
   if (!data?.accounts) {
     throw new Error('Root loader not called.')

--- a/packages/settings/src/data-access/use-active-account.tsx
+++ b/packages/settings/src/data-access/use-active-account.tsx
@@ -1,12 +1,12 @@
-import { useAccountLive } from '@workspace/db-react/use-account-live'
 import { useAccountSetActive } from '@workspace/db-react/use-account-set-active'
+import { useAccountsForActiveWalletLive } from '@workspace/db-react/use-accounts-for-active-wallet-live'
 import { useSetting } from '@workspace/db-react/use-setting'
 import { useMemo } from 'react'
 import { useSortAccounts } from './use-sort-accounts.tsx'
 
 export function useActiveAccount() {
   const [accountId] = useSetting('activeAccountId')
-  const accounts = useAccountLive()
+  const accounts = useAccountsForActiveWalletLive()
   const { mutateAsync } = useAccountSetActive()
 
   const sorted = useSortAccounts(accounts)

--- a/packages/settings/src/settings-feature-wallet-add-account.tsx
+++ b/packages/settings/src/settings-feature-wallet-add-account.tsx
@@ -1,7 +1,7 @@
 import { assertIsAddress } from '@solana/kit'
 import type { Wallet } from '@workspace/db/wallet/wallet'
 import { useAccountCreate } from '@workspace/db-react/use-account-create'
-import { useAccountLive } from '@workspace/db-react/use-account-live'
+import { useAccountsForWalletLive } from '@workspace/db-react/use-accounts-for-wallet-live'
 import { useWalletFindUnique } from '@workspace/db-react/use-wallet-find-unique'
 import { useTranslation } from '@workspace/i18n'
 import { importKeyPairToPublicKeySecretKey } from '@workspace/keypair/import-key-pair-to-public-key-secret-key'
@@ -27,7 +27,7 @@ export function SettingsFeatureWalletAddAccount() {
   const { data: item, error, isError, isLoading } = useWalletFindUnique({ id: walletId })
   const deriveAccount = useDeriveAndCreateAccount()
   const createAccountMutation = useAccountCreate()
-  const accounts = useAccountLive()
+  const accounts = useAccountsForWalletLive({ walletId })
 
   async function createAccountDerived(wallet: Wallet) {
     try {

--- a/packages/settings/src/settings-feature-wallet-details.tsx
+++ b/packages/settings/src/settings-feature-wallet-details.tsx
@@ -1,4 +1,4 @@
-import { useAccountLive } from '@workspace/db-react/use-account-live'
+import { useAccountsForWalletLive } from '@workspace/db-react/use-accounts-for-wallet-live'
 import { useWalletFindUnique } from '@workspace/db-react/use-wallet-find-unique'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
@@ -8,7 +8,6 @@ import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiLoader } from '@workspace/ui/components/ui-loader'
 import { UiNotFound } from '@workspace/ui/components/ui-not-found'
 import { Link, useLocation, useParams } from 'react-router'
-import { useSortAccounts } from './data-access/use-sort-accounts.tsx'
 import { SettingsUiAccountTable } from './ui/settings-ui-account-table.tsx'
 import { SettingsUiWalletItem } from './ui/settings-ui-wallet-item.tsx'
 
@@ -17,8 +16,7 @@ export function SettingsFeatureWalletDetails() {
   const { pathname: from } = useLocation()
   const { walletId } = useParams() as { walletId: string }
   const { data: item, error, isError, isLoading } = useWalletFindUnique({ id: walletId })
-  const accounts = useAccountLive()
-  const sorted = useSortAccounts(accounts)
+  const accounts = useAccountsForWalletLive({ walletId })
 
   if (isLoading) {
     return <UiLoader />
@@ -55,7 +53,7 @@ export function SettingsFeatureWalletDetails() {
       }
     >
       <div className="space-y-2 md:space-y-6">
-        <SettingsUiAccountTable items={sorted} />
+        <SettingsUiAccountTable items={accounts} />
       </div>
     </UiCard>
   )


### PR DESCRIPTION
## Description

This PR fixes an issue with the 'wallet-detail' screen.

It makes sure that it shows the accounts in the selected wallet, instead of the active wallet.

In addition, it removes the sorting from this screen as it expects these accounts to be sorted by derivationIndex (not type/name) so that it knows which wallet to derive next.

It does so by splitting `useAccountLive` into `useAccountsForWalletLive` and `useAccountsForActiveWalletLive`, making both hooks more specific with a clearer name.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes wallet-detail screen to show accounts for selected wallet by introducing specific hooks for wallet and active wallet accounts.
> 
>   - **Behavior**:
>     - `SettingsFeatureWalletDetails` now shows accounts for the selected wallet using `useAccountsForWalletLive`.
>     - Removes sorting from `SettingsFeatureWalletDetails` to maintain derivation order.
>   - **Hooks**:
>     - Splits `useAccountLive` into `useAccountsForWalletLive` and `useAccountsForActiveWalletLive`.
>     - Updates `useAccountActive` and `useActiveAccount` to use `useAccountsForActiveWalletLive`.
>   - **Files**:
>     - Renames `use-account-live.tsx` to `use-accounts-for-wallet-live.tsx`.
>     - Adds `use-accounts-for-active-wallet-live.tsx` for active wallet accounts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b71912120381435e5cb7e0d6840d2263e687eb5c. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->