### PR TITLE
feat: add toggle show menu toggle to token balance item

### DIFF
--- a/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balance-item.tsx
@@ -4,7 +4,7 @@ import { Link, useLocation } from 'react-router'
 import type { TokenBalance } from '../data-access/use-get-token-metadata.ts'
 import { PortfolioUiTokenBalanceItemMenu } from './portfolio-ui-token-balance-item-menu.tsx'
 
-export function PortfolioUiTokenBalanceItem({ item }: { item: TokenBalance }) {
+export function PortfolioUiTokenBalanceItem({ item, showMenu = false }: { item: TokenBalance; showMenu?: boolean }) {
   const name = item.metadata?.name ?? ellipsify(item.mint)
   const symbol = item.metadata?.symbol ?? ellipsify(item.mint, 2, '').toLocaleUpperCase()
   const icon = item.metadata?.icon
@@ -28,7 +28,7 @@ export function PortfolioUiTokenBalanceItem({ item }: { item: TokenBalance }) {
           <div className="font-semibold text-sm">{item.balanceToken}</div>
           <div className="text-muted-foreground/60 text-xs">${item.balanceUsd}</div>
         </div>
-        <PortfolioUiTokenBalanceItemMenu item={item} />
+        {showMenu ? <PortfolioUiTokenBalanceItemMenu item={item} /> : null}
       </div>
     </Link>
   )

--- a/packages/portfolio/src/ui/portfolio-ui-token-balances.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-token-balances.tsx
@@ -6,7 +6,7 @@ export function PortfolioUiTokenBalances({ items }: { items: TokenBalance[] }) {
   return (
     <div className="space-y-2 md:space-y-6">
       {items.map((item) => (
-        <PortfolioUiTokenBalanceItem item={item} key={item.mint} />
+        <PortfolioUiTokenBalanceItem item={item} key={item.mint} showMenu />
       ))}
     </div>
   )


### PR DESCRIPTION

## Description

We generally not want to show this menu, only if it's in the list of tokens.




<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `showMenu` prop to conditionally display menu in `PortfolioUiTokenBalanceItem`, defaulting to hidden.
> 
>   - **Behavior**:
>     - Adds `showMenu` prop to `PortfolioUiTokenBalanceItem` in `portfolio-ui-token-balance-item.tsx` to conditionally render `PortfolioUiTokenBalanceItemMenu`.
>     - Default `showMenu` is `false`, only shows menu if `showMenu` is `true`.
>   - **Usage**:
>     - `PortfolioUiTokenBalances` in `portfolio-ui-token-balances.tsx` sets `showMenu` to `true` for all items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for b7a4395d0a459c06d1f83c55f023b6940a17d7d5. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->