### PR TITLE
fix(db): validate account name

### DIFF
--- a/packages/db/src/account/account-internal-schema.ts
+++ b/packages/db/src/account/account-internal-schema.ts
@@ -6,7 +6,7 @@ export const accountInternalSchema = z.object({
   createdAt: z.date(),
   derivationIndex: z.number(),
   id: z.string(),
-  name: z.string(),
+  name: z.string().trim().min(1).max(20),
   order: z.number(),
   publicKey: solanaAddressSchema,
   secretKey: z.string().optional(),

--- a/packages/db/test/account-create.test.ts
+++ b/packages/db/test/account-create.test.ts
@@ -75,6 +75,50 @@ describe('account-create', () => {
       vi.restoreAllMocks()
     })
 
+    it('should throw an error when creating an account with a too short name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testAccountCreateInput({ name: ' ', walletId: randomId() })
+
+      // ACT & ASSERT
+      await expect(accountCreate(db, input)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
+
+    it('should throw an error when creating an account with a too long name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testAccountCreateInput({ name: 'a'.repeat(21), walletId: randomId() })
+
+      // ACT & ASSERT
+      await expect(accountCreate(db, input)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_big",
+            "maximum": 20,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too big: expected string to have <=20 characters"
+          }
+        ]]
+      `)
+    })
+
     it('should throw an error when creating an account fails', async () => {
       // ARRANGE
       expect.assertions(1)

--- a/packages/db/test/account-find-many.test.ts
+++ b/packages/db/test/account-find-many.test.ts
@@ -82,7 +82,7 @@ describe('account-find-many', () => {
       const account1 = testAccountCreateInput({ name: 'Trading Account', walletId })
       const account2 = testAccountCreateInput({ name: 'Staking Account', type: 'Imported', walletId })
       const account3 = testAccountCreateInput({ name: 'Savings', type: 'Watched', walletId })
-      const account4 = testAccountCreateInput({ name: 'Another Trading Account', type: 'Imported', walletId })
+      const account4 = testAccountCreateInput({ name: 'Some Trading Account', type: 'Imported', walletId })
       await accountCreate(db, account1)
       await accountCreate(db, account2)
       await accountCreate(db, account3)

--- a/packages/db/test/account-update.test.ts
+++ b/packages/db/test/account-update.test.ts
@@ -42,6 +42,52 @@ describe('account-update', () => {
       vi.restoreAllMocks()
     })
 
+    it('should throw an error when updating an account with a too short name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      const id = await accountCreate(db, testAccountCreateInput({ walletId: randomId() }))
+
+      // ACT & ASSERT
+      await expect(accountUpdate(db, id, { name: ' ' })).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_small",
+            "minimum": 1,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too small: expected string to have >=1 characters"
+          }
+        ]]
+      `)
+    })
+
+    it('should throw an error when updating an account with a too long name', async () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      const id = await accountCreate(db, testAccountCreateInput({ walletId: randomId() }))
+
+      // ACT & ASSERT
+      await expect(accountUpdate(db, id, { name: 'a'.repeat(21) })).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "origin": "string",
+            "code": "too_big",
+            "maximum": 20,
+            "inclusive": true,
+            "path": [
+              "name"
+            ],
+            "message": "Too big: expected string to have <=20 characters"
+          }
+        ]]
+      `)
+    })
+
     it('should throw an error when updating an account fails', async () => {
       // ARRANGE
       expect.assertions(1)


### PR DESCRIPTION
## Description

Adds length validation to the `Account.name` property.

Related to #678

## Checklist

- [x] Tests have been added for my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add length validation for `Account.name` to be between 1 and 20 characters, with tests for invalid cases.
> 
>   - **Behavior**:
>     - Adds length validation to `Account.name` in `accountInternalSchema` to be between 1 and 20 characters.
>     - Throws error for names shorter than 1 character or longer than 20 characters in `account-create.test.ts` and `account-update.test.ts`.
>   - **Tests**:
>     - Adds tests in `account-create.test.ts` for too short and too long names.
>     - Adds tests in `account-update.test.ts` for too short and too long names.
>     - Updates test case in `account-find-many.test.ts` to use valid account name length.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 64378f4c9e4897e76ba21e64baabbe0d314f6e9e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->