### PR TITLE
feat: ensure deleting wallet deletes connected accounts

### DIFF
--- a/packages/db/src/wallet/wallet-delete.ts
+++ b/packages/db/src/wallet/wallet-delete.ts
@@ -1,9 +1,15 @@
 import { tryCatch } from '@workspace/core/try-catch'
-
+import { accountFindMany } from '../account/account-find-many.ts'
 import type { Database } from '../database.ts'
 
 export async function walletDelete(db: Database, id: string): Promise<void> {
-  return db.transaction('rw', db.wallets, async () => {
+  return db.transaction('rw', db.accounts, db.wallets, async () => {
+    const accounts = await accountFindMany(db, { walletId: id })
+    const { error: errorAccounts } = await tryCatch(db.accounts.bulkDelete(accounts.map((account) => account.id)))
+    if (errorAccounts) {
+      console.log(errorAccounts)
+      throw new Error(`Error deleting accounts for wallet with id ${id}`)
+    }
     const { data, error } = await tryCatch(db.wallets.delete(id))
     if (error) {
       console.log(error)

--- a/packages/db/test/wallet-delete.test.ts
+++ b/packages/db/test/wallet-delete.test.ts
@@ -1,11 +1,12 @@
 import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
+import { accountCreate } from '../src/account/account-create.ts'
+import { accountFindUnique } from '../src/account/account-find-unique.ts'
 import { walletCreate } from '../src/wallet/wallet-create.ts'
 import { walletDelete } from '../src/wallet/wallet-delete.ts'
 import { walletFindUnique } from '../src/wallet/wallet-find-unique.ts'
-import { createDbTest, testWalletCreateInput } from './test-helpers.ts'
+import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
 
 const db = createDbTest()
 
@@ -27,6 +28,23 @@ describe('wallet-delete', () => {
       // ASSERT
       const deletedItem = await walletFindUnique(db, id)
       expect(deletedItem).toBeNull()
+    })
+
+    it('should delete the accounts in a wallet', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const input = testWalletCreateInput()
+      const id = await walletCreate(db, input)
+      const accountId = await accountCreate(db, testAccountCreateInput({ walletId: id }))
+
+      // ACT
+      await walletDelete(db, id)
+
+      // ASSERT
+      const deletedWallet = await walletFindUnique(db, id)
+      const deletedAccount = await accountFindUnique(db, accountId)
+      expect(deletedWallet).toBeNull()
+      expect(deletedAccount).toBeNull()
     })
   })
 


### PR DESCRIPTION
## Description

Wallet delete now deletes all the linked accounts.

Closes #746

## Checklist

- [x] Tests have been added for my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `walletDelete` now deletes linked accounts before deleting a wallet, with tests added to verify this behavior.
> 
>   - **Behavior**:
>     - `walletDelete` in `wallet-delete.ts` now deletes all accounts linked to a wallet before deleting the wallet itself.
>     - Throws an error if account deletion fails, logging the error.
>   - **Tests**:
>     - Added test in `wallet-delete.test.ts` to verify accounts are deleted when a wallet is deleted.
>     - Test checks both wallet and account are null after deletion.
>     - Mocked error test to ensure error is thrown if wallet deletion fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 071cde4a4d0219fbf3b8070fbd5e8f2031a0dc82. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->