### PR TITLE
feat(wallet-standard): add standard events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -188,6 +188,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@solana/kit": "catalog:",
+        "@solana/wallet-standard-chains": "1.1.1",
         "@solana/wallet-standard-features": "1.3.0",
         "@solana/wallet-standard-util": "1.1.2",
         "@wallet-standard/core": "1.1.1",

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@solana/kit": "catalog:",
+    "@solana/wallet-standard-chains": "1.1.1",
     "@solana/wallet-standard-features": "1.3.0",
     "@solana/wallet-standard-util": "1.1.2",
     "@wallet-standard/core": "1.1.1",

--- a/packages/background/src/services/db.ts
+++ b/packages/background/src/services/db.ts
@@ -1,4 +1,11 @@
 import { address, getAddressEncoder } from '@solana/kit'
+import { SOLANA_CHAINS } from '@solana/wallet-standard-chains'
+import {
+  SolanaSignAndSendTransaction,
+  SolanaSignIn,
+  SolanaSignMessage,
+  SolanaSignTransaction,
+} from '@solana/wallet-standard-features'
 import type { StandardConnectOutput } from '@wallet-standard/core'
 import { defineProxyService } from '@webext-core/proxy-service'
 import type { Account } from '@workspace/db/account/account'
@@ -48,10 +55,10 @@ export const [registerDbService, getDbService] = defineProxyService('DbService',
         accounts: [
           {
             address: account.publicKey,
-            chains: ['solana:devnet'],
-            features: ['solana:signTransaction', 'solana:signAndSendTransaction'],
-            // icon: '',
-            label: account.name,
+            chains: SOLANA_CHAINS,
+            features: [SolanaSignAndSendTransaction, SolanaSignIn, SolanaSignMessage, SolanaSignTransaction],
+            // icon: undefined,
+            // label: undefined,
             publicKey: getAddressEncoder().encode(address(account.publicKey)),
           },
         ],

--- a/packages/keypair/src/ensure-uint8array.ts
+++ b/packages/keypair/src/ensure-uint8array.ts
@@ -1,7 +1,9 @@
+import type { ReadonlyUint8Array } from '@solana/kit'
+
 /**
  * @link https://github.com/mozilla/webextension-polyfill/issues/643
  * @link https://issues.chromium.org/issues/40321352
  */
-export function ensureUint8Array(value: Record<string, number> | Uint8Array): Uint8Array {
+export function ensureUint8Array(value: Record<string, number> | Uint8Array | ReadonlyUint8Array): Uint8Array {
   return value instanceof Uint8Array ? value : new Uint8Array(Object.values(value))
 }

--- a/packages/wallet-standard/src/features/events.ts
+++ b/packages/wallet-standard/src/features/events.ts
@@ -1,8 +1,0 @@
-import type { StandardEventsListeners, StandardEventsNames } from '@wallet-standard/core'
-
-export function on<T extends StandardEventsNames>(event: T, listener: StandardEventsListeners[T]): () => void {
-  console.log('on called', event, listener)
-  return () => {
-    console.log('off called')
-  }
-}


### PR DESCRIPTION
## Description

Adds support for wallet standard onChange event that lets wallet adapters know accounts have changed

Closes https://github.com/samui-build/samui-wallet/issues/677

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `onChange` event support in `SamuiWallet` to notify account changes and updates dependencies and functions for improved event handling.
> 
>   - **Behavior**:
>     - Adds `onChange` event support in `SamuiWallet` to notify when accounts change.
>     - Emits 'change' event in `connect()` and `disconnect()` methods in `wallet.ts`.
>   - **Dependencies**:
>     - Adds `@solana/wallet-standard-chains` to `package.json` and `bun.lock`.
>   - **Functions**:
>     - Updates `ensureUint8Array()` to accept `ReadonlyUint8Array` in `ensure-uint8array.ts`.
>     - Removes `on()` function from `events.ts` and integrates event handling in `wallet.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 522cc0c502cb0fe4610e2339de3134e192c4b06c. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->