### PR TITLE
fix(ui): error when clicking 12-words button on onboarding screen

### DIFF
--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-select-strength.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-select-strength.tsx
@@ -19,7 +19,7 @@ export function OnboardingUiMnemonicSelectStrength({
       variant="outline"
     >
       {[128, 256].map((value) => (
-        <ToggleGroupItem key={value} value={value.toString()}>
+        <ToggleGroupItem disabled={strength === value} key={value} value={value.toString()}>
           {t(($) => $.uiMnemonicWords, { words: value === 128 ? 12 : 24 })}
         </ToggleGroupItem>
       ))}


### PR DESCRIPTION
fix #690 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error in `OnboardingUiMnemonicSelectStrength` by adding a check for non-null `s` in `onValueChange`.
> 
>   - **Bug Fix**:
>     - Fixes error in `OnboardingUiMnemonicSelectStrength` when clicking 12-words button by adding a check for non-null `s` in `onValueChange`.
>   - **Files Affected**:
>     - `onboarding-ui-mnemonic-select-strength.tsx`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for dfe40f347e3c04c7a83068593601d3466ba0062b. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->