### PR TITLE
feat(portfolio): add menu to token balance items

### DIFF
--- a/packages/i18n/locales/en/portfolio.json
+++ b/packages/i18n/locales/en/portfolio.json
@@ -21,5 +21,7 @@
   "sendInputAmountLabel": "Amount",
   "sendInputAmountPlaceholder": "Amount",
   "sendInputDestinationLabel": "Destination",
-  "sendInputDestinationPlaceholder": "Destination"
+  "sendInputDestinationPlaceholder": "Destination",
+  "viewExplorerAccount": "View account in Explorer",
+  "viewExplorerToken": "View token in Explorer"
 }

--- a/packages/i18n/locales/es/portfolio.json
+++ b/packages/i18n/locales/es/portfolio.json
@@ -21,5 +21,7 @@
   "sendInputAmountLabel": "Cantidad",
   "sendInputAmountPlaceholder": "Cantidad",
   "sendInputDestinationLabel": "Destino",
-  "sendInputDestinationPlaceholder": "Destino"
+  "sendInputDestinationPlaceholder": "Destino",
+  "viewExplorerAccount": null,
+  "viewExplorerToken": null
 }

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -78,6 +78,8 @@ interface Resources {
     sendInputAmountPlaceholder: 'Amount'
     sendInputDestinationLabel: 'Destination'
     sendInputDestinationPlaceholder: 'Destination'
+    viewExplorerAccount: 'View account in Explorer'
+    viewExplorerToken: 'View token in Explorer'
   }
   settings: {
     accountTableHeaderActions: 'Actions'

--- a/packages/portfolio/src/ui/portfolio-ui-token-balance-item-menu.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balance-item-menu.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from '@workspace/i18n'
+import { Button } from '@workspace/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@workspace/ui/components/dropdown-menu'
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+import { Link, useLocation } from 'react-router'
+import type { TokenBalance } from '../data-access/use-get-token-metadata.ts'
+
+export function PortfolioUiTokenBalanceItemMenu({ item }: { item: TokenBalance }) {
+  const { t } = useTranslation('portfolio')
+  const { pathname: from } = useLocation()
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button size="icon" variant="ghost">
+          <UiIcon icon="menu" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem>
+          <Link state={{ from }} to={`/explorer/address/${item.account}`}>
+            {t(($) => $.viewExplorerAccount)}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link state={{ from }} to={`/explorer/address/${item.mint}`}>
+            {t(($) => $.viewExplorerToken)}
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
@@ -2,6 +2,7 @@ import { UiAvatar } from '@workspace/ui/components/ui-avatar'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
 import { Link, useLocation } from 'react-router'
 import type { TokenBalance } from '../data-access/use-get-token-metadata.ts'
+import { PortfolioUiTokenBalanceItemMenu } from './portfolio-ui-token-balance-item-menu.tsx'
 
 export function PortfolioUiTokenBalanceItem({ item }: { item: TokenBalance }) {
   const name = item.metadata?.name ?? ellipsify(item.mint)
@@ -22,9 +23,12 @@ export function PortfolioUiTokenBalanceItem({ item }: { item: TokenBalance }) {
           <div className="truncate text-muted-foreground/70 text-xs">{symbol}</div>
         </div>
       </div>
-      <div className="flex shrink-0 flex-col items-end gap-0.5">
-        <div className="font-semibold text-sm">{item.balanceToken}</div>
-        <div className="text-muted-foreground/60 text-xs">${item.balanceUsd}</div>
+      <div className="flex items-center gap-2">
+        <div className="flex shrink-0 flex-col items-end gap-0.5">
+          <div className="font-semibold text-sm">{item.balanceToken}</div>
+          <div className="text-muted-foreground/60 text-xs">${item.balanceUsd}</div>
+        </div>
+        <PortfolioUiTokenBalanceItemMenu item={item} />
       </div>
     </Link>
   )

--- a/packages/solana-client/src/constants.ts
+++ b/packages/solana-client/src/constants.ts
@@ -1,4 +1,6 @@
-export const NATIVE_MINT = 'So11111111111111111111111111111111111111112'
+import { address } from '@solana/kit'
+
+export const NATIVE_MINT = address('So11111111111111111111111111111111111111112')
 export const TRANSACTION_FEE_LAMPORTS = BigInt(5000)
 
 export { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token'

--- a/packages/ui/src/components/ui-icon-map.tsx
+++ b/packages/ui/src/components/ui-icon-map.tsx
@@ -25,6 +25,7 @@ import {
   LucideImport,
   LucideKeyRound,
   LucideLetterText,
+  LucideMoreVertical,
   LucideNetwork,
   LucideNotepadText,
   LucidePanelRight,
@@ -77,6 +78,7 @@ export type UiIconName =
   | 'image'
   | 'import'
   | 'key'
+  | 'menu'
   | 'mnemonic'
   | 'network'
   | 'plus'
@@ -122,6 +124,7 @@ const uiIconMap = new Map<UiIconName, UiIconLucide>()
   .set('image', LucideImage)
   .set('import', LucideImport)
   .set('key', LucideKeyRound)
+  .set('menu', LucideMoreVertical)
   .set('mnemonic', LucideNotepadText)
   .set('network', LucideNetwork)
   .set('plus', LucidePlus)


### PR DESCRIPTION
## Description

This PR adds a dropdown menu to the token balances in the `Portfolio -> Tokens` feature that enables navigation to the explorer for both the (token) account as a token (mint). 

We'll be adding more options here down the line (close mint, copy address, etc).

## Screenshots / Video


<img width="1000" height="1622" alt="image" src="https://github.com/user-attachments/assets/cc2ecfc4-4dbc-44ba-8292-eeeeebe03a2d" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add dropdown menu to token balance items for explorer navigation and update related UI, i18n, and data handling.
> 
>   - **UI Changes**:
>     - Add `PortfolioUiTokenBalanceItemMenu` component in `portfolio-ui-token-balance-item-menu.tsx` for dropdown menu.
>     - Integrate menu into `PortfolioUiTokenBalanceItem` in `portfolio-ui-token-balance-item.tsx`.
>     - Add `menu` icon to `ui-icon-map.tsx`.
>   - **Functionality**:
>     - Dropdown menu allows navigation to explorer for `account` and `mint`.
>   - **i18n**:
>     - Add `viewExplorerAccount` and `viewExplorerToken` translations in `en/portfolio.json` and `es/portfolio.json`.
>   - **Data Handling**:
>     - Update `TokenBalance` interface in `use-get-token-metadata.ts` to include `account` and `mint` as `Address` type.
>     - Modify `mergeData` function to handle `account` and `mint` as `Address` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 4feda7f1ba76fb7473947839d0258287330a9283. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->