### PR TITLE
fix(db): validate network name

### DIFF
--- a/packages/db/src/network/network-schema.ts
+++ b/packages/db/src/network/network-schema.ts
@@ -10,7 +10,7 @@ export const networkSchema = z.object({
     .or(z.literal(''))
     .optional(),
   id: z.string(),
-  name: z.string(),
+  name: z.string().trim().min(1).max(20),
   type: networkTypeSchema,
   updatedAt: z.date(),
 })

--- a/packages/db/test/network-create.test.ts
+++ b/packages/db/test/network-create.test.ts
@@ -95,5 +95,71 @@ describe('network-create', () => {
       // ACT & ASSERT
       await expect(networkCreate(db, input)).rejects.toThrow()
     })
+
+    it('should throw an error with a too short name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testNetworkCreateInput({ name: '' })
+
+      // ACT & ASSERT
+      await expect(networkCreate(db, input)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
+
+    it('should throw an error with a too long name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testNetworkCreateInput({ name: 'a'.repeat(21) })
+
+      // ACT & ASSERT
+      await expect(networkCreate(db, input)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_big",
+            "maximum": 20,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too big: expected string to have <=20 characters"
+          }
+        ]]
+      `)
+    })
+
+    it('should throw an error with a name with only spaces', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testNetworkCreateInput({ name: ' ' })
+
+      // ACT & ASSERT
+      await expect(networkCreate(db, input)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
   })
 })

--- a/packages/db/test/network-update.test.ts
+++ b/packages/db/test/network-update.test.ts
@@ -52,5 +52,71 @@ describe('network-update', () => {
       // ACT & ASSERT
       await expect(networkUpdate(db, id, {})).rejects.toThrow(`Error updating network with id ${id}`)
     })
+
+    it('should throw an error when updating a network with a too short name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = await networkCreate(db, testNetworkCreateInput())
+
+      // ACT & ASSERT
+      await expect(networkUpdate(db, id, { name: '' })).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
+
+    it('should throw an error when updating a network with a too long name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = await networkCreate(db, testNetworkCreateInput())
+
+      // ACT & ASSERT
+      await expect(networkUpdate(db, id, { name: 'a'.repeat(21) })).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_big",
+            "maximum": 20,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too big: expected string to have <=20 characters"
+          }
+        ]]
+      `)
+    })
+
+    it('should throw an error when updating a network with name with only spaces', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = await networkCreate(db, testNetworkCreateInput())
+
+      // ACT & ASSERT
+      await expect(networkUpdate(db, id, { name: ' ' })).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
   })
 })


### PR DESCRIPTION
## Description

Adds length validation to the `Network.name` property.

Related to #678


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add length validation for `Network.name` and corresponding tests for edge cases.
> 
>   - **Validation**:
>     - Add length validation to `Network.name` in `network-schema.ts` to be between 1 and 20 characters.
>   - **Tests**:
>     - Add tests in `network-create.test.ts` for too short, too long, and whitespace-only `name` values.
>     - Add tests in `network-update.test.ts` for too short, too long, and whitespace-only `name` values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3bed720a19376549a9af1bd205eb146500219dd8. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->