### PR TITLE
feat(api): add domain search endpoint

### DIFF
--- a/apps/api/src/routes/domain/api.ts
+++ b/apps/api/src/routes/domain/api.ts
@@ -1,8 +1,22 @@
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from '@effect/platform'
 import { Schema } from 'effect'
+import {
+  SnsDomainNotFound,
+  SnsInvalidDomainName,
+  SnsSearchResult,
+  SnsServiceUnavailable,
+} from '../../services/sns/service.ts'
+
+export const Domain = Schema.String.pipe(Schema.brand('Domain'))
+
+export type Domain = typeof Domain.Type
 
 export class DomainApi extends HttpApiGroup.make('Domain').add(
-  HttpApiEndpoint.get('domainSearch', '/domain/search')
+  HttpApiEndpoint.get('domainSearch', '/domain/:domain')
     .annotate(OpenApi.Summary, 'Search domain name')
-    .addSuccess(Schema.String),
+    .setPath(Schema.Struct({ domain: Domain }))
+    .addSuccess(SnsSearchResult)
+    .addError(SnsDomainNotFound, { status: 404 })
+    .addError(SnsInvalidDomainName, { status: 400 })
+    .addError(SnsServiceUnavailable, { status: 503 }),
 ) {}

--- a/apps/api/src/routes/domain/http.ts
+++ b/apps/api/src/routes/domain/http.ts
@@ -1,13 +1,21 @@
 import { HttpApiBuilder } from '@effect/platform'
-import { Effect } from 'effect'
+import { Effect, Encoding, Layer } from 'effect'
 import { Api } from '../../api.ts'
+import { SnsInvalidDomainName, SnsService } from '../../services/sns/service.ts'
 
 export const HttpDomainLive = HttpApiBuilder.group(Api, 'Domain', (handlers) =>
   Effect.gen(function* () {
-    return handlers.handle('domainSearch', () =>
+    const snsApi = yield* SnsService
+
+    return handlers.handle('domainSearch', ({ path }) =>
       Effect.gen(function* () {
-        return yield* Effect.succeed('tobey.sol')
-      }),
+        const domain = yield* Encoding.encodeUriComponent(path.domain)
+        return yield* snsApi.search(domain)
+      }).pipe(
+        Effect.catchTags({
+          EncodeException: () => Effect.fail(new SnsInvalidDomainName({ domain: path.domain })),
+        }),
+      ),
     )
   }),
-)
+).pipe(Layer.provide([SnsService.Default]))

--- a/apps/api/src/services/sns/service.ts
+++ b/apps/api/src/services/sns/service.ts
@@ -1,0 +1,58 @@
+import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from '@effect/platform'
+import { Effect, flow, Schema } from 'effect'
+
+export class SnsInvalidDomainName extends Schema.TaggedError<SnsInvalidDomainName>()('SnsInvalidDomainName', {
+  domain: Schema.String,
+}) {}
+
+export class SnsResolveResponse extends Schema.Class<SnsResolveResponse>('SnsResolveResponse')({
+  result: Schema.String,
+  s: Schema.Literal('ok', 'error'),
+}) {}
+
+export class SnsDomainNotFound extends Schema.TaggedError<SnsDomainNotFound>()('SnsDomainNotFound', {
+  domain: Schema.String,
+}) {}
+
+export class SnsSearchResult extends Schema.Class<SnsSearchResult>('SnsSearchResult')({
+  address: Schema.String,
+}) {}
+
+export class SnsServiceUnavailable extends Schema.TaggedError<SnsServiceUnavailable>()('SnsServiceUnavailable', {}) {}
+
+export class SnsService extends Effect.Service<SnsService>()('Sns', {
+  dependencies: [FetchHttpClient.layer],
+  effect: Effect.gen(function* () {
+    const baseClient = yield* HttpClient.HttpClient
+    const snsClient = baseClient.pipe(
+      HttpClient.mapRequest(
+        flow(HttpClientRequest.acceptJson, HttpClientRequest.prependUrl('https://sns-sdk-proxy.bonfida.workers.dev')),
+      ),
+    )
+
+    return {
+      search: (domain: string) =>
+        Effect.gen(function* () {
+          if (!domain.endsWith('.sol')) {
+            throw new SnsInvalidDomainName({ domain })
+          }
+
+          const response = yield* snsClient.get(`/resolve/${domain}`)
+          const result = yield* HttpClientResponse.schemaBodyJson(SnsResolveResponse)(response)
+
+          if (result.s === 'error' || result.result === 'Data not found') {
+            throw new SnsDomainNotFound({ domain })
+          }
+
+          return new SnsSearchResult({ address: result.result })
+        }).pipe(
+          Effect.scoped,
+          Effect.catchTags({
+            ParseError: () => Effect.fail(new SnsServiceUnavailable()),
+            RequestError: () => Effect.fail(new SnsServiceUnavailable()),
+            ResponseError: () => Effect.fail(new SnsServiceUnavailable()),
+          }),
+        ),
+    }
+  }),
+}) {}


### PR DESCRIPTION
## Description

- Adds an endpoint to search SNS domains

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `domainSearch` endpoint to search SNS domains, integrating with SNS service and handling various error cases.
> 
>   - **Endpoint Addition**:
>     - Adds `domainSearch` endpoint in `api.ts` to search SNS domains using `/domain/:domain` path.
>     - Handles success with `SnsSearchResult` and errors with `SnsDomainNotFound`, `SnsInvalidDomainName`, and `SnsServiceUnavailable`.
>   - **Service Integration**:
>     - Implements `SnsService` in `service.ts` to interact with SNS API, handling domain validation and response parsing.
>     - Throws `SnsInvalidDomainName` if domain does not end with `.sol`.
>     - Throws `SnsDomainNotFound` if SNS API returns 'Data not found'.
>     - Catches `ParseError`, `RequestError`, and `ResponseError` as `SnsServiceUnavailable`.
>   - **Handler Implementation**:
>     - Updates `http.ts` to handle `domainSearch` using `SnsService`.
>     - Encodes domain using `Encoding.encodeUriComponent` and catches `EncodeException` as `SnsInvalidDomainName`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b669f287cc30874c2fda11777ad842ca4c457aa7. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->