### PR TITLE
feat: add the option to select wallet color

### DIFF
--- a/packages/db/src/color-schema.ts
+++ b/packages/db/src/color-schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const colorSchema = z.enum([
+  'red',
+  'orange',
+  'yellow',
+  'lime',
+  'green',
+  'teal',
+  'cyan',
+  'blue',
+  'indigo',
+  'violet',
+  'purple',
+  'pink',
+])

--- a/packages/db/src/wallet/wallet-internal-schema.ts
+++ b/packages/db/src/wallet/wallet-internal-schema.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod'
 
 import { accountSchema } from '../account/account-schema.ts'
+import { colorSchema } from '../color-schema.ts'
 
 export const walletInternalSchema = z.object({
   accounts: z.array(accountSchema).optional().default([]),
+  color: colorSchema.optional(),
   createdAt: z.date(),
   derivationPath: z.string(),
   description: z.string().max(50).optional(),

--- a/packages/db/test/wallet-create.test.ts
+++ b/packages/db/test/wallet-create.test.ts
@@ -18,8 +18,8 @@ describe('wallet-create', () => {
   describe('expected behavior', () => {
     it('should create a wallet', async () => {
       // ARRANGE
-      expect.assertions(3)
-      const input = testWalletCreateInput()
+      expect.assertions(4)
+      const input = testWalletCreateInput({ color: 'green' })
 
       // ACT
       const result = await walletCreate(db, input)
@@ -29,6 +29,7 @@ describe('wallet-create', () => {
       // @ts-expect-error mnemonic does not exist on the type. Here we ensure it's sanitized.
       expect(item?.mnemonic).toBe(undefined)
       expect(item?.name).toBe(input.name)
+      expect(item?.color).toBe('green')
       expect(item?.order).toBe(0)
     })
 

--- a/packages/i18n/locales/en/settings.json
+++ b/packages/i18n/locales/en/settings.json
@@ -81,6 +81,8 @@
   "walletCreateHeaderSeed": "Seed phrases",
   "walletCreateImportDescription": "Import an existing seed phrase and discover accounts",
   "walletCreateImportTitle": "Import an existing wallet",
+  "walletInputColorDescription": "Select the color for this wallet",
+  "walletInputColorLabel": "Color",
   "walletInputDerivationPathDescription": "Provide the derivation path of the wallet",
   "walletInputDerivationPathLabel": "Derivation patch",
   "walletInputDescriptionDescription": "An optional description to help identify the wallet.",

--- a/packages/i18n/locales/es/settings.json
+++ b/packages/i18n/locales/es/settings.json
@@ -81,6 +81,8 @@
   "walletCreateHeaderSeed": "Frase semilla",
   "walletCreateImportDescription": "Importar una frase semilla existente y descubrir cuentas",
   "walletCreateImportTitle": "Importar una billetera existente",
+  "walletInputColorDescription": null,
+  "walletInputColorLabel": null,
   "walletInputDerivationPathDescription": "Proporcione la ruta de derivación de la billetera.",
   "walletInputDerivationPathLabel": "Ruta de derivación",
   "walletInputDescriptionDescription": "Una descripción opcional para ayudar a identificar la billetera.",

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -162,6 +162,8 @@ interface Resources {
     walletCreateHeaderSeed: 'Seed phrases'
     walletCreateImportDescription: 'Import an existing seed phrase and discover accounts'
     walletCreateImportTitle: 'Import an existing wallet'
+    walletInputColorDescription: 'Select the color for this wallet'
+    walletInputColorLabel: 'Color'
     walletInputDerivationPathDescription: 'Provide the derivation path of the wallet'
     walletInputDerivationPathLabel: 'Derivation patch'
     walletInputDescriptionDescription: 'An optional description to help identify the wallet.'

--- a/packages/settings/src/ui/settings-ui-wallet-form-update.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-form-update.tsx
@@ -14,6 +14,8 @@ import {
   FormMessage,
 } from '@workspace/ui/components/form'
 import { Input } from '@workspace/ui/components/input'
+import { getColorByName, uiColorNames } from '@workspace/ui/lib/get-initials-colors'
+import { cn } from '@workspace/ui/lib/utils'
 import { useForm } from 'react-hook-form'
 
 export function SettingsUiWalletFormUpdate({
@@ -69,6 +71,38 @@ export function SettingsUiWalletFormUpdate({
                 />
               </FormControl>
               <FormDescription>{t(($) => $.walletInputDescriptionDescription)}</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+          rules={{ required: false }}
+        />
+        <FormField
+          control={form.control}
+          name="color"
+          render={({ field }) => (
+            <FormItem className="w-full">
+              <FormLabel>{t(($) => $.walletInputColorLabel)}</FormLabel>
+              <FormDescription>{t(($) => $.walletInputColorDescription)}</FormDescription>
+              <FormControl>
+                <div className="grid grid-cols-6 gap-4">
+                  {uiColorNames.map((uiColorName) => {
+                    const { bg, text } = getColorByName(uiColorName)
+                    return (
+                      <button
+                        className={cn(`flex aspect-square cursor-pointer items-center justify-center`, text, bg, {
+                          'font-bold': field.value === uiColorName,
+                        })}
+                        disabled={field.value === uiColorName}
+                        key={uiColorName}
+                        onClick={() => field.onChange(uiColorName)}
+                        type="button"
+                      >
+                        {uiColorName}
+                      </button>
+                    )
+                  })}
+                </div>
+              </FormControl>
               <FormMessage />
             </FormItem>
           )}

--- a/packages/settings/src/ui/settings-ui-wallet-item.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-item.tsx
@@ -5,7 +5,7 @@ import { UiAvatar } from '@workspace/ui/components/ui-avatar'
 export function SettingsUiWalletItem({ item }: { item: Wallet }) {
   return (
     <div className="flex items-center gap-2 whitespace-nowrap">
-      <UiAvatar label={item.name} />
+      <UiAvatar color={item.color} label={item.name} />
       <div className="flex flex-col">
         <div>{item.name}</div>
         <div className="max-w-[150px] truncate text-muted-foreground text-xs md:max-w-[250px]">{item.description}</div>

--- a/packages/shell/src/ui/shell-ui-menu-wallets.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-wallets.tsx
@@ -39,7 +39,7 @@ export function ShellUiMenuWallets({
         data-testid="wallet-menu-trigger"
       >
         <div className="flex items-center gap-2">
-          <UiAvatar className="size-6 md:size-8" label={activeWallet.name} />
+          <UiAvatar className="size-6 md:size-8" color={activeWallet.color} label={activeWallet.name} />
           {activeAccount.name}
           <UiTextCopyIcon
             onPointerDown={(e) => e.stopPropagation()}
@@ -54,7 +54,7 @@ export function ShellUiMenuWallets({
         {wallets.map((wallet) => (
           <MenubarSub key={wallet.id}>
             <MenubarSubTrigger className="gap-2">
-              <UiAvatar label={wallet.name} />
+              <UiAvatar color={wallet.color} label={wallet.name} />
               <div className="flex flex-col">
                 <div>{wallet.name}</div>
                 <div className="max-w-[150px] truncate text-muted-foreground text-xs md:max-w-[250px]">

--- a/packages/ui/src/components/ui-avatar.tsx
+++ b/packages/ui/src/components/ui-avatar.tsx
@@ -1,12 +1,22 @@
 import { useMemo } from 'react'
 import { getInitials } from '../lib/get-initials.ts'
-import { getInitialsColor } from '../lib/get-initials-colors.ts'
+import { getColorByName, getInitialsColor, type UiColorName } from '../lib/get-initials-colors.ts'
 import { cn } from '../lib/utils.ts'
 import { Avatar, AvatarFallback, AvatarImage } from './avatar.tsx'
 
-export function UiAvatar({ className, label, src }: { className?: string; label: string; src?: string }) {
+export function UiAvatar({
+  className,
+  color,
+  label,
+  src,
+}: {
+  className?: string
+  color?: UiColorName | undefined
+  label: string
+  src?: string
+}) {
   const initials = useMemo(() => getInitials(label), [label])
-  const { bg, text } = useMemo(() => getInitialsColor(initials), [initials])
+  const { bg, text } = useMemo(() => (color ? getColorByName(color) : getInitialsColor(initials)), [color, initials])
   return (
     <Avatar className={className}>
       {src ? <AvatarImage src={src} /> : null}


### PR DESCRIPTION
## Description

Allows for setting a custom color per wallet instead of deriving one based on the name. 

## Screenshots / Video
<img width="978" height="966" alt="image" src="https://github.com/user-attachments/assets/cc4c2899-36eb-4606-a0d6-4413c5c8423a" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds feature to select custom wallet colors, updating schemas, UI components, and tests.
> 
>   - **Behavior**:
>     - Adds `color` field to `walletInternalSchema` in `wallet-internal-schema.ts` to allow custom wallet colors.
>     - Updates `walletCreate` test in `wallet-create.test.ts` to include color validation.
>     - Adds color selection UI in `settings-ui-wallet-form-update.tsx`.
>   - **UI Components**:
>     - Updates `UiAvatar` in `ui-avatar.tsx` to accept a `color` prop for custom colors.
>     - Modifies `SettingsUiWalletItem` and `ShellUiMenuWallets` to use the new `color` prop in `UiAvatar`.
>   - **Localization**:
>     - Adds English translations for color selection in `settings.json`.
>     - Adds placeholders for Spanish translations in `settings.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 40b61a28e9d1c2e7f14f89fcc828cb02bdce0d0e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->