### PR TITLE
feat(db): ensure we have a runtime check to see if network type is valid

### DIFF
--- a/packages/db/src/network/network-create.ts
+++ b/packages/db/src/network/network-create.ts
@@ -7,7 +7,6 @@ import { networkCreateSchema } from './network-create-schema.ts'
 
 export async function networkCreate(db: Database, input: NetworkCreateInput): Promise<string> {
   const now = new Date()
-  // TODO: Add runtime check to ensure Network.type is valid
   const parsedInput = networkCreateSchema.parse(input)
 
   return db.transaction('rw', db.networks, async () => {

--- a/packages/db/test/network-create.test.ts
+++ b/packages/db/test/network-create.test.ts
@@ -161,5 +161,33 @@ describe('network-create', () => {
         ]]
       `)
     })
+
+    it('should throw an error with an invalid type', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testNetworkCreateInput({
+        // @ts-expect-error we override the type
+        type: 'solana:custom',
+      })
+
+      // ACT & ASSERT
+      await expect(networkCreate(db, input)).rejects.toThrowErrorMatchingInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_value",
+            "values": [
+              "solana:devnet",
+              "solana:localnet",
+              "solana:mainnet",
+              "solana:testnet"
+            ],
+            "path": [
+              "type"
+            ],
+            "message": "Invalid option: expected one of \\"solana:devnet\\"|\\"solana:localnet\\"|\\"solana:mainnet\\"|\\"solana:testnet\\""
+          }
+        ]]
+      `)
+    })
   })
 })


### PR DESCRIPTION
## Description

Removes a todo and assures this works by adding a test.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes TODO and adds test to ensure `networkCreate` throws error for invalid network type.
> 
>   - **Behavior**:
>     - Removes TODO comment in `networkCreate` function in `network-create.ts` regarding runtime check for valid network type.
>     - Adds test in `network-create.test.ts` to ensure `networkCreate` throws an error for invalid network type `solana:custom`.
>   - **Tests**:
>     - Validates that `networkCreate` rejects invalid network types with a specific error message using Zod validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for cab26b027f6454b4445e8aac2dccb5283b457fd6. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->