### PR TITLE
fix(tools): only show unique accounts in the airdrop dropdown

### DIFF
--- a/packages/tools/src/ui/tools-ui-airdrop-form.tsx
+++ b/packages/tools/src/ui/tools-ui-airdrop-form.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
+import type { Account } from '@workspace/db/account/account'
 import type { Wallet } from '@workspace/db/wallet/wallet'
 import { Button } from '@workspace/ui/components/button'
 import {
@@ -78,7 +79,7 @@ export function ToolsUiAirdropForm({
                     {wallets.map((wallet) => (
                       <SelectGroup key={wallet.id}>
                         <SelectLabel>{wallet.name}</SelectLabel>
-                        {wallet.accounts.map((account) => (
+                        {uniqueAccounts(wallet.accounts ?? []).map((account) => (
                           <SelectItem key={account.id} value={account.publicKey}>
                             {account.name}
                           </SelectItem>
@@ -122,4 +123,8 @@ export function ToolsUiAirdropForm({
       </form>
     </Form>
   )
+}
+
+function uniqueAccounts(accounts: Account[] = []): Account[] {
+  return Array.from(new Map(accounts.map((account) => [account.publicKey, account])).values())
 }


### PR DESCRIPTION
## Description

This patch makes sure the wallet dropdown in in the Airdrop tool only shows unique accounts.

## Screenshots / Video
<img width="635" height="1016" alt="image" src="https://github.com/user-attachments/assets/0b66e5e0-974e-406f-bc8e-515076681235" />

<img width="724" height="1062" alt="image" src="https://github.com/user-attachments/assets/3f8e61d6-c60c-46ae-9299-0b3314079174" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensures unique accounts are shown in the wallet dropdown in `ToolsUiAirdropForm` by using `uniqueAccounts()`.
> 
>   - **Behavior**:
>     - Ensures unique accounts are shown in the wallet dropdown in `ToolsUiAirdropForm` by using `uniqueAccounts()`.
>   - **Functions**:
>     - Adds `uniqueAccounts()` to filter accounts by unique `publicKey` in `tools-ui-airdrop-form.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 59e11e7fb68c89d079fb87738dcba11fe0bd7b67. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->