### PR TITLE
feat: use safe area insets for bottom bar

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -2,10 +2,9 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Samui</title>
   </head>
-
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/apps/extension/src/entrypoints/onboarding/index.html
+++ b/apps/extension/src/entrypoints/onboarding/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Samui</title>
     <meta name="manifest.type" content="browser_action" />
   </head>

--- a/apps/extension/src/entrypoints/popup/index.html
+++ b/apps/extension/src/entrypoints/popup/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark w-[375px] h-[600px]">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Samui</title>
     <meta name="manifest.type" content="browser_action" />
   </head>

--- a/apps/extension/src/entrypoints/request/index.html
+++ b/apps/extension/src/entrypoints/request/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Samui</title>
     <meta name="manifest.type" content="browser_action" />
   </head>

--- a/apps/extension/src/entrypoints/sidepanel/index.html
+++ b/apps/extension/src/entrypoints/sidepanel/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Samui</title>
     <meta name="manifest.open_at_install" content="true" />
     <meta name="manifest.browser_style" content="true" />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/samui.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Samui</title>
   </head>
   <body>

--- a/packages/shell/src/ui/shell-ui-layout.tsx
+++ b/packages/shell/src/ui/shell-ui-layout.tsx
@@ -42,7 +42,7 @@ export function ShellUiLayout() {
       <main className="flex-1 overflow-y-auto p-1 md:p-2 lg:p-4">
         <Outlet />
       </main>
-      <footer className="flex items-center justify-between bg-secondary/30">
+      <footer className="flex items-center justify-between bg-secondary/30 pb-[env(safe-area-inset-bottom)]">
         {links.map(({ icon, label, to }) => (
           <NavLink
             className={({ isActive }) =>


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

Use safe area insets for bottom bar

## Screenshots / Video

<img width="428" height="936" alt="image" src="https://github.com/user-attachments/assets/843431a9-e6d7-4858-a9cc-f3fdc9b7565f" />

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update viewport settings and footer padding to use safe area insets for better layout handling.
> 
>   - **HTML Files**:
>     - Updated `meta name="viewport"` to include `viewport-fit=cover` in `apps/desktop/index.html`, `apps/extension/src/entrypoints/onboarding/index.html`, and `apps/web/index.html`.
>     - Similar updates in `apps/extension/src/entrypoints/popup/index.html`, `apps/extension/src/entrypoints/request/index.html`, and `apps/extension/src/entrypoints/sidepanel/index.html`.
>   - **React Component**:
>     - Updated `footer` in `ShellUiLayout` in `shell-ui-layout.tsx` to include `pb-[env(safe-area-inset-bottom)]` for safe area insets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for d2c122e8f7812a6eb444136bbec43bd5b520a2eb. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->