### PR TITLE
refactor(ui): ensure ui-confirm can be used in controlled mode

### DIFF
--- a/packages/explorer/src/ui/explorer-ui-bookmark-account-table.tsx
+++ b/packages/explorer/src/ui/explorer-ui-bookmark-account-table.tsx
@@ -64,11 +64,12 @@ export function ExplorerUiBookmarkAccountTable({
                   actionLabel={t(($) => $.actionDelete)}
                   description={t(($) => $.bookmarkDeleteDescription)}
                   title={t(($) => $.bookmarkDeleteTitle)}
-                >
-                  <Button size="icon" title={t(($) => $.bookmarkDelete)} variant="outline">
-                    <UiIcon className="text-red-500" icon="delete" />
-                  </Button>
-                </UiConfirm>
+                  trigger={
+                    <Button size="icon" title={t(($) => $.bookmarkDelete)} variant="outline">
+                      <UiIcon className="text-red-500" icon="delete" />
+                    </Button>
+                  }
+                />
               </div>
             </TableCell>
           </TableRow>

--- a/packages/explorer/src/ui/explorer-ui-bookmark-transaction-table.tsx
+++ b/packages/explorer/src/ui/explorer-ui-bookmark-transaction-table.tsx
@@ -64,11 +64,12 @@ export function ExplorerUiBookmarkTransactionTable({
                   actionLabel={t(($) => $.actionDelete)}
                   description={t(($) => $.bookmarkDeleteDescription)}
                   title={t(($) => $.bookmarkDeleteTitle)}
-                >
-                  <Button size="icon" title={t(($) => $.bookmarkDelete)} variant="outline">
-                    <UiIcon className="text-red-500" icon="delete" />
-                  </Button>
-                </UiConfirm>
+                  trigger={
+                    <Button size="icon" title={t(($) => $.bookmarkDelete)} variant="outline">
+                      <UiIcon className="text-red-500" icon="delete" />
+                    </Button>
+                  }
+                />
               </div>
             </TableCell>
           </TableRow>

--- a/packages/settings/src/settings-feature-general-danger-delete-database.tsx
+++ b/packages/settings/src/settings-feature-general-danger-delete-database.tsx
@@ -39,11 +39,12 @@ export function SettingsFeatureGeneralDangerDeleteDatabase() {
           actionVariant="destructive"
           description="This action cannot be reversed."
           title="Are you sure you want to reset the application?"
-        >
-          <Button disabled={!accept} variant="destructive">
-            Delete Database
-          </Button>
-        </UiConfirm>
+          trigger={
+            <Button disabled={!accept} variant="destructive">
+              Delete Database
+            </Button>
+          }
+        />
       </div>
     </div>
   )

--- a/packages/settings/src/ui/settings-ui-network-delete-confirm.tsx
+++ b/packages/settings/src/ui/settings-ui-network-delete-confirm.tsx
@@ -1,0 +1,33 @@
+import type { Network } from '@workspace/db/network/network'
+import { useTranslation } from '@workspace/i18n'
+import { Button } from '@workspace/ui/components/button'
+import { UiConfirm } from '@workspace/ui/components/ui-confirm'
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+import { Fragment, useState } from 'react'
+
+export function SettingsUiNetworkDeleteConfirm({
+  deleteItem,
+  item,
+}: {
+  deleteItem: (item: Network) => Promise<void>
+  item: Network
+}) {
+  const { t } = useTranslation('settings')
+  const [open, setOpen] = useState(false)
+  return (
+    <Fragment>
+      <Button onClick={() => setOpen((value) => !value)} size="icon" title={t(($) => $.actionDelete)} variant="outline">
+        <UiIcon className="size-4 text-red-500" icon="delete" />
+      </Button>
+      <UiConfirm
+        action={async () => await deleteItem(item)}
+        actionLabel="Delete"
+        actionVariant="destructive"
+        description="This action cannot be reversed."
+        onOpenChange={(value) => setOpen(value)}
+        open={open}
+        title="Are you sure you want to delete this network?"
+      />
+    </Fragment>
+  )
+}

--- a/packages/settings/src/ui/settings-ui-network-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-network-list-item.tsx
@@ -2,9 +2,9 @@ import type { Network } from '@workspace/db/network/network'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { Item, ItemActions, ItemContent, ItemTitle } from '@workspace/ui/components/item'
-import { UiConfirm } from '@workspace/ui/components/ui-confirm'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { Link } from 'react-router'
+import { SettingsUiNetworkDeleteConfirm } from './settings-ui-network-delete-confirm.tsx'
 import { SettingsUiNetworkItem } from './settings-ui-network-item.tsx'
 
 export function SettingsUiNetworkListItem({
@@ -37,17 +37,7 @@ export function SettingsUiNetworkListItem({
             <UiIcon className="size-4" icon="edit" />
           </Link>
         </Button>
-        <UiConfirm
-          action={async () => await deleteItem(item)}
-          actionLabel="Delete"
-          actionVariant="destructive"
-          description="This action cannot be reversed."
-          title="Are you sure you want to delete this network?"
-        >
-          <Button size="icon" title={t(($) => $.actionDelete)} variant="outline">
-            <UiIcon className="size-4 text-red-500" icon="delete" />
-          </Button>
-        </UiConfirm>
+        <SettingsUiNetworkDeleteConfirm deleteItem={deleteItem} item={item} />
       </ItemActions>
     </Item>
   )

--- a/packages/settings/src/ui/settings-ui-wallet-delete-confirm.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-delete-confirm.tsx
@@ -1,0 +1,33 @@
+import type { Wallet } from '@workspace/db/wallet/wallet'
+import { useTranslation } from '@workspace/i18n'
+import { Button } from '@workspace/ui/components/button'
+import { UiConfirm } from '@workspace/ui/components/ui-confirm'
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+import { Fragment, useState } from 'react'
+
+export function SettingsUiWalletDeleteConfirm({
+  deleteItem,
+  item,
+}: {
+  deleteItem: (item: Wallet) => Promise<void>
+  item: Wallet
+}) {
+  const { t } = useTranslation('settings')
+  const [open, setOpen] = useState(false)
+  return (
+    <Fragment>
+      <Button onClick={() => setOpen((value) => !value)} size="icon" title={t(($) => $.actionDelete)} variant="outline">
+        <UiIcon className="size-4 text-red-500" icon="delete" />
+      </Button>
+      <UiConfirm
+        action={async () => await deleteItem(item)}
+        actionLabel="Delete"
+        actionVariant="destructive"
+        description="This action cannot be reversed."
+        onOpenChange={(value) => setOpen(value)}
+        open={open}
+        title="Are you sure you want to delete this wallet?"
+      />
+    </Fragment>
+  )
+}

--- a/packages/settings/src/ui/settings-ui-wallet-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-wallet-list-item.tsx
@@ -2,10 +2,10 @@ import type { Wallet } from '@workspace/db/wallet/wallet'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { Item, ItemActions, ItemContent, ItemTitle } from '@workspace/ui/components/item'
-import { UiConfirm } from '@workspace/ui/components/ui-confirm'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { Link, useLocation } from 'react-router'
 import { SettingsUiExportWalletMnemonic } from './settings-ui-export-wallet-mnemonic.tsx'
+import { SettingsUiWalletDeleteConfirm } from './settings-ui-wallet-delete-confirm.tsx'
 import { SettingsUiWalletItem } from './settings-ui-wallet-item.tsx'
 
 export function SettingsUiWalletListItem({
@@ -35,17 +35,7 @@ export function SettingsUiWalletListItem({
             <UiIcon className="size-4" icon="edit" />
           </Link>
         </Button>
-        <UiConfirm
-          action={async () => await deleteItem(item)}
-          actionLabel="Delete"
-          actionVariant="destructive"
-          description="This action cannot be reversed."
-          title="Are you sure you want to delete this wallet?"
-        >
-          <Button size="icon" title={t(($) => $.actionDelete)} variant="outline">
-            <UiIcon className="size-4 text-red-500" icon="delete" />
-          </Button>
-        </UiConfirm>
+        <SettingsUiWalletDeleteConfirm deleteItem={deleteItem} item={item} />
       </ItemActions>
     </Item>
   )

--- a/packages/ui/src/components/ui-confirm.tsx
+++ b/packages/ui/src/components/ui-confirm.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,23 +13,24 @@ import {
 import { buttonVariants } from './button.tsx'
 
 export function UiConfirm({
-  actionLabel,
   action,
-  children,
-  title,
-  description,
+  actionLabel,
   actionVariant = 'default',
-}: {
-  title: ReactNode
+  description,
+  title,
+  trigger,
+  ...props
+}: Omit<ComponentProps<typeof AlertDialog>, 'children'> & {
   action: () => Promise<void>
-  children: ReactNode
-  description: ReactNode
   actionLabel: ReactNode
   actionVariant?: 'default' | 'destructive' | 'ghost' | 'link' | 'outline' | 'secondary'
+  description: ReactNode
+  title: ReactNode
+  trigger?: ReactNode
 }) {
   return (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+    <AlertDialog {...props}>
+      {trigger ? <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger> : null}
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>


### PR DESCRIPTION
## Description


This changes the `UiConfirm` component so it can be used controlled and uncontrolled, and moves the `open` state next to the button in 2 places. 

This is in preparation for #736 where we want to be able to trigger these sheets from a dropdown menu.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `UiConfirm` to support controlled mode and update its usage across components with a new `trigger` prop.
> 
>   - **Behavior**:
>     - Refactor `UiConfirm` in `ui-confirm.tsx` to support controlled and uncontrolled modes using a new `trigger` prop.
>     - Update `ExplorerUiBookmarkAccountTable` and `ExplorerUiBookmarkTransactionTable` to use `trigger` prop for `UiConfirm`.
>     - Update `SettingsFeatureGeneralDangerDeleteDatabase` to use `trigger` prop for `UiConfirm`.
>   - **New Components**:
>     - Add `SettingsUiNetworkDeleteConfirm` and `SettingsUiWalletDeleteConfirm` to handle network and wallet deletions with `UiConfirm`.
>   - **Component Usage**:
>     - Replace inline `UiConfirm` usage with `SettingsUiNetworkDeleteConfirm` in `settings-ui-network-list-item.tsx`.
>     - Replace inline `UiConfirm` usage with `SettingsUiWalletDeleteConfirm` in `settings-ui-wallet-list-item.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3d862f6c9bb0596b98f974b4d6150faa433c7d51. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->