### PR TITLE
refactor(api): move routes to subdirectory

### DIFF
--- a/apps/api/src/api.ts
+++ b/apps/api/src/api.ts
@@ -1,0 +1,5 @@
+import { HttpApi, OpenApi } from '@effect/platform'
+import { DomainApi } from './routes/domain/api.ts'
+import { RootApi } from './routes/root/api.ts'
+
+export class Api extends HttpApi.make('api').add(RootApi).add(DomainApi).annotate(OpenApi.Title, 'Samui') {}

--- a/apps/api/src/http.ts
+++ b/apps/api/src/http.ts
@@ -1,0 +1,7 @@
+import { HttpApiBuilder } from '@effect/platform'
+import { Layer } from 'effect'
+import { Api } from './api.ts'
+import { HttpDomainLive } from './routes/domain/http.ts'
+import { HttpRootLive } from './routes/root/http.ts'
+
+export const ApiLive = Layer.provide(HttpApiBuilder.api(Api), [HttpRootLive, HttpDomainLive])

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,19 +1,6 @@
-import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, HttpServer, OpenApi } from '@effect/platform'
-import { Effect, Layer, Schema } from 'effect'
-
-const RootApi = HttpApiGroup.make('Root').add(
-  HttpApiEndpoint.get('health-check', '/health-check')
-    .annotate(OpenApi.Summary, 'Health Check')
-    .addSuccess(Schema.String),
-)
-
-const Api = HttpApi.make('Samui').annotate(OpenApi.Title, 'Samui API').add(RootApi)
-
-const HttpRootLive = HttpApiBuilder.group(Api, 'Root', (handlers) =>
-  handlers.handle('health-check', () => Effect.succeed('Ok')),
-)
-
-const ApiLive = HttpApiBuilder.api(Api).pipe(Layer.provide(HttpRootLive))
+import { HttpApiBuilder, HttpServer } from '@effect/platform'
+import { Layer } from 'effect'
+import { ApiLive } from './http.ts'
 
 export default {
   fetch: (request: Request, env: Cloudflare.Env) => {

--- a/apps/api/src/routes/domain/api.ts
+++ b/apps/api/src/routes/domain/api.ts
@@ -1,0 +1,8 @@
+import { HttpApiEndpoint, HttpApiGroup, OpenApi } from '@effect/platform'
+import { Schema } from 'effect'
+
+export class DomainApi extends HttpApiGroup.make('Domain').add(
+  HttpApiEndpoint.get('domainSearch', '/domain/search')
+    .annotate(OpenApi.Summary, 'Search domain name')
+    .addSuccess(Schema.String),
+) {}

--- a/apps/api/src/routes/domain/http.ts
+++ b/apps/api/src/routes/domain/http.ts
@@ -1,0 +1,13 @@
+import { HttpApiBuilder } from '@effect/platform'
+import { Effect } from 'effect'
+import { Api } from '../../api.ts'
+
+export const HttpDomainLive = HttpApiBuilder.group(Api, 'Domain', (handlers) =>
+  Effect.gen(function* () {
+    return handlers.handle('domainSearch', () =>
+      Effect.gen(function* () {
+        return yield* Effect.succeed('tobey.sol')
+      }),
+    )
+  }),
+)

--- a/apps/api/src/routes/root/api.ts
+++ b/apps/api/src/routes/root/api.ts
@@ -1,0 +1,6 @@
+import { HttpApiEndpoint, HttpApiGroup, OpenApi } from '@effect/platform'
+import { Schema } from 'effect'
+
+export class RootApi extends HttpApiGroup.make('Root').add(
+  HttpApiEndpoint.get('health', '/').annotate(OpenApi.Summary, 'Health Check').addSuccess(Schema.String),
+) {}

--- a/apps/api/src/routes/root/http.ts
+++ b/apps/api/src/routes/root/http.ts
@@ -1,0 +1,13 @@
+import { HttpApiBuilder } from '@effect/platform'
+import { Effect } from 'effect'
+import { Api } from '../../api.ts'
+
+export const HttpRootLive = HttpApiBuilder.group(Api, 'Root', (handlers) =>
+  Effect.gen(function* () {
+    return handlers.handle('health', () =>
+      Effect.gen(function* () {
+        return yield* Effect.succeed('OK')
+      }),
+    )
+  }),
+)


### PR DESCRIPTION
## Description

Moves routes to a subdirectory to allow for a follow up pull request for SNS domain lookups.

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor API by moving route definitions to subdirectory, creating `api.ts` and `http.ts` for consolidated setup, and updating `index.ts`.
> 
>   - **Refactor API Structure**:
>     - Move `RootApi` and `DomainApi` route definitions to `routes/root/api.ts` and `routes/domain/api.ts`.
>     - Move HTTP handlers to `routes/root/http.ts` and `routes/domain/http.ts`.
>   - **API Setup**:
>     - Create `api.ts` to consolidate `RootApi` and `DomainApi` using `HttpApi`.
>     - Create `http.ts` to provide `ApiLive` with `HttpRootLive` and `HttpDomainLive`.
>   - **Index Update**:
>     - Update `index.ts` to use `ApiLive` from `http.ts` and configure middleware.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 9672e54c4a9b5a0e92668db49babd21435a86b23. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->