### PR TITLE
feat: load all accounts in the root loader

### DIFF
--- a/packages/db-react/src/options-account.tsx
+++ b/packages/db-react/src/options-account.tsx
@@ -26,6 +26,7 @@ export const optionsAccount = {
       onSuccess: () => {
         queryClient.invalidateQueries(optionsSetting.getAll())
         queryClient.invalidateQueries(optionsSetting.getValue('activeAccountId'))
+        queryClient.invalidateQueries(optionsAccount.findMany({}))
       },
       ...props,
     }),

--- a/packages/db-react/src/options-network.tsx
+++ b/packages/db-react/src/options-network.tsx
@@ -30,7 +30,7 @@ export const optionsNetwork = {
       onSuccess: () => toastSuccess('Network deleted'),
       ...props,
     }),
-  findMany: (input: NetworkFindManyInput = {}) =>
+  findMany: (input: NetworkFindManyInput) =>
     queryOptions({
       queryFn: () => networkFindMany(db, input),
       queryKey: ['networkFindMany', input],

--- a/packages/db-react/src/options-wallet.tsx
+++ b/packages/db-react/src/options-wallet.tsx
@@ -26,6 +26,7 @@ export const optionsWallet = {
       onSuccess: () => {
         queryClient.invalidateQueries(optionsSetting.getAll())
         queryClient.invalidateQueries(optionsSetting.getValue('activeWalletId'))
+        queryClient.invalidateQueries(optionsWallet.findMany({}))
       },
       ...props,
     }),
@@ -34,7 +35,7 @@ export const optionsWallet = {
       mutationFn: ({ id }: { id: string }) => walletDelete(db, id),
       ...props,
     }),
