### PR TITLE
refactor(solana-client): switch to TransactionSigner interface

### DIFF
--- a/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
@@ -30,8 +30,8 @@ export function useCreateAndSendSolTransaction({ account, network }: { account: 
       return createAndSendSolTransaction(client, {
         amount: solToLamports(amount),
         destination: address(destination),
-        feePayerSigner: sender,
         senderBalance: senderBalance.value,
+        transactionSigner: sender,
       })
     },
     onSuccess: () => {

--- a/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
@@ -1,4 +1,4 @@
-import { address, type KeyPairSigner } from '@solana/kit'
+import { address, type TransactionSigner } from '@solana/kit'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { Network } from '@workspace/db/network/network'
 import { createAndSendSplTransaction } from '@workspace/solana-client/create-and-send-spl-transaction'
@@ -16,24 +16,24 @@ export function useCreateAndSendSplTransaction({ network }: { network: Network }
       amount,
       decimals,
       destination,
-      feePayerSigner,
       mint,
+      transactionSigner,
     }: {
       amount: string
       decimals: number
       destination: string
-      feePayerSigner: KeyPairSigner
       mint: string
+      transactionSigner: TransactionSigner
     }) => {
       return createAndSendSplTransaction(client, {
         amount,
         decimals,
         destination: address(destination),
-        feePayerSigner,
         mint: address(mint),
+        transactionSigner,
       })
     },
-    onSuccess: (_, { feePayerSigner: { address } }) => {
+    onSuccess: (_, { transactionSigner: { address } }) => {
       queryClient.invalidateQueries({
         queryKey: getBalanceQueryOptions({ address, client, network }).queryKey,
       })

--- a/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
+++ b/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
@@ -32,14 +32,14 @@ export function usePortfolioTxSend() {
       throw new Error(`No secret key for this account`)
     }
 
-    const feePayerSigner = await createKeyPairSignerFromJson({ json: secretKey })
+    const transactionSigner = await createKeyPairSignerFromJson({ json: secretKey })
     // Send SPL token
     const { data: result, error: sendError } = await tryCatch(
       sendSplMutation.mutateAsync({
         ...input,
         decimals: input.mint.decimals,
-        feePayerSigner,
         mint: input.mint.mint,
+        transactionSigner,
       }),
     )
 

--- a/packages/solana-client/src/create-and-send-sol-transaction.ts
+++ b/packages/solana-client/src/create-and-send-sol-transaction.ts
@@ -1,4 +1,4 @@
-import type { Address, KeyPairSigner, Signature } from '@solana/kit'
+import type { Address, Signature, TransactionSigner } from '@solana/kit'
 import { createSolTransferInstructions } from './create-sol-transfer-instructions.ts'
 import type { LatestBlockhash } from './get-latest-blockhash.ts'
 import { lamportsToSol } from './lamports-to-sol.ts'
@@ -9,14 +9,14 @@ import type { SolanaClient } from './solana-client.ts'
 export interface CreateAndSendSolTransactionOptions {
   amount: bigint
   destination: Address
-  feePayerSigner: KeyPairSigner
   latestBlockhash?: LatestBlockhash | undefined
   senderBalance: bigint
+  transactionSigner: TransactionSigner
 }
 
 export async function createAndSendSolTransaction(
   client: SolanaClient,
-  { amount, destination, latestBlockhash, feePayerSigner, senderBalance }: CreateAndSendSolTransactionOptions,
+  { amount, destination, latestBlockhash, senderBalance, transactionSigner }: CreateAndSendSolTransactionOptions,
 ): Promise<Signature> {
   const maxAvailable = maxAvailableSolAmount(senderBalance, amount)
 
@@ -27,8 +27,8 @@ export async function createAndSendSolTransaction(
   }
 
   return signAndSendTransaction(client, {
-    feePayerSigner,
-    instructions: createSolTransferInstructions({ amount, destination, source: feePayerSigner }),
+    instructions: createSolTransferInstructions({ amount, destination, source: transactionSigner }),
     latestBlockhash,
+    transactionSigner,
   })
 }

--- a/packages/solana-client/src/create-sol-transfer-instructions.ts
+++ b/packages/solana-client/src/create-sol-transfer-instructions.ts
@@ -1,5 +1,10 @@
-import type { Address, Instruction, TransactionSigner } from '@solana/kit'
-import { assertIsAddress, assertIsKeyPairSigner } from '@solana/kit'
+import {
+  type Address,
+  assertIsAddress,
+  assertIsTransactionSigner,
+  type Instruction,
+  type TransactionSigner,
+} from '@solana/kit'
 import { getTransferSolInstruction } from '@solana-program/system'
 
 export interface CreateSolTransferTransactionOptions {
@@ -14,7 +19,7 @@ export function createSolTransferInstructions({
   source,
 }: CreateSolTransferTransactionOptions): Instruction[] {
   assertIsAddress(destination)
-  assertIsKeyPairSigner(source)
+  assertIsTransactionSigner(source)
 
   const transferInstruction = getTransferSolInstruction({ amount, destination, source })
 

--- a/packages/solana-client/src/create-spl-transfer-instructions.ts
+++ b/packages/solana-client/src/create-spl-transfer-instructions.ts
@@ -1,7 +1,7 @@
 import {
   type Address,
   assertIsAddress,
-  assertIsKeyPairSigner,
+  assertIsTransactionSigner,
   type Instruction,
   type TransactionSigner,
 } from '@solana/kit'
@@ -41,9 +41,9 @@ export function createSplTransferInstructions({
   assertIsAddress(mint)
   assertIsAddress(sourceTokenAccount)
   assertIsAddress(tokenProgram)
-  assertIsKeyPairSigner(sender)
+  assertIsTransactionSigner(sender)
   if (source) {
-    assertIsKeyPairSigner(source)
+    assertIsTransactionSigner(source)
   }
 
   const instructions: Instruction[] = []

--- a/packages/solana-client/src/sign-and-send-transaction.ts
+++ b/packages/solana-client/src/sign-and-send-transaction.ts
@@ -4,26 +4,26 @@ import {
   createTransactionMessage,
   getSignatureFromTransaction,
   type Instruction,
-  type KeyPairSigner,
   pipe,
   type Signature,
   sendAndConfirmTransactionFactory,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
+  type TransactionSigner,
 } from '@solana/kit'
 import { getLatestBlockhash, type LatestBlockhash } from './get-latest-blockhash.ts'
 import type { SolanaClient } from './solana-client.ts'
 
 export interface SignAndSendTransaction {
-  feePayerSigner: KeyPairSigner
   instructions: Instruction[]
   latestBlockhash?: LatestBlockhash | undefined
+  transactionSigner: TransactionSigner
 }
 
 export async function signAndSendTransaction(
   client: SolanaClient,
-  { feePayerSigner, instructions, latestBlockhash }: SignAndSendTransaction,
+  { instructions, latestBlockhash, transactionSigner }: SignAndSendTransaction,
 ): Promise<Signature> {
   // Use provided latestBlockhash or get one
   latestBlockhash = latestBlockhash ?? (await getLatestBlockhash(client))
@@ -37,7 +37,7 @@ export async function signAndSendTransaction(
 
   const transactionMessageWithFeePayerAndBlockhash = pipe(
     // Sign the message
-    setTransactionMessageFeePayerSigner(feePayerSigner, transactionMessage),
+    setTransactionMessageFeePayerSigner(transactionSigner, transactionMessage),
     // Add the latest blockhash
     (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
   )

--- a/packages/solana-client/test/create-and-send-sol-transaction.integration.test.ts
+++ b/packages/solana-client/test/create-and-send-sol-transaction.integration.test.ts
@@ -8,7 +8,7 @@ import { getBalance } from '../src/get-balance.ts'
 import { setupIntegrationTestContext } from './test-helpers.ts'
 
 describe('create-and-send-sol-transaction', async () => {
-  const { client, latestBlockhash, feePayerSigner } = await setupIntegrationTestContext()
+  const { client, latestBlockhash, transactionSigner } = await setupIntegrationTestContext()
 
   describe('expected behavior', () => {
     it('should create and send sol', async () => {
@@ -16,13 +16,13 @@ describe('create-and-send-sol-transaction', async () => {
       expect.assertions(2)
       const destinationKeypair = await generateKeyPairSigner()
       const destination = destinationKeypair.address
-      const senderBalance = await getBalance(client, { address: feePayerSigner.address }).then((res) => res.value)
+      const senderBalance = await getBalance(client, { address: transactionSigner.address }).then((res) => res.value)
       const input: CreateAndSendSolTransactionOptions = {
         amount: 100n,
         destination,
-        feePayerSigner: feePayerSigner,
         latestBlockhash,
         senderBalance,
+        transactionSigner,
       }
 
       // ACT

--- a/packages/solana-client/test/create-and-send-spl-transaction.integration.test.ts
+++ b/packages/solana-client/test/create-and-send-spl-transaction.integration.test.ts
@@ -8,8 +8,8 @@ import { getTokenAccountsForMint } from '../src/get-token-accounts-for-mint.ts'
 import { setupIntegrationTestContext, setupIntegrationTestMint } from './test-helpers.ts'
 
 describe('create-and-send-spl-transaction', async () => {
-  const { client, latestBlockhash, feePayerSigner } = await setupIntegrationTestContext()
-  const testMint = await setupIntegrationTestMint({ client, feePayerSigner, latestBlockhash })
+  const { client, latestBlockhash, transactionSigner } = await setupIntegrationTestContext()
+  const testMint = await setupIntegrationTestMint({ client, latestBlockhash, transactionSigner })
 
   describe('expected behavior', () => {
     it('should create and send spl token', async () => {
@@ -21,9 +21,9 @@ describe('create-and-send-spl-transaction', async () => {
         amount: '420',
         decimals: testMint.input.decimals,
         destination,
-        feePayerSigner,
         latestBlockhash,
         mint: testMint.result.mint,
+        transactionSigner,
       }
 
       // ACT

--- a/packages/solana-client/test/spl-token-2022-create-token-mint.integration.test.ts
+++ b/packages/solana-client/test/spl-token-2022-create-token-mint.integration.test.ts
@@ -7,7 +7,7 @@ import { uiAmountToBigInt } from '../src/ui-amount-to-big-int.ts'
 import { setupIntegrationTestContext } from './test-helpers.ts'
 
 describe('spl-token-2022-create-token-mint', async () => {
-  const { client, latestBlockhash, feePayerSigner } = await setupIntegrationTestContext()
+  const { client, latestBlockhash, transactionSigner } = await setupIntegrationTestContext()
 
   describe('expected behavior', () => {
     it('should create a token 2022 mint without extensions', async () => {
@@ -19,10 +19,10 @@ describe('spl-token-2022-create-token-mint', async () => {
       // ACT
       const result = await splToken2022CreateTokenMint(client, {
         decimals,
-        feePayerSigner,
         latestBlockhash,
         mint,
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        transactionSigner,
       })
 
       // ASSERT
@@ -43,9 +43,9 @@ describe('spl-token-2022-create-token-mint', async () => {
           closeMint: true,
           permanentDelegate: false,
         },
-        feePayerSigner,
         latestBlockhash,
         mint,
+        transactionSigner,
       })
 
       // ASSERT
@@ -67,11 +67,11 @@ describe('spl-token-2022-create-token-mint', async () => {
           closeMint: false,
           permanentDelegate: true,
         },
-        feePayerSigner,
         latestBlockhash,
         mint,
 
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        transactionSigner,
       })
 
       // ASSERT
@@ -93,10 +93,10 @@ describe('spl-token-2022-create-token-mint', async () => {
           closeMint: true,
           permanentDelegate: true,
         },
-        feePayerSigner,
         latestBlockhash,
         mint,
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        transactionSigner,
       })
 
       // ASSERT
@@ -119,17 +119,17 @@ describe('spl-token-2022-create-token-mint', async () => {
           closeMint: true,
           permanentDelegate: false,
         },
-        feePayerSigner,
         latestBlockhash,
         mint,
         supply,
 
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        transactionSigner,
       })
 
       // ASSERT
       const [tokenAccount] = await getTokenAccountsForMint(client, {
-        address: feePayerSigner.address,
+        address: transactionSigner.address,
         mint: result.mint,
       }).then((res) => res.value)
       if (!tokenAccount) {
@@ -159,16 +159,16 @@ describe('spl-token-2022-create-token-mint', async () => {
           closeMint: true,
           permanentDelegate: true,
         },
-        feePayerSigner,
         latestBlockhash,
         mint,
         supply,
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        transactionSigner,
       })
 
       // ASSERT
       const [tokenAccount] = await getTokenAccountsForMint(client, {
-        address: feePayerSigner.address,
+        address: transactionSigner.address,
         mint: result.mint,
       }).then((res) => res.value)
       if (!tokenAccount) {

--- a/packages/solana-client/test/spl-token-create-token-mint.integration.test.ts
+++ b/packages/solana-client/test/spl-token-create-token-mint.integration.test.ts
@@ -6,7 +6,7 @@ import { uiAmountToBigInt } from '../src/ui-amount-to-big-int.ts'
 import { setupIntegrationTestContext } from './test-helpers.ts'
 
 describe('spl-token-create-token-mint', async () => {
-  const { client, latestBlockhash, feePayerSigner } = await setupIntegrationTestContext()
+  const { client, latestBlockhash, transactionSigner } = await setupIntegrationTestContext()
 
   describe('expected behavior', () => {
     it('should create a token mint with mint and no supply', async () => {
@@ -15,12 +15,18 @@ describe('spl-token-create-token-mint', async () => {
       const mint = await generateKeyPairSigner()
 
       // ACT
-      const result = await splTokenCreateTokenMint(client, { decimals: 0, feePayerSigner, latestBlockhash, mint })
+      const result = await splTokenCreateTokenMint(client, {
+        decimals: 0,
+        latestBlockhash,
+        mint,
+        transactionSigner,
+      })
 
       // ASSERT
-      const res = await getTokenAccountsForMint(client, { address: feePayerSigner.address, mint: mint.address }).then(
-        (res) => res.value,
-      )
+      const res = await getTokenAccountsForMint(client, {
+        address: transactionSigner.address,
+        mint: mint.address,
+      }).then((res) => res.value)
       expect(res.length).toBe(0)
       expect(result.mint).toBe(mint.address)
     })
@@ -33,12 +39,18 @@ describe('spl-token-create-token-mint', async () => {
       const supply = uiAmountToBigInt('1000', decimals)
 
       // ACT
-      const result = await splTokenCreateTokenMint(client, { decimals, feePayerSigner, latestBlockhash, mint, supply })
+      const result = await splTokenCreateTokenMint(client, {
+        decimals,
+        latestBlockhash,
+        mint,
+        supply,
+        transactionSigner,
+      })
 
       // ASSERT
 
       const [tokenAccount] = await getTokenAccountsForMint(client, {
-        address: feePayerSigner.address,
+        address: transactionSigner.address,
         mint: mint.address,
       }).then((res) => res.value)
       if (!tokenAccount) {
@@ -59,7 +71,11 @@ describe('spl-token-create-token-mint', async () => {
       const decimals = 9
 
       // ACT
-      const result = await splTokenCreateTokenMint(client, { decimals, feePayerSigner, latestBlockhash })
+      const result = await splTokenCreateTokenMint(client, {
+        decimals,
+        latestBlockhash,
+        transactionSigner,
+      })
 
       // ASSERT
       expect(isAddress(result.mint)).toBeTruthy()
@@ -72,11 +88,16 @@ describe('spl-token-create-token-mint', async () => {
       const supply = uiAmountToBigInt('1000', 9)
 
       // ACT
-      const result = await splTokenCreateTokenMint(client, { decimals, feePayerSigner, latestBlockhash, supply })
+      const result = await splTokenCreateTokenMint(client, {
+        decimals,
+        latestBlockhash,
+        supply,
+        transactionSigner,
+      })
 
       // ASSERT
       const [tokenAccount] = await getTokenAccountsForMint(client, {
-        address: feePayerSigner.address,
+        address: transactionSigner.address,
         mint: result.mint,
       }).then((res) => res.value)
       if (!tokenAccount) {

--- a/packages/solana-client/test/test-helpers.ts
+++ b/packages/solana-client/test/test-helpers.ts
@@ -13,8 +13,8 @@ import { uiAmountToBigInt } from '../src/ui-amount-to-big-int.ts'
 
 export interface IntegrationTestContext {
   client: SolanaClient
-  feePayerSigner: KeyPairSigner
   latestBlockhash: LatestBlockhash
+  transactionSigner: KeyPairSigner
 }
 
 export async function setupIntegrationTestContext(): Promise<IntegrationTestContext> {
@@ -22,10 +22,10 @@ export async function setupIntegrationTestContext(): Promise<IntegrationTestCont
     url: 'http://localhost:8899',
     urlSubscriptions: 'ws://localhost:8900',
   })
-  const [latestBlockhash, feePayerSigner] = await Promise.all([getLatestBlockhash(client), generateKeyPairSigner()])
-  await requestAirdrop(client, { address: feePayerSigner.address, amount: solToLamports('1') })
+  const [latestBlockhash, transactionSigner] = await Promise.all([getLatestBlockhash(client), generateKeyPairSigner()])
+  await requestAirdrop(client, { address: transactionSigner.address, amount: solToLamports('1') })
 
-  return { client, feePayerSigner, latestBlockhash }
+  return { client, latestBlockhash, transactionSigner }
 }
 
 export interface IntegrationTestMint {
@@ -35,18 +35,18 @@ export interface IntegrationTestMint {
 
 export async function setupIntegrationTestMint({
   client,
-  feePayerSigner,
   latestBlockhash,
+  transactionSigner,
 }: IntegrationTestContext): Promise<IntegrationTestMint> {
   const newTokenMint = await generateKeyPairSigner()
   const decimals = 6
   const supply = 420
   const input: SplTokenCreateTokenMintOptions = {
     decimals,
-    feePayerSigner,
     latestBlockhash,
     mint: newTokenMint,
     supply: uiAmountToBigInt(supply.toString(), decimals),
+    transactionSigner,
   }
 
   const result = await splTokenCreateTokenMint(client, input)

--- a/packages/tools/src/tools-feature-create-token.tsx
+++ b/packages/tools/src/tools-feature-create-token.tsx
@@ -64,7 +64,7 @@ export default function ToolsFeatureCreateToken(props: { account: Account; netwo
     if (!secretKey) {
       throw new Error('Missing account secret key')
     }
-    const feePayerSigner = await createKeyPairSignerFromJson({ json: secretKey })
+    const transactionSigner = await createKeyPairSignerFromJson({ json: secretKey })
     let res: SplTokenCreateTokenMint | SplToken2022CreateTokenMint
     if (tokenProgram === TOKEN_2022_PROGRAM_ADDRESS) {
       const extensions = {
@@ -74,18 +74,18 @@ export default function ToolsFeatureCreateToken(props: { account: Account; netwo
       res = await mutation2022.mutateAsync({
         decimals,
         extensions,
-        feePayerSigner,
         mint: queryKeypair.data,
         supply: supply > 0 ? uiAmountToBigInt(supply.toString(), decimals) : undefined,
         tokenProgram,
+        transactionSigner,
       })
     } else {
       res = await mutation.mutateAsync({
         decimals,
-        feePayerSigner,
         mint: queryKeypair.data,
         supply: supply > 0 ? uiAmountToBigInt(supply.toString(), decimals) : undefined,
         tokenProgram,
+        transactionSigner,
       })
     }
 


### PR DESCRIPTION
## Description

This PR switches from `KeyPairSigner` to the more generic `TransactionSigner` to make these functions more flexible.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to replace `KeyPairSigner` with `TransactionSigner` for transaction flexibility across the codebase.
> 
>   - **Behavior**:
>     - Switch from `KeyPairSigner` to `TransactionSigner` in transaction functions for flexibility.
>     - Affects `createAndSendSolTransaction` and `createAndSendSplTransaction` in `create-and-send-sol-transaction.ts` and `create-and-send-spl-transaction.ts`.
>     - Updates transaction handling in `useCreateAndSendSolTransaction` and `useCreateAndSendSplTransaction`.
>   - **Tests**:
>     - Update integration tests in `create-and-send-sol-transaction.integration.test.ts` and `create-and-send-spl-transaction.integration.test.ts` to use `TransactionSigner`.
>     - Modify test setup in `test-helpers.ts` to generate `TransactionSigner`.
>   - **Misc**:
>     - Update `tools-feature-create-token.tsx` to use `TransactionSigner` for token creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 2d4d4be6a87f17799f24226766b11c8b1356a0a3. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->