### PR TITLE
feat(solana-client): add support for sending SOL to multiple recipients

### DIFF
--- a/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
@@ -1,10 +1,10 @@
-import { address, type KeyPairSigner } from '@solana/kit'
+import type { KeyPairSigner } from '@solana/kit'
 import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
 import { createAndSendSolTransaction } from '@workspace/solana-client/create-and-send-sol-transaction'
+import type { TransferRecipient } from '@workspace/solana-client/create-sol-transfer-instructions'
 import { getBalance } from '@workspace/solana-client/get-balance'
-import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
 import type { SolanaClient } from '@workspace/solana-client/solana-client'
 import { getAccountInfoQueryOptions } from '@workspace/solana-client-react/use-get-account-info'
 import { getBalanceQueryOptions } from '@workspace/solana-client-react/use-get-balance'
@@ -17,22 +17,13 @@ export function createAndSendSolTransactionMutationOptions(
   network: Network,
 ) {
   return mutationOptions({
-    mutationFn: async ({
-      amount,
-      destination,
-      sender,
-    }: {
-      amount: string
-      destination: string
-      sender: KeyPairSigner
-    }) => {
+    mutationFn: async ({ recipients, sender }: { recipients: TransferRecipient[]; sender: KeyPairSigner }) => {
       const senderBalance = await getBalance(client, { address: sender.address })
       if (!senderBalance?.value) {
         throw new Error('Balance not available')
       }
       return createAndSendSolTransaction(client, {
-        amount: solToLamports(amount),
-        destination: address(destination),
+        recipients,
         senderBalance: senderBalance.value,
         transactionSigner: sender,
       })

--- a/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
+++ b/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
@@ -1,4 +1,4 @@
-import type { Signature } from '@solana/kit'
+import { address, type Signature } from '@solana/kit'
 import { mutationOptions, useMutation } from '@tanstack/react-query'
 import { tryCatch } from '@workspace/core/try-catch'
 import type { Account } from '@workspace/db/account/account'
@@ -7,6 +7,7 @@ import { useAccountReadSecretKey } from '@workspace/db-react/use-account-read-se
 import { useNetworkActive } from '@workspace/db-react/use-network-active'
 import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
 import { NATIVE_MINT } from '@workspace/solana-client/constants'
+import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { useCreateAndSendSolTransaction } from './use-create-and-send-sol-transaction.tsx'
@@ -69,8 +70,12 @@ export function portfolioTxSendMutationOptions({
     const sender = await createKeyPairSignerFromJson({ json: secretKey })
     const { data: result, error: sendError } = await tryCatch(
       sendSolMutation.mutateAsync({
-        amount: input.amount,
-        destination: input.destination,
+        recipients: [
+          {
+            amount: solToLamports(input.amount),
+            destination: address(input.destination),
+          },
+        ],
         sender,
       }),
     )

--- a/packages/solana-client/src/create-sol-transfer-instructions.ts
+++ b/packages/solana-client/src/create-sol-transfer-instructions.ts
@@ -7,21 +7,23 @@ import {
 } from '@solana/kit'
 import { getTransferSolInstruction } from '@solana-program/system'
 
-export interface CreateSolTransferTransactionOptions {
+export interface TransferRecipient {
   amount: bigint
   destination: Address
+}
+export interface CreateSolTransferTransactionOptions {
+  recipients: TransferRecipient[]
   source: TransactionSigner
 }
 
 export function createSolTransferInstructions({
-  amount,
-  destination,
+  recipients,
   source,
 }: CreateSolTransferTransactionOptions): Instruction[] {
-  assertIsAddress(destination)
+  for (const { destination } of recipients) {
+    assertIsAddress(destination)
+  }
   assertIsTransactionSigner(source)
 
-  const transferInstruction = getTransferSolInstruction({ amount, destination, source })
-
-  return [transferInstruction]
+  return recipients.map(({ amount, destination }) => getTransferSolInstruction({ amount, destination, source }))
 }

--- a/packages/solana-client/test/create-sol-transfer-transaction.test.ts
+++ b/packages/solana-client/test/create-sol-transfer-transaction.test.ts
@@ -18,15 +18,38 @@ describe('create-sol-transfer-transaction', () => {
   describe('expected behavior', () => {
     it('should receive correct amount, destination and source', async () => {
       // ARRANGE
-      expect.assertions(1)
+      expect.assertions(2)
       const destination = address('So11111111111111111111111111111111111111112')
       const source = await generateKeyPairSigner()
 
       // ACT
-      createSolTransferInstructions({ amount: 100n, destination, source })
+      createSolTransferInstructions({ recipients: [{ amount: 100n, destination }], source })
 
       // ASSERT
+      expect(getTransferSolInstruction).toHaveBeenCalledTimes(1)
       expect(getTransferSolInstruction).toHaveBeenCalledWith({ amount: 100n, destination, source })
+    })
+
+    it('should receive correct amount, destination and source for multiple recipients', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const destinationAlice = address('So11111111111111111111111111111111111111112')
+      const destinationBob = address('So11111111111111111111111111111111111111113')
+      const source = await generateKeyPairSigner()
+
+      // ACT
+      createSolTransferInstructions({
+        recipients: [
+          { amount: 100n, destination: destinationAlice },
+          { amount: 42n, destination: destinationBob },
+        ],
+        source,
+      })
+
+      // ASSERT
+      expect(getTransferSolInstruction).toHaveBeenCalledTimes(2)
+      expect(getTransferSolInstruction).toHaveBeenCalledWith({ amount: 100n, destination: destinationAlice, source })
+      expect(getTransferSolInstruction).toHaveBeenCalledWith({ amount: 42n, destination: destinationBob, source })
     })
 
     it('should return properly structured transaction message', async () => {
@@ -36,7 +59,7 @@ describe('create-sol-transfer-transaction', () => {
       const source = await generateKeyPairSigner()
 
       // ACT
-      const result = createSolTransferInstructions({ amount: 1000000n, destination, source })
+      const result = createSolTransferInstructions({ recipients: [{ amount: 1000000n, destination }], source })
 
       // ASSERT
       expect(result).toHaveLength(1)
@@ -49,7 +72,7 @@ describe('create-sol-transfer-transaction', () => {
       const source = await generateKeyPairSigner()
 
       // ACT
-      createSolTransferInstructions({ amount: 0n, destination, source })
+      createSolTransferInstructions({ recipients: [{ amount: 0n, destination }], source })
 
       // ASSERT
       expect(getTransferSolInstruction).toHaveBeenCalledWith(
@@ -67,7 +90,7 @@ describe('create-sol-transfer-transaction', () => {
       const largeAmount = 18446744073709551615n // Max uint64
 
       // ACT
-      createSolTransferInstructions({ amount: largeAmount, destination, source })
+      createSolTransferInstructions({ recipients: [{ amount: largeAmount, destination }], source })
 
       // ASSERT
       expect(getTransferSolInstruction).toHaveBeenCalledWith(expect.objectContaining({ amount: largeAmount }))
@@ -91,9 +114,13 @@ describe('create-sol-transfer-transaction', () => {
       // ACT & ASSERT
       expect(() =>
         createSolTransferInstructions({
-          amount: 100n,
-          // @ts-expect-error: Testing invalid input
-          destination: 'invalid-address',
+          recipients: [
+            {
+              amount: 100n,
+              // @ts-expect-error: Testing invalid input
+              destination: 'invalid-address',
+            },
+          ],
           source,
         }),
       ).toThrow()


### PR DESCRIPTION
## Description

This is the first part of the preparation for the ux to add sending SOL and Tokens multiple destinations.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for sending SOL to multiple recipients in `createAndSendSolTransaction` and update related tests.
> 
>   - **Behavior**:
>     - `createAndSendSolTransaction` in `create-and-send-sol-transaction.ts` now supports multiple recipients by accepting an array of `TransferRecipient`.
>     - `createSolTransferInstructions` in `create-sol-transfer-instructions.ts` updated to handle multiple recipients.
>     - Updated `portfolioTxSendMutationOptions` in `use-portfolio-tx-send.tsx` to send SOL to multiple recipients.
>   - **Tests**:
>     - Added test for multiple recipients in `create-and-send-sol-transaction.integration.test.ts`.
>     - Updated `create-sol-transfer-transaction.test.ts` to test multiple recipients and edge cases like zero and large amounts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c0215692f38dddee5c44dc5e22a33d20becab91e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->