### PR TITLE
refactor: use superjson rather than global prototypes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -349,6 +349,7 @@
         "@workspace/ui": "workspace:*",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
+        "superjson": "2.2.6",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -11,6 +11,7 @@
     "@workspace/ui": "workspace:*",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",
+    "superjson": "2.2.6",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/explorer/src/ui/explorer-ui-tx-details.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-details.tsx
@@ -1,5 +1,6 @@
 import type { Network } from '@workspace/db/network/network'
 import { Separator } from '@workspace/ui/components/separator'
+import superjson from 'superjson'
 import type { ExplorerGetTransactionResult } from '../data-access/use-explorer-get-transaction.ts'
 import { ExplorerUiDetailRow } from './explorer-ui-detail-row.tsx'
 import { ExplorerUiExplorers } from './explorer-ui-explorers.tsx'
@@ -47,7 +48,11 @@ export function ExplorerUiTxDetails({
       <Separator />
       <ExplorerUiDetailRow
         label="Raw TX"
-        value={<pre className="overflow-auto text-[9px]">{JSON.stringify(tx, null, 2)}</pre>}
+        value={
+          <pre className="overflow-auto whitespace-pre-wrap text-[9px]">
+            {JSON.stringify(superjson.serialize(tx).json, null, 2)}
+          </pre>
+        }
       />
     </div>
   )

--- a/packages/shell/src/data-access/shell-providers.tsx
+++ b/packages/shell/src/data-access/shell-providers.tsx
@@ -41,14 +41,3 @@ export function ShellProviders({ children }: ShellProviderProps) {
     </PersistQueryClientProvider>
   )
 }
-
-// Patch BigInt so we can log it using JSON.stringify without any errors
-declare global {
-  interface BigInt {
-    toJSON(): string
-  }
-}
-
-BigInt.prototype.toJSON = function () {
-  return this.toString()
-}


### PR DESCRIPTION
## Description

Replaces global prototype usage with superjson. This gives us more support for other types such as Date with JSON.stringify when necessary

Closes #671

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to use `superjson` for JSON serialization in `explorer-ui-tx-details.tsx`, removing global `BigInt` prototype patch.
> 
>   - **Behavior**:
>     - Replaces `JSON.stringify(tx, null, 2)` with `JSON.stringify(superjson.serialize(tx).json, null, 2)` in `ExplorerUiTxDetails` in `explorer-ui-tx-details.tsx`.
>     - Removes global `BigInt.prototype.toJSON` patch in `shell-providers.tsx`.
>   - **Dependencies**:
>     - Adds `superjson` version `2.2.6` to `dependencies` in `package.json` and `bun.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 6b5027f939986d4efd900573984bbe14a4c4aa41. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->