-  findMany: (input: WalletFindManyInput = {}) =>
+  findMany: (input: WalletFindManyInput) =>
     queryOptions({
       queryFn: () => walletFindMany(db, input),
       queryKey: ['walletFindMany', input],

--- a/packages/db-react/src/root-loader.tsx
+++ b/packages/db-react/src/root-loader.tsx
@@ -17,16 +17,12 @@ export interface RootLoaderData {
 }
 
 export async function rootLoader() {
-  const [networks, settings, wallets] = await Promise.all([
-    getOrFetchQuery(queryClient, optionsNetwork.findMany()),
+  const [accounts, networks, settings, wallets] = await Promise.all([
+    getOrFetchQuery(queryClient, optionsAccount.findMany({})),
+    getOrFetchQuery(queryClient, optionsNetwork.findMany({})),
     getOrFetchQuery(queryClient, optionsSetting.getAll()),
-    getOrFetchQuery(queryClient, optionsWallet.findMany()),
+    getOrFetchQuery(queryClient, optionsWallet.findMany({})),
   ])
-
-  const activeWalletId = settings.find((s) => s.key === 'activeWalletId')?.value
-  const accounts = activeWalletId
-    ? await getOrFetchQuery(queryClient, optionsAccount.findMany({ walletId: activeWalletId }))
-    : []
 
   return {
     accounts,

--- a/packages/db-react/src/use-accounts-for-wallet-live.tsx
+++ b/packages/db-react/src/use-accounts-for-wallet-live.tsx
@@ -10,5 +10,6 @@ export function useAccountsForWalletLive({ walletId }: { walletId: string }) {
     throw new Error('Root loader not called.')
   }
 
-  return useLiveQuery<Account[], Account[]>(() => accountFindMany(db, { walletId }), [walletId], data.accounts)
+  const accounts = useLiveQuery<Account[], Account[]>(() => accountFindMany(db), [], data.accounts)
+  return accounts.filter((account) => account.walletId === walletId)
 }

--- a/packages/db-react/src/use-setting-get-value-live.tsx
+++ b/packages/db-react/src/use-setting-get-value-live.tsx
@@ -1,5 +1,6 @@
 import { db } from '@workspace/db/db'
-import { settingGetValue } from '@workspace/db/setting/setting-get-value'
+import type { Setting } from '@workspace/db/setting/setting'
+import { settingGetAll } from '@workspace/db/setting/setting-get-all'
 import type { SettingKey } from '@workspace/db/setting/setting-key'
 import { useLiveQuery } from 'dexie-react-hooks'
 import { useRootLoaderData } from './use-root-loader-data.tsx'
@@ -10,7 +11,6 @@ export function useSettingGetValueLive(key: SettingKey) {
     throw new Error('Root loader not called.')
   }
 
-  const value = data.settings.find((s) => s.key === key)?.value ?? null
-
-  return useLiveQuery<null | string, null | string>(() => settingGetValue(db, key), [key], value)
+  const settings = useLiveQuery<Setting[], Setting[]>(() => settingGetAll(db), [], data.settings)
+  return settings.find((s) => s.key === key)?.value ?? null
 }

--- a/packages/db/src/account/account-find-many-schema.ts
+++ b/packages/db/src/account/account-find-many-schema.ts
@@ -6,8 +6,6 @@ export const accountFindManySchema = accountSchema
     name: true,
     publicKey: true,
     type: true,
+    walletId: true,
   })
   .partial()
-  .extend({
-    walletId: accountSchema.shape.walletId,
-  })

--- a/packages/db/src/account/account-find-many.ts
+++ b/packages/db/src/account/account-find-many.ts
@@ -5,13 +5,13 @@ import type { AccountFindManyInput } from './account-find-many-input.ts'
 import { accountFindManySchema } from './account-find-many-schema.ts'
 import { accountSanitizer } from './account-sanitizer.ts'
 
-export async function accountFindMany(db: Database, input: AccountFindManyInput): Promise<Account[]> {
+export async function accountFindMany(db: Database, input: AccountFindManyInput = {}): Promise<Account[]> {
   const parsedInput = accountFindManySchema.parse(input)
   const { data, error } = await tryCatch(
     db.accounts
       .orderBy('derivationIndex')
       .filter((item) => {
-        const matchWalletId = item.walletId === parsedInput.walletId
+        const matchWalletId = !parsedInput.walletId || item.walletId === parsedInput.walletId
         const matchId = !parsedInput.id || item.id === parsedInput.id
         const matchName = !parsedInput.name || item.name.includes(parsedInput.name)
         const matchPublicKey = !parsedInput.publicKey || item.publicKey === parsedInput.publicKey

--- a/packages/shell/src/shell-routes.tsx
+++ b/packages/shell/src/shell-routes.tsx
@@ -1,4 +1,7 @@
+import { optionsAccount } from '@workspace/db-react/options-account'
+import { optionsNetwork } from '@workspace/db-react/options-network'
 import { optionsSetting } from '@workspace/db-react/options-setting'
+import { optionsWallet } from '@workspace/db-react/options-wallet'
 import { queryClient } from '@workspace/db-react/query-client'
 import { getEntrypoint } from '@workspace/env/get-entrypoint'
 import { UiErrorBoundary } from '@workspace/ui/components/ui-error-boundary'
@@ -38,10 +41,13 @@ function createRouter() {
       hydrateFallbackElement: <UiLoaderFull />,
       id: 'root',
       loader: rootRouteLoader(),
-      shouldRevalidate: () => {
-        const state = queryClient.getQueryState(optionsSetting.getAll().queryKey)
-        return !state || state.isInvalidated
-      },
+      shouldRevalidate: () =>
+        [
+          queryClient.getQueryState(optionsAccount.findMany({}).queryKey)?.isInvalidated,
+          queryClient.getQueryState(optionsNetwork.findMany({}).queryKey)?.isInvalidated,
+          queryClient.getQueryState(optionsSetting.getAll().queryKey)?.isInvalidated,
+          queryClient.getQueryState(optionsWallet.findMany({}).queryKey)?.isInvalidated,
+        ].some((isInvalidated) => isInvalidated || false),
     },
   ])
 }

--- a/packages/shell/src/ui/shell-ui-layout.tsx
+++ b/packages/shell/src/ui/shell-ui-layout.tsx
@@ -1,4 +1,3 @@
-import { useRootLoaderData } from '@workspace/db-react/use-root-loader-data'
 import { useTranslation } from '@workspace/i18n'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import type { UiIconName } from '@workspace/ui/components/ui-icon-map'
@@ -17,10 +16,6 @@ export interface ShellLayoutLink {
 
 export function ShellUiLayout() {
   const { t } = useTranslation('shell')
-  const data = useRootLoaderData()
-  if (!data?.accounts?.length) {
-    return null
-  }
 
   const links: ShellLayoutLink[] = [
     { icon: 'portfolio', label: t(($) => $.labelPortfolio), to: '/portfolio' },


### PR DESCRIPTION
## Description

This PR changes how the road loader works, it will load all the accounts by default instead of a filtered list based on the active wallet that is selected.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> The PR updates the root loader to load all accounts by default, modifies query invalidation logic, and refactors related components.
> 
>   - **Behavior**:
>     - `rootLoader` in `root-loader.tsx` now loads all accounts by default, removing filtering by active wallet.
>     - `useAccountsForWalletLive` in `use-accounts-for-wallet-live.tsx` now filters accounts by `walletId` after fetching all accounts.
>     - `accountFindMany` in `account-find-many.ts` updated to handle empty input and match all accounts if `walletId` is not specified.
>   - **Query Invalidation**:
>     - Added `queryClient.invalidateQueries(optionsAccount.findMany({}))` in `options-account.tsx` and `options-wallet.tsx` to ensure account queries are invalidated on success.
>   - **Misc**:
>     - Removed unused code in `shell-ui-layout.tsx` related to account data.
>     - Updated `findMany` functions in `options-network.tsx` and `options-wallet.tsx` to require input parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 03371e92a3d54cb6ccfa0a041cb046562a2c7ac0. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->