### PR TITLE
fix(onboarding): determine new wallet name based on existing wallet

### DIFF
--- a/packages/onboarding/src/data-access/use-create-new-wallet.tsx
+++ b/packages/onboarding/src/data-access/use-create-new-wallet.tsx
@@ -1,16 +1,18 @@
 import { derivationPaths } from '@workspace/keypair/derivation-paths'
+import { useDetermineWalletName } from '@workspace/settings/data-access/use-determine-wallet-name'
 import { useGenerateWalletWithAccountMutation } from '@workspace/settings/data-access/use-generate-wallet-with-account-mutation'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 
 export function useCreateNewWallet() {
   const mutation = useGenerateWalletWithAccountMutation()
+  const name = useDetermineWalletName()
   return (mnemonic: string) =>
     mutation
       .mutateAsync({
         derivationPath: derivationPaths.default,
         mnemonic,
-        name: 'Wallet 1',
+        name,
         secret: '',
       })
       .then(() => {


### PR DESCRIPTION
## Description

Use the logic we use in the generate/import flow in the settings package to determine the next wallet name.

Closes #787


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces hardcoded wallet name with dynamic name using `useDetermineWalletName()` in `useCreateNewWallet()` function.
> 
>   - **Behavior**:
>     - Replaces hardcoded wallet name 'Wallet 1' with dynamic name using `useDetermineWalletName()` in `useCreateNewWallet()` in `use-create-new-wallet.tsx`.
>   - **Imports**:
>     - Adds import for `useDetermineWalletName` from `@workspace/settings/data-access/use-determine-wallet-name` in `use-create-new-wallet.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 0b871a8dbcbf39cf7c52cb02deaedfb77f7b8ba2. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->