### PR TITLE
refactor(tools): remove coming soon tools

### DIFF
--- a/packages/tools/src/tools-feature-overview.tsx
+++ b/packages/tools/src/tools-feature-overview.tsx
@@ -4,8 +4,7 @@ import { ToolsUiOverview } from './ui/tools-ui-overview.tsx'
 export default function ToolsFeatureOverview() {
   return (
     <div className="flex flex-col gap-1 sm:gap-2 md:gap-4">
-      <ToolsUiOverview tools={tools.filter((t) => !t.comingSoon)} />
-      <ToolsUiOverview tools={tools.filter((t) => t.comingSoon)} />
+      <ToolsUiOverview tools={tools} />
     </div>
   )
 }

--- a/packages/tools/src/tools.tsx
+++ b/packages/tools/src/tools.tsx
@@ -1,17 +1,12 @@
 import type { UiIconName } from '@workspace/ui/components/ui-icon-map'
 
 export interface Tool {
-  comingSoon?: boolean
   icon: UiIconName
   label: string
   path: string
 }
 
 export const tools: Tool[] = [
-  { comingSoon: false, icon: 'airdrop', label: 'Airdrop', path: '/tools/airdrop' },
-  { comingSoon: true, icon: 'upload', label: 'Arweave Uploader', path: '/tools/arweave-uploader' },
-  { comingSoon: true, icon: 'image', label: 'NFT Creator', path: '/tools/nft-creator' },
-  { comingSoon: true, icon: 'camera', label: 'NFT Snapshots', path: '/tools/nft-snapshots' },
-  { comingSoon: false, icon: 'coins', label: 'Token Creator', path: '/tools/create-token' },
-  { comingSoon: true, icon: 'handCoins', label: 'Token Minter', path: '/tools/mint-token' },
+  { icon: 'airdrop', label: 'Airdrop', path: '/tools/airdrop' },
+  { icon: 'coins', label: 'Token Creator', path: '/tools/create-token' },
 ]

--- a/packages/tools/src/ui/tools-ui-overview-item.tsx
+++ b/packages/tools/src/ui/tools-ui-overview-item.tsx
@@ -1,22 +1,12 @@
-import { Badge } from '@workspace/ui/components/badge'
 import { Item, ItemActions, ItemContent, ItemMedia, ItemTitle } from '@workspace/ui/components/item'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
-import { cn } from '@workspace/ui/lib/utils'
 import { Link } from 'react-router'
 import type { Tool } from '../tools.tsx'
 
 export function ToolsUiOverviewItem({ tool }: { tool: Tool }) {
   return (
-    <Item
-      asChild
-      className={cn({
-        'text-muted-foreground': tool.comingSoon,
-      })}
-      key={tool.path}
-      size="sm"
-      variant="outline"
-    >
-      <Link to={tool.comingSoon ? '#' : tool.path}>
+    <Item asChild key={tool.path} size="sm" variant="outline">
+      <Link to={tool.path}>
         <ItemMedia>
           <UiIcon className="size-4 md:size-6" icon={tool.icon} />
         </ItemMedia>
@@ -24,11 +14,7 @@ export function ToolsUiOverviewItem({ tool }: { tool: Tool }) {
           <ItemTitle className="md:text-xl">{tool.label}</ItemTitle>
         </ItemContent>
         <ItemActions>
-          {tool.comingSoon ? (
-            <Badge variant="secondary">Coming soon</Badge>
-          ) : (
-            <UiIcon className="size-4" icon="chevronRight" />
-          )}
+          <UiIcon className="size-4" icon="chevronRight" />
         </ItemActions>
       </Link>
     </Item>


### PR DESCRIPTION
## Description

We talked about removing these as they were primarily in place for the demo for the hackathon.

## Screenshots / Video

<img width="1153" height="206" alt="image" src="https://github.com/user-attachments/assets/b528c2a2-b7af-447b-b2a7-d4dd66965142" />

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove 'coming soon' tools and related UI elements from the tools feature.
> 
>   - **Behavior**:
>     - Removed 'coming soon' tools from `tools.tsx`.
>     - Updated `ToolsFeatureOverview` in `tools-feature-overview.tsx` to display all tools without filtering.
>   - **UI Components**:
>     - Removed 'coming soon' badge and conditional logic from `ToolsUiOverviewItem` in `tools-ui-overview-item.tsx`.
>   - **Data Structure**:
>     - Removed `comingSoon` property from `Tool` interface in `tools.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 8af0a7e075f711bc2f068235b18aafc06c2b2737. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->