### PR TITLE
feat(api): add wallet list example command

### DIFF
--- a/apps/cli/src/commands/wallets/command.ts
+++ b/apps/cli/src/commands/wallets/command.ts
@@ -1,0 +1,4 @@
+import { Command } from '@effect/cli'
+import { list } from './list.ts'
+
+export const wallets = Command.make('wallets').pipe(Command.withSubcommands([list]))

--- a/apps/cli/src/commands/wallets/list.ts
+++ b/apps/cli/src/commands/wallets/list.ts
@@ -1,0 +1,11 @@
+import { Command } from '@effect/cli'
+import { Console, Effect } from 'effect'
+
+export const list = Command.make('list', {}, () =>
+  Effect.all([
+    Console.log('┌────────────────────────────────────────────────────────┐'),
+    Console.log('│                        Wallets                         │'),
+    Console.log('├────────────────────────────────────────────────────────┤'),
+    Console.log('└────────────────────────────────────────────────────────┘'),
+  ]),
+)

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,11 +1,10 @@
 import { Command } from '@effect/cli'
 import { BunContext, BunRuntime } from '@effect/platform-bun'
 import { start } from '@workspace/tui'
-import { Console, Effect } from 'effect'
+import { Effect } from 'effect'
+import { wallets } from './commands/wallets/command.ts'
 
-const example = Command.make('example', {}, () => Console.log('Samui Wallet'))
-
-const command = Command.make('samui', {}, () => Effect.sync(() => start())).pipe(Command.withSubcommands([example]))
+const command = Command.make('samui', {}, () => Effect.sync(() => start())).pipe(Command.withSubcommands([wallets]))
 
 const cli = Command.run(command, {
   name: 'Samui Wallet CLI',


### PR DESCRIPTION
## Description

This adds a empty `wallets list` command to the CLI. I am open to the naming conventions we use for commands.

I would like to get a few things working in the CLI even if it's just generating a keypair or something so we are running our code in a web environment and bun environment within our CI/CD pipelines and tests. I want to make sure we have our globals setup correctly to make sure our tsconfig does not allow both bun and web runtime in the same place

## Screenshots / Video

<img width="542" height="114" alt="image" src="https://github.com/user-attachments/assets/cea46a70-77db-4e90-b468-f46fc910168b" />

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `wallets` command with a `list` subcommand to the CLI for future wallet management features.
> 
>   - **Commands**:
>     - Add `wallets` command in `command.ts` with a subcommand `list`.
>     - `list` command in `list.ts` logs a placeholder wallet list to the console.
>   - **Integration**:
>     - Integrate `wallets` command into main CLI in `index.ts`, replacing the previous `example` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 6a77d618d9120a74fc3a448d1ec688f3438bbd04. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->