### PR TITLE
refactor: use mutation options for all react query mutations

### DIFF
--- a/packages/db-react/src/options-bookmark-account.tsx
+++ b/packages/db-react/src/options-bookmark-account.tsx
@@ -11,6 +11,7 @@ export type BookmarkAccountUpdateMutateOptions = MutateOptions<
   Error,
   { address: Address; input: BookmarkAccountUpdateInput }
 >
+
 export const optionsBookmarkAccount = {
   toggle: (props: BookmarkAccountToggleMutateOptions) =>
     mutationOptions({

--- a/packages/db-react/src/use-reset.tsx
+++ b/packages/db-react/src/use-reset.tsx
@@ -1,16 +1,20 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
 import { db } from '@workspace/db/db'
 import { reset } from '@workspace/db/reset'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 
-export function useReset() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
+export function resetMutationOptions(queryClient: QueryClient) {
+  return mutationOptions({
     mutationFn: async () => {
       await reset(db)
       queryClient.clear()
       toastSuccess('Database reset successfully')
     },
   })
+}
+
+export function useReset() {
+  const queryClient = useQueryClient()
+
+  return useMutation(resetMutationOptions(queryClient))
 }

--- a/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
@@ -1,19 +1,22 @@
 import { address, type KeyPairSigner } from '@solana/kit'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
 import { createAndSendSolTransaction } from '@workspace/solana-client/create-and-send-sol-transaction'
 import { getBalance } from '@workspace/solana-client/get-balance'
 import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
 import { getAccountInfoQueryOptions } from '@workspace/solana-client-react/use-get-account-info'
 import { getBalanceQueryOptions } from '@workspace/solana-client-react/use-get-balance'
 import { useSolanaClient } from '@workspace/solana-client-react/use-solana-client'
 
-export function useCreateAndSendSolTransaction({ account, network }: { account: Account; network: Network }) {
-  const queryClient = useQueryClient()
-  const client = useSolanaClient({ network })
-
-  return useMutation({
+export function createAndSendSolTransactionMutationOptions(
+  client: SolanaClient,
+  queryClient: QueryClient,
+  account: Account,
+  network: Network,
+) {
+  return mutationOptions({
     mutationFn: async ({
       amount,
       destination,
@@ -43,4 +46,11 @@ export function useCreateAndSendSolTransaction({ account, network }: { account: 
       })
     },
   })
+}
+
+export function useCreateAndSendSolTransaction({ account, network }: { account: Account; network: Network }) {
+  const queryClient = useQueryClient()
+  const client = useSolanaClient({ network })
+
+  return useMutation(createAndSendSolTransactionMutationOptions(client, queryClient, account, network))
 }

--- a/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-spl-transaction.tsx
@@ -1,17 +1,19 @@
 import { address, type TransactionSigner } from '@solana/kit'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { Network } from '@workspace/db/network/network'
 import { createAndSendSplTransaction } from '@workspace/solana-client/create-and-send-spl-transaction'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
 import { getAccountInfoQueryOptions } from '@workspace/solana-client-react/use-get-account-info'
 import { getBalanceQueryOptions } from '@workspace/solana-client-react/use-get-balance'
 import { getTokenAccountsQueryOptions } from '@workspace/solana-client-react/use-get-token-accounts'
 import { useSolanaClient } from '@workspace/solana-client-react/use-solana-client'
 
-export function useCreateAndSendSplTransaction({ network }: { network: Network }) {
-  const queryClient = useQueryClient()
-  const client = useSolanaClient({ network })
-
-  return useMutation({
+export function createAndSendSplTransactionMutationOptions(
+  client: SolanaClient,
+  queryClient: QueryClient,
+  network: Network,
+) {
+  return mutationOptions({
     mutationFn: async ({
       amount,
       decimals,
@@ -45,4 +47,11 @@ export function useCreateAndSendSplTransaction({ network }: { network: Network }
       })
     },
   })
+}
+
+export function useCreateAndSendSplTransaction({ network }: { network: Network }) {
+  const queryClient = useQueryClient()
+  const client = useSolanaClient({ network })
+
+  return useMutation(createAndSendSplTransactionMutationOptions(client, queryClient, network))
 }

--- a/packages/settings/src/data-access/use-derive-and-create-account.tsx
+++ b/packages/settings/src/data-access/use-derive-and-create-account.tsx
@@ -1,15 +1,20 @@
-import { useMutation } from '@tanstack/react-query'
+import { mutationOptions, useMutation } from '@tanstack/react-query'
 import type { Wallet } from '@workspace/db/wallet/wallet'
 import { useAccountCreate } from '@workspace/db-react/use-account-create'
 import { useWalletReadMnemonic } from '@workspace/db-react/use-wallet-read-mnemonic'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
 import { useDeriveFromMnemonic } from './use-derive-from-mnemonic.tsx'
 
-export function useDeriveAndCreateAccount() {
-  const createAccountMutation = useAccountCreate()
-  const deriveFromMnemonicMutation = useDeriveFromMnemonic()
-  const readMnemonicMutation = useWalletReadMnemonic()
-  return useMutation({
+export function deriveAndCreateAccountMutationOptions({
+  createAccountMutation,
+  deriveFromMnemonicMutation,
+  readMnemonicMutation,
+}: {
+  createAccountMutation: ReturnType<typeof useAccountCreate>
+  deriveFromMnemonicMutation: ReturnType<typeof useDeriveFromMnemonic>
+  readMnemonicMutation: ReturnType<typeof useWalletReadMnemonic>
+}) {
+  return mutationOptions({
     mutationFn: async ({ index, item }: { index: number; item: Wallet }) => {
       const mnemonic = await readMnemonicMutation.mutateAsync({ id: item.id })
       const derivedAccount = await deriveFromMnemonicMutation.mutateAsync({
@@ -28,4 +33,18 @@ export function useDeriveAndCreateAccount() {
       })
     },
   })
+}
+
+export function useDeriveAndCreateAccount() {
+  const createAccountMutation = useAccountCreate()
+  const deriveFromMnemonicMutation = useDeriveFromMnemonic()
+  const readMnemonicMutation = useWalletReadMnemonic()
+
+  return useMutation(
+    deriveAndCreateAccountMutationOptions({
+      createAccountMutation,
+      deriveFromMnemonicMutation,
+      readMnemonicMutation,
+    }),
+  )
 }

--- a/packages/settings/src/data-access/use-derive-from-mnemonic.tsx
+++ b/packages/settings/src/data-access/use-derive-from-mnemonic.tsx
@@ -1,13 +1,17 @@
-import { useMutation } from '@tanstack/react-query'
+import { mutationOptions, useMutation } from '@tanstack/react-query'
 import type { DeriveFromMnemonicAtIndexProps } from '@workspace/keypair/derive-from-mnemonic-at-index'
 import { deriveFromMnemonicAtIndex } from '@workspace/keypair/derive-from-mnemonic-at-index'
 import { toastError } from '@workspace/ui/lib/toast-error'
 
-export function useDeriveFromMnemonic() {
-  return useMutation({
+export function deriveFromMnemonicMutationOptions() {
+  return mutationOptions({
     mutationFn: (input: DeriveFromMnemonicAtIndexProps) => deriveFromMnemonicAtIndex(input),
     onError: (error) => {
       toastError(`Error: ${error.message}`)
     },
   })
+}
+
+export function useDeriveFromMnemonic() {
+  return useMutation(deriveFromMnemonicMutationOptions())
 }

--- a/packages/settings/src/data-access/use-generate-wallet-with-account-mutation.tsx
+++ b/packages/settings/src/data-access/use-generate-wallet-with-account-mutation.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query'
+import { mutationOptions, useMutation } from '@tanstack/react-query'
 import type { WalletCreateInput } from '@workspace/db/wallet/wallet-create-input'
 import { useAccountCreate } from '@workspace/db-react/use-account-create'
 import { useWalletCreate } from '@workspace/db-react/use-wallet-create'
@@ -6,12 +6,16 @@ import { ellipsify } from '@workspace/ui/lib/ellipsify'
 
 import { useDeriveFromMnemonic } from './use-derive-from-mnemonic.tsx'
 
-export function useGenerateWalletWithAccountMutation() {
-  const createWalletMutation = useWalletCreate()
-  const createAccountMutation = useAccountCreate()
-  const deriveAccountMutation = useDeriveFromMnemonic()
-
-  return useMutation({
+export function generateWalletWithAccountMutationOptions({
+  createWalletMutation,
+  createAccountMutation,
+  deriveAccountMutation,
+}: {
+  createWalletMutation: ReturnType<typeof useWalletCreate>
+  createAccountMutation: ReturnType<typeof useAccountCreate>
+  deriveAccountMutation: ReturnType<typeof useDeriveFromMnemonic>
+}) {
+  return mutationOptions({
     mutationFn: async (input: WalletCreateInput) => {
       // First, we see if we can derive the first account from this mnemonic
       const derivedAccount = await deriveAccountMutation.mutateAsync({ mnemonic: input.mnemonic })
@@ -29,4 +33,18 @@ export function useGenerateWalletWithAccountMutation() {
       return walletId
     },
   })
+}
+
+export function useGenerateWalletWithAccountMutation() {
+  const createWalletMutation = useWalletCreate()
+  const createAccountMutation = useAccountCreate()
+  const deriveAccountMutation = useDeriveFromMnemonic()
+
+  return useMutation(
+    generateWalletWithAccountMutationOptions({
+      createAccountMutation,
+      createWalletMutation,
+      deriveAccountMutation,
+    }),
+  )
 }

--- a/packages/solana-client-react/src/use-get-solana-network-from-genesis-hash.tsx
+++ b/packages/solana-client-react/src/use-get-solana-network-from-genesis-hash.tsx
@@ -1,13 +1,22 @@
-import { useMutation } from '@tanstack/react-query'
+import { mutationOptions, useMutation } from '@tanstack/react-query'
 import { createSolanaClient } from '@workspace/solana-client/create-solana-client'
 import { getSolanaNetworkFromGenesisHash } from '@workspace/solana-client/get-solana-network-from-genesis-hash'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
 
-export function useGetSolanaNetworkFromGenesisHash() {
-  return useMutation({
+export function getSolanaNetworkFromGenesisHashMutationOptions() {
+  return mutationOptions({
     mutationFn: async (endpoint: string) => {
       const client = createSolanaClient({ url: endpoint })
-      const hash = await client.rpc.getGenesisHash().send()
+      const hash = await getGenesisHash(client)
       return getSolanaNetworkFromGenesisHash(hash)
     },
   })
+}
+
+export function useGetSolanaNetworkFromGenesisHash() {
+  return useMutation(getSolanaNetworkFromGenesisHashMutationOptions())
+}
+
+export async function getGenesisHash(client: SolanaClient) {
+  return client.rpc.getGenesisHash().send()
 }

--- a/packages/solana-client-react/src/use-request-airdrop.tsx
+++ b/packages/solana-client-react/src/use-request-airdrop.tsx
@@ -1,19 +1,16 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { Network } from '@workspace/db/network/network'
 import type { RequestAirdropOption } from '@workspace/solana-client/request-airdrop'
 import { requestAirdrop } from '@workspace/solana-client/request-airdrop'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
-
 import { getAccountInfoQueryOptions } from './use-get-account-info.tsx'
 import { getBalanceQueryOptions } from './use-get-balance.tsx'
 import { useSolanaClient } from './use-solana-client.tsx'
 
-export function useRequestAirdrop(network: Network) {
-  const client = useSolanaClient({ network })
-  const queryClient = useQueryClient()
-
-  return useMutation({
+export function requestAirdropMutationOptions(client: SolanaClient, queryClient: QueryClient, network: Network) {
+  return mutationOptions({
     mutationFn: (input: RequestAirdropOption) => requestAirdrop(client, input),
     onError: () => {
       toastError(
@@ -38,4 +35,11 @@ export function useRequestAirdrop(network: Network) {
       toastSuccess('Airdrop requested successfully')
     },
   })
+}
+
+export function useRequestAirdrop(network: Network) {
+  const client = useSolanaClient({ network })
+  const queryClient = useQueryClient()
+
+  return useMutation(requestAirdropMutationOptions(client, queryClient, network))
 }

--- a/packages/solana-client-react/src/use-spl-token-create-token-2022-mint.tsx
+++ b/packages/solana-client-react/src/use-spl-token-create-token-2022-mint.tsx
@@ -1,19 +1,17 @@
-import { useMutation } from '@tanstack/react-query'
+import { mutationOptions, useMutation } from '@tanstack/react-query'
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
 import {
   type SplToken2022CreateTokenMintOptions,
   splToken2022CreateTokenMint,
 } from '@workspace/solana-client/spl-token-2022-create-token-mint'
-
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { useSolanaClient } from './use-solana-client.tsx'
 
-export function useSplTokenCreateToken2022Mint(props: { account: Account; network: Network }) {
-  const client = useSolanaClient({ network: props.network })
-
-  return useMutation({
+export function splTokenCreateToken2022MintMutationOptions(client: SolanaClient) {
+  return mutationOptions({
     mutationFn: async (input: SplToken2022CreateTokenMintOptions) => splToken2022CreateTokenMint(client, input),
     onError: () => {
       toastError('Failed to create token 2022 mint.')
@@ -22,4 +20,10 @@ export function useSplTokenCreateToken2022Mint(props: { account: Account; networ
       toastSuccess('Token 2022 mint created successfully')
     },
   })
+}
+
+export function useSplTokenCreateToken2022Mint(props: { account: Account; network: Network }) {
+  const client = useSolanaClient({ network: props.network })
+
+  return useMutation(splTokenCreateToken2022MintMutationOptions(client))
 }

--- a/packages/solana-client-react/src/use-spl-token-create-token-mint.tsx
+++ b/packages/solana-client-react/src/use-spl-token-create-token-mint.tsx
@@ -1,16 +1,15 @@
-import { useMutation } from '@tanstack/react-query'
+import { mutationOptions, useMutation } from '@tanstack/react-query'
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
 import type { SplTokenCreateTokenMintOptions } from '@workspace/solana-client/spl-token-create-token-mint'
 import { splTokenCreateTokenMint } from '@workspace/solana-client/spl-token-create-token-mint'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { useSolanaClient } from './use-solana-client.tsx'
 
-export function useSplTokenCreateTokenMint(props: { account: Account; network: Network }) {
-  const client = useSolanaClient({ network: props.network })
-
-  return useMutation({
+export function splTokenCreateTokenMintMutationOptions(client: SolanaClient) {
+  return mutationOptions({
     mutationFn: async (input: SplTokenCreateTokenMintOptions) => splTokenCreateTokenMint(client, input),
     onError: () => {
       toastError('Failed to create token mint.')
@@ -19,4 +18,10 @@ export function useSplTokenCreateTokenMint(props: { account: Account; network: N
       toastSuccess('Token mint created successfully')
     },
   })
+}
+
+export function useSplTokenCreateTokenMint(props: { account: Account; network: Network }) {
+  const client = useSolanaClient({ network: props.network })
+
+  return useMutation(splTokenCreateTokenMintMutationOptions(client))
 }


### PR DESCRIPTION
## Description

Updates to use `mutationOptions` for all `useMutation` hooks.

This means that we are able to extend these mutation options and we will be able to more easily solve #253 and #254 once merged

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor all `useMutation` hooks to use `mutationOptions` for easier extension across transaction and account management functions.
> 
>   - **Behavior**:
>     - Refactor all `useMutation` hooks to use `mutationOptions` for easier extension.
>     - Affects transaction and account management functions across multiple files.
>   - **Functions**:
>     - Introduce `mutationOptions` in `useReset`, `useCreateAndSendSolTransaction`, `useCreateAndSendSplTransaction`, `usePortfolioTxSend`, `useDeriveAndCreateAccount`, `useDeriveFromMnemonic`, `useGenerateWalletWithAccountMutation`, `useGetSolanaNetworkFromGenesisHash`, `useRequestAirdrop`, `useSplTokenCreateToken2022Mint`, and `useSplTokenCreateTokenMint`.
>     - Add specific mutation option functions like `resetMutationOptions`, `createAndSendSolTransactionMutationOptions`, etc.
>   - **Misc**:
>     - Minor import adjustments to accommodate new `mutationOptions` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 7b0a7888ce81db3582a296e115cde4029d41d878. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->