### PR TITLE
test: add e2e tests with playwright to web app

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,29 @@ jobs:
       - name: Test Integration
         run: bun run test:integration
 
+  test-e2e:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+
+      - name: Install Dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
+      - name: Install Playwright Browsers
+        run: bunx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: bun run test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
   commitlint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ ios
 
 # IDEs
 .vscode
+
+# Playwright
+playwright-report
+test-results

--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test'
+
+test('onboarding - import existing wallet', async ({ page }) => {
+  await page.goto('')
+  await page.getByRole('link', { name: 'I already have a wallet' }).click()
+
+  const seedPhrase = [
+    'pill',
+    'tomorrow',
+    'foster',
+    'begin',
+    'walnut',
+    'borrow',
+    'virtual',
+    'kick',
+    'shift',
+    'mutual',
+    'shoe',
+    'scatter',
+  ]
+
+  for (const [index, word] of seedPhrase.entries()) {
+    const name = (index + 1).toString()
+    await page.getByRole('textbox', { exact: true, name }).click()
+    await page.getByRole('textbox', { exact: true, name }).fill(word)
+  }
+
+  await page.getByRole('button', { name: 'Import wallet' }).click()
+  await page.getByRole('button', { name: 'Copy public key' }).click()
+  await expect(page.getByTestId('wallet-menu-trigger')).toContainText('W15F86')
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
     "react-router": "catalog:"
   },
   "devDependencies": {
+    "@playwright/test": "1.57.0",
+    "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@workspace/config-typescript": "workspace:*",
@@ -28,7 +30,8 @@
     "build:analyze": "ANALYZE=1 bun run build",
     "dev": "vite",
     "postinstall": "[ -f .env.example ] && [ ! -f .env ] && cp -v .env.example .env || true",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "type": "module",
   "version": "0.0.0"

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const isCi = Boolean(process.env['CI'])
+
+export default defineConfig({
+  forbidOnly: isCi,
+  fullyParallel: true,
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+  ],
+  reporter: 'html',
+  retries: isCi ? 2 : 0,
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'bun run build && bun run preview',
+    reuseExistingServer: !isCi,
+    url: 'http://localhost:4173',
+  },
+  workers: isCi ? 1 : 3,
+})

--- a/bun.lock
+++ b/bun.lock
@@ -172,6 +172,8 @@
         "react-router": "catalog:",
       },
       "devDependencies": {
+        "@playwright/test": "1.57.0",
+        "@types/node": "catalog:",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "@workspace/config-typescript": "workspace:*",
@@ -1694,6 +1696,8 @@
     "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@playwright/test": ["@playwright/test@1.57.0", "", { "dependencies": { "playwright": "1.57.0" }, "bin": { "playwright": "cli.js" } }, "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -3875,6 +3879,10 @@
 
     "planck": ["planck@1.4.2", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-mNbhnV3g8X2rwGxzcesjmN8BDA6qfXgQxXVMkWau9MCRlQY0RLNEkyHlVp6yFy/X6qrzAXyNONCnZ1cGDLrNew=="],
 
+    "playwright": ["playwright@1.57.0", "", { "dependencies": { "playwright-core": "1.57.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw=="],
+
+    "playwright-core": ["playwright-core@1.57.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ=="],
+
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
@@ -5286,6 +5294,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
 
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "prepare": "lefthook install",
     "spell-check": "cspell -c ./cspell.config.mts .",
     "test": "vitest run",
+    "test:e2e": "turbo run test:e2e",
     "test:integration": "vitest run --config=vitest.integration.config.ts",
     "test:integration:watch": "vitest --watch --config=vitest.integration.config.ts",
     "test:watch": "vitest --watch"

--- a/packages/shell/src/ui/shell-ui-menu-wallets.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-wallets.tsx
@@ -33,7 +33,11 @@ export function ShellUiMenuWallets({
   const { t } = useTranslation('shell')
   return (
     <MenubarMenu>
-      <MenubarTrigger asChild className="h-8 gap-2 px-1 py-2 md:h-12 md:min-w-[150px] md:px-2">
+      <MenubarTrigger
+        asChild
+        className="h-8 gap-2 px-1 py-2 md:h-12 md:min-w-[150px] md:px-2"
+        data-testid="wallet-menu-trigger"
+      >
         <div className="flex items-center gap-2">
           <UiAvatar className="size-6 md:size-8" label={activeWallet.name} />
           {activeAccount.name}

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,16 @@
     "test": {
       "dependsOn": ["^test"]
     },
+    "test:e2e": {
+      "dependsOn": ["^test:e2e"]
+    },
+    "test:integration": {
+      "dependsOn": ["^test:integration"]
+    },
+    "test:integration:watch": {
+      "cache": false,
+      "persistent": true
+    },
     "test:watch": {
       "cache": false,
       "persistent": true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    projects: ['apps/*', 'packages/*'],
+    projects: ['apps/*/vitest.config.ts', 'packages/*/vitest.config.ts'],
   },
 })


### PR DESCRIPTION
## Description

- Adds e2e tests with playwright to the web app
- Adds a simple test to go through onboarding flow with an existing wallet to verify e2es are working

**Note:** We should probably also use surfpool and localnet for e2e tests but let's do that in a follow up pull request to set the default network with the environment variables

Closes #675 

## Screenshots / Video

N/A

## Checklist

- [x] Tests have been added for my change
~- [ ] Docs have been updated for my change~
