### PR TITLE
fix(db): validate wallet name

### DIFF
--- a/packages/db/src/wallet/wallet-internal-schema.ts
+++ b/packages/db/src/wallet/wallet-internal-schema.ts
@@ -9,7 +9,7 @@ export const walletInternalSchema = z.object({
   description: z.string().max(50).optional(),
   id: z.string(),
   mnemonic: z.string(),
-  name: z.string().max(20),
+  name: z.string().trim().min(1).max(20),
   order: z.number(),
   secret: z.string(),
   updatedAt: z.date(),

--- a/packages/db/test/wallet-create.test.ts
+++ b/packages/db/test/wallet-create.test.ts
@@ -71,6 +71,29 @@ describe('wallet-create', () => {
     afterEach(() => {
       vi.restoreAllMocks()
     })
+
+    it('should throw an error when creating a wallet with a too short name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput({ name: ' ' })
+
+      // ACT & ASSERT
+      await expect(walletCreate(db, input)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
+
     it('should throw an error when creating a wallet with a too long name', async () => {
       // ARRANGE
       expect.assertions(1)

--- a/packages/db/test/wallet-update.test.ts
+++ b/packages/db/test/wallet-update.test.ts
@@ -68,6 +68,29 @@ describe('wallet-update', () => {
       await expect(walletUpdate(db, id, {})).rejects.toThrow(`Error updating wallet with id ${id}`)
     })
 
+    it('should throw an error when updating a wallet with a too short name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput()
+      const id = await walletCreate(db, input)
+
+      // ACT & ASSERT
+      await expect(walletUpdate(db, id, { name: ' ' })).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
+
     it('should throw an error when updating a wallet with a too long name', async () => {
       // ARRANGE
       expect.assertions(1)


### PR DESCRIPTION
## Description

Adds length validation to the `Wallet.name` property.

Related to #678

## Checklist

- [x] Tests have been added for my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds length validation to `Wallet.name` ensuring it is between 1 and 20 characters, with tests for creation and update scenarios.
> 
>   - **Behavior**:
>     - Adds length validation to `Wallet.name` in `wallet-internal-schema.ts`, requiring 1-20 characters.
>   - **Tests**:
>     - Adds test for too short `name` in `wallet-create.test.ts`.
>     - Adds test for too short `name` in `wallet-update.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 5a4674cfeee76bf6b7f38165ddbca54c1acd4608. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->