### PR TITLE
refactor(db-react): use live query for all queries

### DIFF
--- a/packages/db-react/src/options-bookmark-account.tsx
+++ b/packages/db-react/src/options-bookmark-account.tsx
@@ -1,11 +1,9 @@
 import type { Address } from '@solana/kit'
-import { type MutateOptions, mutationOptions, queryOptions } from '@tanstack/react-query'
-import { bookmarkAccountFindByAddress } from '@workspace/db/bookmark-account/bookmark-account-find-by-address'
+import { type MutateOptions, mutationOptions } from '@tanstack/react-query'
 import { bookmarkAccountToggle } from '@workspace/db/bookmark-account/bookmark-account-toggle'
 import { bookmarkAccountUpdate } from '@workspace/db/bookmark-account/bookmark-account-update'
 import type { BookmarkAccountUpdateInput } from '@workspace/db/bookmark-account/bookmark-account-update-input'
 import { db } from '@workspace/db/db'
-import { queryClient } from './query-client.tsx'
 
 export type BookmarkAccountToggleMutateOptions = MutateOptions<'created' | 'deleted', Error, { address: Address }>
 export type BookmarkAccountUpdateMutateOptions = MutateOptions<
@@ -14,26 +12,15 @@ export type BookmarkAccountUpdateMutateOptions = MutateOptions<
   { address: Address; input: BookmarkAccountUpdateInput }
 >
 export const optionsBookmarkAccount = {
-  findByAddress: (address: Address) =>
-    queryOptions({
-      queryFn: () => bookmarkAccountFindByAddress(db, address),
-      queryKey: ['bookmarkAccountFindByAddress', address],
-    }),
   toggle: (props: BookmarkAccountToggleMutateOptions) =>
     mutationOptions({
       mutationFn: ({ address }: { address: Address }) => bookmarkAccountToggle(db, address),
-      onSuccess: (_, { address }) => {
-        queryClient.invalidateQueries(optionsBookmarkAccount.findByAddress(address))
-      },
       ...props,
     }),
   update: (props: BookmarkAccountUpdateMutateOptions = {}) =>
     mutationOptions({
       mutationFn: ({ id, input }: { id: string; address: Address; input: BookmarkAccountUpdateInput }) =>
         bookmarkAccountUpdate(db, id, input),
-      onSuccess: (_, { address }) => {
-        queryClient.invalidateQueries(optionsBookmarkAccount.findByAddress(address))
-      },
       ...props,
     }),
 }

--- a/packages/db-react/src/options-bookmark-transaction.tsx
+++ b/packages/db-react/src/options-bookmark-transaction.tsx
@@ -1,11 +1,9 @@
 import type { Signature } from '@solana/kit'
-import { type MutateOptions, mutationOptions, queryOptions } from '@tanstack/react-query'
-import { bookmarkTransactionFindBySignature } from '@workspace/db/bookmark-transaction/bookmark-transaction-find-by-signature'
+import { type MutateOptions, mutationOptions } from '@tanstack/react-query'
 import { bookmarkTransactionToggle } from '@workspace/db/bookmark-transaction/bookmark-transaction-toggle'
 import { bookmarkTransactionUpdate } from '@workspace/db/bookmark-transaction/bookmark-transaction-update'
 import type { BookmarkTransactionUpdateInput } from '@workspace/db/bookmark-transaction/bookmark-transaction-update-input'
 import { db } from '@workspace/db/db'
-import { queryClient } from './query-client.tsx'
 
 export type BookmarkTransactionToggleMutateOptions = MutateOptions<
   'created' | 'deleted',
@@ -18,26 +16,15 @@ export type BookmarkTransactionUpdateMutateOptions = MutateOptions<
   { signature: Signature; input: BookmarkTransactionUpdateInput }
 >
 export const optionsBookmarkTransaction = {
-  findBySignature: (signature: Signature) =>
-    queryOptions({
-      queryFn: () => bookmarkTransactionFindBySignature(db, signature),
-      queryKey: ['bookmarkTransactionFindBySignature', signature],
-    }),
   toggle: (props: BookmarkTransactionToggleMutateOptions) =>
     mutationOptions({
       mutationFn: ({ signature }: { signature: Signature }) => bookmarkTransactionToggle(db, signature),
-      onSuccess: (_, { signature }) => {
-        queryClient.invalidateQueries(optionsBookmarkTransaction.findBySignature(signature))
-      },
       ...props,
     }),
   update: (props: BookmarkTransactionUpdateMutateOptions = {}) =>
     mutationOptions({
       mutationFn: ({ id, input }: { id: string; signature: Signature; input: BookmarkTransactionUpdateInput }) =>
         bookmarkTransactionUpdate(db, id, input),
-      onSuccess: (_, { signature }) => {
-        queryClient.invalidateQueries(optionsBookmarkTransaction.findBySignature(signature))
-      },
       ...props,
     }),
 }

--- a/packages/db-react/src/use-bookmark-account-find-by-address.tsx
+++ b/packages/db-react/src/use-bookmark-account-find-by-address.tsx
@@ -1,7 +1,9 @@
 import type { Address } from '@solana/kit'
-import { useQuery } from '@tanstack/react-query'
-import { optionsBookmarkAccount } from './options-bookmark-account.tsx'
+import type { BookmarkAccount } from '@workspace/db/bookmark-account/bookmark-account'
+import { bookmarkAccountFindByAddress } from '@workspace/db/bookmark-account/bookmark-account-find-by-address'
+import { db } from '@workspace/db/db'
+import { useLiveQuery } from 'dexie-react-hooks'
 
 export function useBookmarkAccountFindByAddress({ address }: { address: Address }) {
-  return useQuery(optionsBookmarkAccount.findByAddress(address))
+  return useLiveQuery<null | BookmarkAccount, null>(() => bookmarkAccountFindByAddress(db, address), [address], null)
 }

