### PR TITLE
feat(onboarding): blur generated mnemonic

### DIFF
--- a/packages/i18n/locales/en/onboarding.json
+++ b/packages/i18n/locales/en/onboarding.json
@@ -2,6 +2,8 @@
   "generateButtonCreate": "Create wallet",
   "generateCardDescription": "This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!",
   "generateCardTitle": "Generate Recovery Phrase",
+  "generateMnemonicHide": "Hide mnemonic",
+  "generateMnemonicShow": "Show mnemonic",
   "generateToastCopied": "Mnemonic copied to clipboard",
   "generateToastCopy": "Copy",
   "importButtonSubmit": "Import wallet",

--- a/packages/i18n/locales/es/onboarding.json
+++ b/packages/i18n/locales/es/onboarding.json
@@ -2,6 +2,8 @@
   "generateButtonCreate": "Crea billetera",
   "generateCardDescription": "Esta frase semilla es la ÚNICA forma de recuperar tu billetera. ¡No la compartas con nadie!",
   "generateCardTitle": "Generar frase de recuperación",
+  "generateMnemonicHide": "Ocultar mnemónica",
+  "generateMnemonicShow": "Revelar mnemónica",
   "generateToastCopied": "Mnemónica copiada al portapapeles",
   "generateToastCopy": "Copiar",
   "importButtonSubmit": "Importar billetera",

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -39,6 +39,8 @@ interface Resources {
     generateButtonCreate: 'Create wallet'
     generateCardDescription: "This seed phrase is the ONLY way to recover your wallet. Don't share it with anyone!"
     generateCardTitle: 'Generate Recovery Phrase'
+    generateMnemonicHide: 'Hide mnemonic'
+    generateMnemonicShow: 'Show mnemonic'
     generateToastCopied: 'Mnemonic copied to clipboard'
     generateToastCopy: 'Copy'
     importButtonSubmit: 'Import wallet'

--- a/packages/onboarding/src/onboarding-feature-generate.tsx
+++ b/packages/onboarding/src/onboarding-feature-generate.tsx
@@ -3,11 +3,14 @@ import { useTranslation } from '@workspace/i18n'
 import type { MnemonicStrength } from '@workspace/keypair/generate-mnemonic'
 import { generateMnemonic } from '@workspace/keypair/generate-mnemonic'
 import { validateMnemonic } from '@workspace/keypair/validate-mnemonic'
+import { Button } from '@workspace/ui/components/button'
 import { Form } from '@workspace/ui/components/form'
 import { UiBackButton } from '@workspace/ui/components/ui-back-button'
 import { UiCard } from '@workspace/ui/components/ui-card'
+import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
 import { toastError } from '@workspace/ui/lib/toast-error'
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 import { z } from 'zod'
@@ -27,6 +30,7 @@ export function OnboardingFeatureGenerate({ redirectTo }: { redirectTo: string }
   const { t } = useTranslation('onboarding')
   const create = useCreateNewWallet()
   const navigate = useNavigate()
+  const [revealed, setRevealed] = useState<boolean>(false)
 
   const form = useForm<OnboardingGenerateForm>({
     defaultValues: {
@@ -85,8 +89,12 @@ export function OnboardingFeatureGenerate({ redirectTo }: { redirectTo: string }
                   strength={strength}
                 />
               </div>
+              <Button onClick={() => setRevealed((value) => !value)} type="button" variant="secondary">
+                <UiIcon icon="watch" />
+                {revealed ? t(($) => $.generateMnemonicHide) : t(($) => $.generateMnemonicShow)}
+              </Button>
             </div>
-            <OnboardingUiMnemonicShow mnemonic={mnemonic} />
+            <OnboardingUiMnemonicShow mnemonic={mnemonic} revealed={revealed} />
           </div>
         </UiCard>
       </form>

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-show.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-show.tsx
@@ -4,7 +4,7 @@ import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { useMemo } from 'react'
 import { OnboardingUiMnemonicWordReadonly } from './onboarding-ui-mnemonic-word-readonly.tsx'
 
-export function OnboardingUiMnemonicShow({ mnemonic }: { mnemonic: string }) {
+export function OnboardingUiMnemonicShow({ mnemonic, revealed }: { mnemonic: string; revealed: boolean }) {
   const { t } = useTranslation('onboarding')
   const expected = [12, 24]
   const words = useMemo(() => mnemonic.trim().split(/\s+/), [mnemonic])
@@ -19,10 +19,11 @@ export function OnboardingUiMnemonicShow({ mnemonic }: { mnemonic: string }) {
       </Alert>
     )
   }
+
   return (
     <div className={`grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-3`}>
       {words.map((word, index) => (
-        <OnboardingUiMnemonicWordReadonly index={index} key={`${index}-${word}`} word={word} />
+        <OnboardingUiMnemonicWordReadonly index={index} key={`${index}-${word}`} revealed={revealed} word={word} />
       ))}
     </div>
   )

--- a/packages/onboarding/src/ui/onboarding-ui-mnemonic-word-readonly.tsx
+++ b/packages/onboarding/src/ui/onboarding-ui-mnemonic-word-readonly.tsx
@@ -1,25 +1,29 @@
-import { Input } from '@workspace/ui/components/input'
 import { Label } from '@workspace/ui/components/label'
+import { cn } from '@workspace/ui/lib/utils'
 
-export function OnboardingUiMnemonicWordReadonly({ index, word }: { index: number; word: string }) {
+export function OnboardingUiMnemonicWordReadonly({
+  index,
+  word,
+  revealed,
+}: {
+  index: number
+  word: string
+  revealed: boolean
+}) {
   return (
-    <div className="relative">
+    <div className={cn('relative', { 'pointer-events-none select-none blur-sm': !revealed })}>
       <Label
         className="-top-2 absolute left-2 inline-block bg-white px-1 font-medium text-xs text-zinc-500 dark:bg-zinc-900 dark:text-zinc-400"
         htmlFor={`${word}-${index}`}
       >
         <span>{index + 1}</span>
       </Label>
-      <Input
-        autoComplete="off"
-        autoCorrect="off"
+      <div
         className="block w-full rounded-md border-0 bg-transparent px-3 py-2.5 text-zinc-900 shadow-sm ring-1 ring-zinc-300 ring-inset transition-all duration-150 placeholder:text-zinc-400 focus:ring-2 focus:ring-blue-600 focus:ring-inset sm:text-sm sm:leading-6 dark:text-zinc-50 dark:ring-zinc-700 dark:focus:ring-blue-500 dark:placeholder:text-zinc-500"
-        defaultValue={word}
         id={`${word}-${index}`}
-        readOnly
-        spellCheck="false"
-        type="text"
-      />
+      >
+        {word}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Description

Blurs the onboarding mnemonic by default with a toggle to show it

## Screenshots / Video

<img width="577" height="572" alt="image" src="https://github.com/user-attachments/assets/07e4b801-8d15-4521-b0e3-e0f9fe0bef79" />

## Checklist

~- [ ] Tests have been added for my change~
~- [ ] Docs have been updated for my change~

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Blur mnemonic by default in onboarding with toggle to reveal, updating UI components and translations.
> 
>   - **Behavior**:
>     - Default blurring of mnemonic in `OnboardingFeatureGenerate` with toggle button to reveal it.
>     - `OnboardingUiMnemonicShow` and `OnboardingUiMnemonicWordReadonly` updated to handle `revealed` state.
>   - **UI Components**:
>     - Added `revealed` state in `onboarding-feature-generate.tsx` to toggle mnemonic visibility.
>     - Updated `OnboardingUiMnemonicShow` to pass `revealed` prop to `OnboardingUiMnemonicWordReadonly`.
>     - Modified `OnboardingUiMnemonicWordReadonly` to apply blur effect based on `revealed` prop.
>   - **Translations**:
>     - Added `generateMnemonicHide` and `generateMnemonicShow` keys in `en/onboarding.json` and `es/onboarding.json`.
>     - Updated `resources.d.ts` to include new translation keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 921b78c458920a54b70194a3455e4ca0ab566cd1. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->