### PR TITLE
feat: add ui-debug component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -352,7 +352,6 @@
         "@workspace/ui": "workspace:*",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
-        "superjson": "2.2.6",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -678,6 +677,7 @@
         "react-resizable-panels": "3.0.6",
         "react-router": "catalog:",
         "sonner": "2.0.7",
+        "superjson": "2.2.6",
         "tailwind-merge": "3.4.0",
         "tw-animate-css": "1.4.0",
         "zod": "catalog:",

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -11,7 +11,6 @@
     "@workspace/ui": "workspace:*",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",
-    "superjson": "2.2.6",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/explorer/src/ui/explorer-ui-tx-details.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-details.tsx
@@ -1,6 +1,6 @@
 import type { Network } from '@workspace/db/network/network'
 import { Separator } from '@workspace/ui/components/separator'
-import superjson from 'superjson'
+import { UiDebug } from '@workspace/ui/components/ui-debug'
 import type { ExplorerGetTransactionResult } from '../data-access/use-explorer-get-transaction.ts'
 import { ExplorerUiDetailRow } from './explorer-ui-detail-row.tsx'
 import { ExplorerUiExplorers } from './explorer-ui-explorers.tsx'
@@ -46,14 +46,7 @@ export function ExplorerUiTxDetails({
         <ExplorerUiDetailRow label="Timestamp" value={<ExplorerUiTxTimestamp blockTime={tx.blockTime} />} />
       </div>
       <Separator />
-      <ExplorerUiDetailRow
-        label="Raw TX"
-        value={
-          <pre className="overflow-auto whitespace-pre-wrap text-[9px]">
-            {JSON.stringify(superjson.serialize(tx).json, null, 2)}
-          </pre>
-        }
-      />
+      <ExplorerUiDetailRow label="Raw TX" value={<UiDebug data={tx} />} />
     </div>
   )
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
     "react-resizable-panels": "3.0.6",
     "react-router": "catalog:",
     "sonner": "2.0.7",
+    "superjson": "2.2.6",
     "tailwind-merge": "3.4.0",
     "tw-animate-css": "1.4.0",
     "zod": "catalog:"

--- a/packages/ui/src/components/ui-debug.tsx
+++ b/packages/ui/src/components/ui-debug.tsx
@@ -1,0 +1,17 @@
+import type { ComponentProps, ReactNode } from 'react'
+import superjson from 'superjson'
+import { cn } from '../lib/utils.ts'
+
+export function UiDebug({
+  data,
+  className,
+  ...props
+}: { data: string | unknown } & Omit<ComponentProps<'pre'>, 'children'>) {
+  const content: ReactNode = typeof data === 'string' ? data : JSON.stringify(superjson.serialize(data).json, null, 2)
+
+  return (
+    <pre className={cn('overflow-auto whitespace-pre-wrap text-[9px]', className)} {...props}>
+      {content}
+    </pre>
+  )
+}


### PR DESCRIPTION
## Description

Implements a component to print raw JSON objects using superjson. This saves us from having to do pre + JSON.stringify manually, and having to import superjson in other feature components.

## Screenshots / Video

Usage:

```tsx
<UiDebug data={{ bigint: 10n, key: 'value', now: new Date() }} />
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `UiDebug` component for JSON rendering using `superjson` and integrates it into `explorer-ui-tx-details.tsx`.
> 
>   - **New Component**:
>     - Adds `UiDebug` component in `ui-debug.tsx` to render JSON objects using `superjson`.
>     - Accepts `data` prop for JSON input and optional `className`.
>   - **Integration**:
>     - Replaces manual JSON rendering with `UiDebug` in `explorer-ui-tx-details.tsx`.
>   - **Dependencies**:
>     - Moves `superjson` from `dependencies` to `devDependencies` in `explorer/package.json` and `ui/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 8b530d7d12770b738f31bce286aeb6ba53abaeb2. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->