--- a/packages/db-react/src/use-bookmark-transaction-find-by-signature.tsx
+++ b/packages/db-react/src/use-bookmark-transaction-find-by-signature.tsx
@@ -1,7 +1,13 @@
 import type { Signature } from '@solana/kit'
-import { useQuery } from '@tanstack/react-query'
-import { optionsBookmarkTransaction } from './options-bookmark-transaction.tsx'
+import type { BookmarkTransaction } from '@workspace/db/bookmark-transaction/bookmark-transaction'
+import { bookmarkTransactionFindBySignature } from '@workspace/db/bookmark-transaction/bookmark-transaction-find-by-signature'
+import { db } from '@workspace/db/db'
+import { useLiveQuery } from 'dexie-react-hooks'
 
 export function useBookmarkTransactionFindBySignature({ signature }: { signature: Signature }) {
-  return useQuery(optionsBookmarkTransaction.findBySignature(signature))
+  return useLiveQuery<BookmarkTransaction | null, null>(
+    () => bookmarkTransactionFindBySignature(db, signature),
+    [signature],
+    null,
+  )
 }

--- a/packages/explorer/src/data-access/use-explorer-bookmark-account.tsx
+++ b/packages/explorer/src/data-access/use-explorer-bookmark-account.tsx
@@ -7,12 +7,11 @@ import { toastSuccess } from '@workspace/ui/lib/toast-success'
 
 export function useExplorerBookmarkAccount({ address }: { address: Address }) {
   const { t } = useTranslation('explorer')
-  const query = useBookmarkAccountFindByAddress({ address })
+  const bookmark = useBookmarkAccountFindByAddress({ address })
   const mutationToggle = useBookmarkAccountToggle()
 
   return {
-    ...query,
-    hasBookmark: !!query.data,
+    hasBookmark: Boolean(bookmark),
     toggle: async () => {
       try {
         const result = await mutationToggle.mutateAsync({ address })

--- a/packages/explorer/src/data-access/use-explorer-bookmark-transaction.tsx
+++ b/packages/explorer/src/data-access/use-explorer-bookmark-transaction.tsx
@@ -6,12 +6,11 @@ import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 
 export function useExplorerBookmarkTransaction({ signature }: { signature: Signature }) {
-  const query = useBookmarkTransactionFindBySignature({ signature })
+  const bookmarkTransaction = useBookmarkTransactionFindBySignature({ signature })
   const mutationToggle = useBookmarkTransactionToggle()
 
   return {
-    ...query,
-    hasBookmark: !!query.data,
+    hasBookmark: Boolean(bookmarkTransaction),
     toggle: async () => {
       try {
         const result = await mutationToggle.mutateAsync({ signature })

--- a/packages/explorer/src/explorer-feature-bookmark-account-button.tsx
+++ b/packages/explorer/src/explorer-feature-bookmark-account-button.tsx
@@ -7,13 +7,8 @@ import { useExplorerBookmarkAccount } from './data-access/use-explorer-bookmark-
 
 export function ExplorerFeatureBookmarkAccountButton({ address }: { address: Address }) {
   const { t } = useTranslation('explorer')
-  const { hasBookmark, isLoading, isError, toggle } = useExplorerBookmarkAccount({ address })
-  if (isLoading) {
-    return null
-  }
-  if (isError) {
-    return null
-  }
+  const { hasBookmark, toggle } = useExplorerBookmarkAccount({ address })
+
   return (
     <Button
       onClick={toggle}

--- a/packages/explorer/src/explorer-feature-bookmark-transaction-button.tsx
+++ b/packages/explorer/src/explorer-feature-bookmark-transaction-button.tsx
@@ -5,13 +5,8 @@ import { cn } from '@workspace/ui/lib/utils'
 import { useExplorerBookmarkTransaction } from './data-access/use-explorer-bookmark-transaction.tsx'
 
 export function ExplorerFeatureBookmarkTransactionButton({ signature }: { signature: Signature }) {
-  const { hasBookmark, isLoading, isError, toggle } = useExplorerBookmarkTransaction({ signature })
-  if (isLoading) {
-    return null
-  }
-  if (isError) {
-    return null
-  }
+  const { hasBookmark, toggle } = useExplorerBookmarkTransaction({ signature })
+
   return (
     <Button onClick={toggle} size="sm" title={`${hasBookmark ? 'Remove' : 'Add'} bookmark`} variant="secondary">
       <UiIcon


### PR DESCRIPTION
## Description

Replaces all useQuery usage with useLiveQuery for db-react queries

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to use `useLiveQuery` for real-time updates in bookmark queries, simplifying logic and UI components.
> 
>   - **Behavior**:
>     - Replaces `useQuery` with `useLiveQuery` in `use-bookmark-account-find-by-address.tsx` and `use-bookmark-transaction-find-by-signature.tsx` for real-time updates.
>     - Removes query invalidation logic in `options-bookmark-account.tsx` and `options-bookmark-transaction.tsx`.
>   - **Functions**:
>     - Updates `useExplorerBookmarkAccount` and `useExplorerBookmarkTransaction` to use `useLiveQuery` results directly.
>   - **UI**:
>     - Simplifies `ExplorerFeatureBookmarkAccountButton` and `ExplorerFeatureBookmarkTransactionButton` by removing loading and error checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 69b4206a81f0b9c1141fa4d28e3561f7d31bc39a. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->