### PR TITLE
feat: add open code github action

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,31 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run opencode
+        uses: sst/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/big-pickle


### PR DESCRIPTION
## Description

The coding agent I use has interesting Github integration which I would like to test. Might be useful or supplementary to Ellipsis.

https://opencode.ai/docs/github/

## Screenshots / Video

N/A

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a GitHub Action workflow to integrate OpenCode, triggering on specific comment keywords.
> 
>   - **New Workflow**:
>     - Adds `.github/workflows/opencode.yml` to integrate OpenCode with GitHub.
>     - Triggers on `issue_comment` and `pull_request_review_comment` events with specific keywords.
>   - **Job Configuration**:
>     - Runs on `ubuntu-latest`.
>     - Requires `id-token: write`, `contents: read`, `pull-requests: read`, and `issues: read` permissions.
>     - Steps include checking out the repository and running `sst/opencode/github@latest` with `OPENCODE_API_KEY`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 636229546d6c089c55c151ba6f2fd476fd912bda. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->