### PR TITLE
fix(tools): improve validation on airdrop form

### DIFF
--- a/packages/tools/src/ui/tools-ui-airdrop-form.tsx
+++ b/packages/tools/src/ui/tools-ui-airdrop-form.tsx
@@ -1,6 +1,6 @@
-'use client'
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema'
 import type { Account } from '@workspace/db/account/account'
+import { solanaAddressSchema } from '@workspace/db/solana/solana-address-schema'
 import type { Wallet } from '@workspace/db/wallet/wallet'
 import { Button } from '@workspace/ui/components/button'
 import {
@@ -27,7 +27,7 @@ import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 
 const formSchema = z.object({
-  address: z.string(),
+  address: solanaAddressSchema,
   amount: z.number().min(0),
 })
 
@@ -42,7 +42,7 @@ export function ToolsUiAirdropForm({
   submit: (input: AirdropFormSchema) => Promise<void>
   wallets: Wallet[]
 }) {
-  const form = useForm<z.infer<typeof formSchema>>({
+  const form = useForm({
     resolver: standardSchemaResolver(formSchema),
     values: {
       address: '',
@@ -119,7 +119,7 @@ export function ToolsUiAirdropForm({
           )}
         />
 
-        <Button disabled={disabled || !form.formState.isValid} type="submit">
+        <Button disabled={disabled} type="submit">
           Submit
         </Button>
       </form>


### PR DESCRIPTION
## Description

Ensure an address is valid

Closes #795

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves airdrop form validation by using `solanaAddressSchema` for address validation in `tools-ui-airdrop-form.tsx`.
> 
>   - **Validation**:
>     - Replaces `z.string()` with `solanaAddressSchema` for `address` in `formSchema` in `tools-ui-airdrop-form.tsx` to ensure valid Solana addresses.
>   - **Form Handling**:
>     - Removes `!form.formState.isValid` check from `Button` disabled condition in `tools-ui-airdrop-form.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 228a0b2624a186304245c5a3535e45d7c1e02c65. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->