### PR TITLE
feat(tools): show table of airdrop results with link to explorer

### DIFF
--- a/packages/tools/src/tools-feature-airdrop.tsx
+++ b/packages/tools/src/tools-feature-airdrop.tsx
@@ -1,19 +1,25 @@
-import { address } from '@solana/kit'
+import { type Address, address, type Signature } from '@solana/kit'
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
 import { useWalletLive } from '@workspace/db-react/use-wallet-live'
 import { ExplorerUiExplorerLink } from '@workspace/explorer/ui/explorer-ui-explorer-link'
+import { ExplorerUiLinkAddress } from '@workspace/explorer/ui/explorer-ui-link-address'
+import { ExplorerUiLinkSignature } from '@workspace/explorer/ui/explorer-ui-link-signature'
 import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
 import { useRequestAirdrop } from '@workspace/solana-client-react/use-request-airdrop'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { useState } from 'react'
 import { ToolsUiAirdropForm } from './ui/tools-ui-airdrop-form.tsx'
 
 export default function ToolsFeatureAirdrop(props: { account: Account; network: Network }) {
   const wallets = useWalletLive()
   const { isPending, mutateAsync } = useRequestAirdrop(props.network)
+  const [results, setResults] = useState<AirdropResult[]>([])
+
   return (
-    <UiCard backButtonTo="/tools" title="Airdrop">
+    <UiCard backButtonTo="/tools" contentProps={{ className: 'space-y-2 md:space-y-6' }} title="Airdrop">
       <ToolsUiAirdropForm
         disabled={isPending}
         submit={async (input) => {
@@ -21,6 +27,14 @@ export default function ToolsFeatureAirdrop(props: { account: Account; network: 
             address: address(input.address),
             amount: solToLamports(input.amount.toString()),
           })
+          setResults((result) => [
+            ...result,
+            {
+              address: address(input.address),
+              amount: input.amount,
+              signature,
+            },
+          ])
           toastSuccess(
             <ExplorerUiExplorerLink
               label="View on explorer"
@@ -32,6 +46,43 @@ export default function ToolsFeatureAirdrop(props: { account: Account; network: 
         }}
         wallets={wallets}
       />
+      <ToolsUiAirdropResultTable results={results} />
     </UiCard>
+  )
+}
+
+interface AirdropResult {
+  address: Address
+  amount: number
+  signature: Signature
+}
+function ToolsUiAirdropResultTable({ results = [] }: { results: AirdropResult[] }) {
+  if (!results.length) {
+    return null
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="hover:bg-transparent">
+          <TableHead>Address</TableHead>
+          <TableHead>Signature</TableHead>
+          <TableHead className="w-[120px] text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {results.map(({ address, amount, signature }) => (
+          <TableRow className="hover:bg-transparent" key={signature}>
+            <TableCell>
+              <ExplorerUiLinkAddress address={address} basePath="/explorer" />
+            </TableCell>
+            <TableCell>
+              <ExplorerUiLinkSignature basePath="/explorer" signature={signature} />
+            </TableCell>
+            <TableCell className="w-[120px] text-right">{amount} SOL</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   )
 }

--- a/packages/tools/src/ui/tools-ui-airdrop-form.tsx
+++ b/packages/tools/src/ui/tools-ui-airdrop-form.tsx
@@ -28,7 +28,7 @@ import { z } from 'zod'
 
 const formSchema = z.object({
   address: z.string(),
-  amount: z.number().int({ message: 'Amount must be an integer' }).min(0),
+  amount: z.number().min(0),
 })
 
 export type AirdropFormSchema = z.infer<typeof formSchema>
@@ -103,9 +103,11 @@ export function ToolsUiAirdropForm({
               <FormLabel>Amount</FormLabel>
               <FormControl>
                 <Input
+                  autoComplete="off"
                   className="w-[200px]"
+                  min="0"
                   placeholder="Enter the amount of SOL to airdrop"
-                  step="1"
+                  step="any"
                   type="number"
                   {...field}
                   onChange={(e) => field.onChange(e.target.valueAsNumber)}


### PR DESCRIPTION
## Description

This adds a bit more polish to the airdrop tool


## Screenshots / Video
<img width="684" height="1143" alt="image" src="https://github.com/user-attachments/assets/edb05d3a-5f96-49bb-9c49-239a633b60ed" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances airdrop tool with a results table displaying airdrop details and allows non-integer amounts in the form.
> 
>   - **Behavior**:
>     - Adds `ToolsUiAirdropResultTable` in `tools-feature-airdrop.tsx` to display airdrop results with address, signature, and amount.
>     - Updates `ToolsUiAirdropForm` in `tools-ui-airdrop-form.tsx` to allow non-integer amounts and improve form input handling.
>   - **UI Components**:
>     - Uses `Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow` from `@workspace/ui/components/table` for results display.
>     - Utilizes `ExplorerUiLinkAddress` and `ExplorerUiLinkSignature` for linking to explorer.
>   - **Misc**:
>     - Changes `amount` validation in `tools-ui-airdrop-form.tsx` to allow non-integer values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 31b16228639e6df021c4a818bcf4946952a99040. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->