### PR TITLE
refactor(solana-client): clean up create-and-send-spl-transaction

### DIFF
--- a/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
@@ -16,20 +16,17 @@ export function createAndSendSplTransactionMutationOptions(
   return mutationOptions({
     mutationFn: async ({
       amount,
-      decimals,
       destination,
       mint,
       transactionSigner,
     }: {
       amount: string
-      decimals: number
       destination: string
       mint: string
       transactionSigner: TransactionSigner
     }) => {
       return createAndSendSplTransaction(client, {
         amount,
-        decimals,
         destination: address(destination),
         mint: address(mint),
         transactionSigner,

--- a/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
+++ b/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
@@ -41,8 +41,8 @@ export function portfolioTxSendMutationOptions({
     // Send SPL token
     const { data: result, error: sendError } = await tryCatch(
       sendSplMutation.mutateAsync({
-        ...input,
-        decimals: input.mint.decimals,
+        amount: input.amount,
+        destination: input.destination,
         mint: input.mint.mint,
         transactionSigner,
       }),

--- a/packages/solana-client/src/create-get-or-create-ata-instruction.ts
+++ b/packages/solana-client/src/create-get-or-create-ata-instruction.ts
@@ -1,0 +1,31 @@
+import type { Address, Instruction, TransactionSigner } from '@solana/kit'
+import { findAssociatedTokenPda } from '@solana-program/token'
+import { getCreateAssociatedTokenIdempotentInstruction } from '@solana-program/token-2022'
+
+export async function createGetOrCreateAtaInstruction({
+  mint,
+  owner,
+  tokenProgram,
+  transactionSigner: payer,
+}: {
+  mint: Address
+  owner: Address
+  tokenProgram: Address
+  transactionSigner: TransactionSigner
+}): Promise<[Address, Instruction]> {
+  const [ata] = await findAssociatedTokenPda({
+    mint,
+    owner,
+    tokenProgram,
+  })
+
+  const ix = getCreateAssociatedTokenIdempotentInstruction({
+    ata,
+    mint,
+    owner,
+    payer,
+    tokenProgram,
+  })
+
+  return [ata, ix]
+}

--- a/packages/solana-client/src/spl-token-mint-to.ts
+++ b/packages/solana-client/src/spl-token-mint-to.ts
@@ -1,6 +1,7 @@
 import type { Address, Signature, TransactionSigner } from '@solana/kit'
-import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token'
-import { getCreateAssociatedTokenIdempotentInstruction, getMintToCheckedInstruction } from '@solana-program/token-2022'
+import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token'
+import { getMintToCheckedInstruction } from '@solana-program/token-2022'
+import { createGetOrCreateAtaInstruction } from './create-get-or-create-ata-instruction.ts'
 import type { LatestBlockhash } from './get-latest-blockhash.ts'
 import { signAndSendTransaction } from './sign-and-send-transaction.ts'
 import type { SolanaClient } from './solana-client.ts'
@@ -30,18 +31,11 @@ export async function splTokenMintTo(
     transactionSigner,
   }: SplTokenMintToOptions,
 ): Promise<SplTokenMintToResult> {
-  const [ata] = await findAssociatedTokenPda({
+  const [ata, createAtaInstruction] = await createGetOrCreateAtaInstruction({
     mint,
     owner: transactionSigner.address,
     tokenProgram,
-  })
-
-  const createAtaInstruction = getCreateAssociatedTokenIdempotentInstruction({
-    ata,
-    mint,
-    owner: transactionSigner.address,
-    payer: transactionSigner,
-    tokenProgram,
+    transactionSigner,
   })
 
   const mintToInstruction = getMintToCheckedInstruction(

--- a/packages/solana-client/src/spl-token-transfer.ts
+++ b/packages/solana-client/src/spl-token-transfer.ts
@@ -1,6 +1,6 @@
 import type { Address, Signature, TransactionSigner } from '@solana/kit'
-import { findAssociatedTokenPda, getMintToInstruction, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token'
-import { getCreateAssociatedTokenIdempotentInstruction } from '@solana-program/token-2022'
+import { getMintToInstruction, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token'
+import { createGetOrCreateAtaInstruction } from './create-get-or-create-ata-instruction.ts'
 import type { LatestBlockhash } from './get-latest-blockhash.ts'
 import { signAndSendTransaction } from './sign-and-send-transaction.ts'
 import type { SolanaClient } from './solana-client.ts'
@@ -22,18 +22,11 @@ export async function splTokenTransfer(
   client: SolanaClient,
   { amount, latestBlockhash, mint, tokenProgram = TOKEN_PROGRAM_ADDRESS, transactionSigner }: SplTokenTransferOptions,
 ): Promise<SplTokenTransferResult> {
-  const [ata] = await findAssociatedTokenPda({
+  const [ata, createAtaInstruction] = await createGetOrCreateAtaInstruction({
     mint,
     owner: transactionSigner.address,
     tokenProgram,
-  })
-
-  const createAtaInstruction = getCreateAssociatedTokenIdempotentInstruction({
-    ata,
-    mint,
-    owner: transactionSigner.address,
-    payer: transactionSigner,
-    tokenProgram,
+    transactionSigner,
   })
 
   const mintToInstruction = getMintToInstruction({

--- a/packages/solana-client/test/create-and-send-spl-transaction.integration.test.ts
+++ b/packages/solana-client/test/create-and-send-spl-transaction.integration.test.ts
@@ -19,7 +19,6 @@ describe('create-and-send-spl-transaction', async () => {
       const destination = destinationKeypair.address
       const input: CreateAndSendSplTransactionOptions = {
         amount: '420',
-        decimals: testMint.input.decimals,
         destination,
         latestBlockhash,
         mint: testMint.result.mint,


### PR DESCRIPTION
## Description

Simplify the `create-and-send-spl-transaction` and clean up the api.

Part of #508

## Screenshots / Video

<!-- Please include screenshots or video if UI changes are made. -->

## Checklist

- [ ] Tests have been added for my change
- [ ] Docs have been updated for my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactors SPL transaction creation by removing redundant parameters, simplifying logic, and introducing idempotent ATA creation, with updated tests to ensure correctness.
> 
>   - **Behavior**:
>     - Simplifies `createAndSendSplTransaction` by removing `decimals` parameter and fetching it internally in `create-and-send-spl-transaction.ts`.
>     - Refactors `createSplTransferInstructions` to handle associated token accounts idempotently in `create-spl-transfer-instructions.ts`.
>     - Introduces `createGetOrCreateAtaInstruction` in `create-get-or-create-ata-instruction.ts` for idempotent ATA creation.
>   - **Tests**:
>     - Updates integration tests in `create-and-send-spl-transaction.integration.test.ts` to reflect refactored logic.
>     - Modifies unit tests in `create-spl-transfer-transaction.test.ts` to cover new behavior and edge cases.
>   - **Misc**:
>     - Removes `findAssociatedTokenPda` usage from `create-and-send-spl-transaction.ts` and `spl-token-mint-to.ts`.
>     - Adjusts `portfolioTxSendMutationOptions` in `use-portfolio-tx-send.tsx` to align with refactored SPL transaction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 872a02a5069ae7db6824868ccd3455d36f7e85a9. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->