### PR TITLE
feat(extension): persist popup or sidepanel preference

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -548,6 +548,7 @@
         "@tanstack/query-sync-storage-persister": "5.90.13",
         "@tanstack/react-query": "catalog:",
         "@tanstack/react-query-persist-client": "5.90.13",
+        "@workspace/background": "workspace:*",
         "@workspace/db": "workspace:*",
         "@workspace/db-react": "workspace:*",
         "@workspace/dev": "workspace:*",

--- a/packages/background/src/sidepanel.ts
+++ b/packages/background/src/sidepanel.ts
@@ -1,0 +1,24 @@
+import { browser } from '@wxt-dev/browser'
+
+export async function openSidePanel() {
+  browser.sidePanel.setPanelBehavior({
+    openPanelOnActionClick: true,
+  })
+
+  const currentWindow = await browser.windows.getCurrent()
+  const windowId = currentWindow.id
+
+  if (!windowId) {
+    throw new Error('Window id is not found')
+  }
+
+  await browser.sidePanel.open({ windowId })
+  window.close()
+}
+
+export async function closeSidePanel() {
+  browser.sidePanel.setPanelBehavior({
+    openPanelOnActionClick: false,
+  })
+  window.close()
+}

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -4,6 +4,7 @@
     "@tanstack/query-sync-storage-persister": "5.90.13",
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-persist-client": "5.90.13",
+    "@workspace/background": "workspace:*",
     "@workspace/db": "workspace:*",
     "@workspace/db-react": "workspace:*",
     "@workspace/dev": "workspace:*",

--- a/packages/shell/src/ui/shell-ui-menu-actions-popup.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-actions-popup.tsx
@@ -1,25 +1,14 @@
+import { openSidePanel } from '@workspace/background/sidepanel'
+import { getRuntime } from '@workspace/env/get-runtime'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
-import { browser } from '@wxt-dev/browser'
 
 export function ShellUiMenuActionsPopup() {
   const { t } = useTranslation('shell')
 
-  if (!browser || !browser?.sidePanel) {
+  if (getRuntime() !== 'extension') {
     return null
-  }
-
-  async function openSidePanel() {
-    const currentWindow = await browser.windows.getCurrent()
-    const windowId = currentWindow.id
-
-    if (!windowId) {
-      throw new Error('Window id is not found')
-    }
-
-    await browser.sidePanel.open({ windowId })
-    window.close()
   }
 
   return (

--- a/packages/shell/src/ui/shell-ui-menu-actions-sidebar.tsx
+++ b/packages/shell/src/ui/shell-ui-menu-actions-sidebar.tsx
@@ -1,3 +1,4 @@
+import { closeSidePanel } from '@workspace/background/sidepanel'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
@@ -5,7 +6,7 @@ import { UiIcon } from '@workspace/ui/components/ui-icon'
 export function ShellUiMenuActionsSidebar() {
   const { t } = useTranslation('shell')
   return (
-    <Button onClick={() => window.close()} size="icon" title={t(($) => $.actionsSidebarHide)} variant="secondary">
+    <Button onClick={closeSidePanel} size="icon" title={t(($) => $.actionsSidebarHide)} variant="secondary">
       <UiIcon icon="sidebarClose" />
     </Button>
   )


### PR DESCRIPTION
## Description

Adds persistence to your choice between popup and sidepanel in extesion

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add persistence for popup or sidepanel preference in extension with new sidepanel management functions.
> 
>   - **Behavior**:
>     - Adds `openSidePanel` and `closeSidePanel` functions in `sidepanel.ts` to manage sidepanel state.
>     - Updates `ShellUiMenuActionsPopup` in `shell-ui-menu-actions-popup.tsx` to use `openSidePanel`.
>     - Updates `ShellUiMenuActionsSidebar` in `shell-ui-menu-actions-sidebar.tsx` to use `closeSidePanel`.
>   - **Dependencies**:
>     - Adds `@workspace/background` to `dependencies` in `package.json` for sidepanel management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 2d4052f332062a9d1da654d26430fc312801b331. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->