### PR TITLE
feat(portfolio): prepare send and confirm logic for multiple recipients

### DIFF
--- a/packages/portfolio/src/data-access/get-amount-for-mint.ts
+++ b/packages/portfolio/src/data-access/get-amount-for-mint.ts
@@ -1,0 +1,10 @@
+import { NATIVE_MINT } from '@workspace/solana-client/constants'
+import { uiAmountToBigInt } from '@workspace/solana-client/ui-amount-to-big-int'
+import type { TokenBalance } from './use-get-token-metadata.ts'
+
+export function getAmountForMint({ amount, mint }: { amount: string; mint: TokenBalance }) {
+  if (mint.mint === NATIVE_MINT) {
+    return uiAmountToBigInt(amount, 9)
+  }
+  return uiAmountToBigInt(amount, mint.decimals)
+}

--- a/packages/portfolio/src/portfolio-feature-modal-confirm.tsx
+++ b/packages/portfolio/src/portfolio-feature-modal-confirm.tsx
@@ -1,7 +1,9 @@
+import { address } from '@solana/kit'
 import { useTranslation } from '@workspace/i18n'
 import { UiError } from '@workspace/ui/components/ui-error'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
 import { useNavigate, useParams } from 'react-router'
+import { getAmountForMint } from './data-access/get-amount-for-mint.ts'
 import { usePortfolioTokenMint } from './data-access/use-portfolio-token-mint.tsx'
 import { usePortfolioTxSend } from './data-access/use-portfolio-tx-send.tsx'
 import { PortfolioUiModal } from './ui/portfolio-ui-modal.tsx'
@@ -32,16 +34,15 @@ export function PortfolioFeatureModalConfirm() {
   return (
     <PortfolioUiModal title={t(($) => $.actionConfirm)}>
       <PortfolioUiSendConfirm
-        amount={amount}
         confirm={async (input) => {
           const signature = await confirmMutation.mutateAsync(input)
           if (signature) {
             await navigate(`/modals/complete/${signature}`)
           }
         }}
-        destination={destination}
         isLoading={confirmMutation.isPending}
         mint={mint}
+        recipients={[{ amount: getAmountForMint({ amount, mint }), destination: address(destination) }]}
       />
     </PortfolioUiModal>
   )

--- a/packages/portfolio/src/ui/portfolio-ui-send-confirm.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-send-confirm.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from '@workspace/i18n'
+import type { TransferRecipient } from '@workspace/solana-client/transfer-recipient'
 import { Button } from '@workspace/ui/components/button'
 import { Field, FieldGroup, FieldLabel, FieldSet } from '@workspace/ui/components/field'
 import { Input } from '@workspace/ui/components/input'
@@ -9,21 +10,17 @@ import type { PortfolioTxSendInput } from '../data-access/use-portfolio-tx-send.
 import { PortfolioUiTokenBalanceItem } from './portfolio-ui-token-balance-item.tsx'
 
 export function PortfolioUiSendConfirm({
-  mint,
-  amount,
-  isLoading,
   confirm,
-  destination,
+  isLoading,
+  mint,
+  recipients,
 }: {
-  mint: TokenBalance
-  amount: string
-  destination: string
-  isLoading: boolean
   confirm: (input: PortfolioTxSendInput) => Promise<void>
+  isLoading: boolean
+  mint: TokenBalance
+  recipients: TransferRecipient[]
 }) {
   const { t } = useTranslation('portfolio')
-  const destinationId = useId()
-  const amountId = useId()
 
   return (
     <div>
@@ -31,45 +28,20 @@ export function PortfolioUiSendConfirm({
         <FieldGroup>
           <FieldSet>
             {mint ? <PortfolioUiTokenBalanceItem item={mint} /> : t(($) => $.searchInputSelect)}
-
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor={destinationId}>{t(($) => $.sendInputDestinationLabel)}</FieldLabel>
-                <Input
-                  defaultValue={destination}
-                  disabled
-                  id={destinationId}
-                  placeholder={t(($) => $.sendInputDestinationPlaceholder)}
-                  readOnly
-                  type="text"
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor={amountId}>{t(($) => $.sendInputAmountLabel)}</FieldLabel>
-                <Input
-                  defaultValue={amount}
-                  disabled
-                  id={amountId}
-                  min="1"
-                  placeholder={t(($) => $.sendInputAmountPlaceholder)}
-                  readOnly
-                  required
-                  step="any"
-                  type="number"
-                />
-              </Field>
-            </FieldGroup>
+            {recipients.map((recipient) => (
+              <PortfolioUiSendConfirmDestination key={recipient.destination} recipient={recipient} />
+            ))}
           </FieldSet>
           <Field className="flex justify-end" orientation="horizontal">
             <Button
               autoFocus
-              disabled={!mint || !amount || !destination || isLoading}
+              disabled={!mint || isLoading}
               onClick={async (e) => {
                 e.preventDefault()
                 if (!mint) {
                   return
                 }
-                await confirm({ amount, destination, mint })
+                await confirm({ mint, recipients })
               }}
               type="button"
             >
@@ -80,5 +52,41 @@ export function PortfolioUiSendConfirm({
         </FieldGroup>
       </form>
     </div>
+  )
+}
+
+function PortfolioUiSendConfirmDestination({ recipient: { amount, destination } }: { recipient: TransferRecipient }) {
+  const { t } = useTranslation('portfolio')
+  const destinationId = useId()
+  const amountId = useId()
+
+  return (
+    <FieldGroup>
+      <Field>
+        <FieldLabel htmlFor={destinationId}>{t(($) => $.sendInputDestinationLabel)}</FieldLabel>
+        <Input
+          defaultValue={destination}
+          disabled
+          id={destinationId}
+          placeholder={t(($) => $.sendInputDestinationPlaceholder)}
+          readOnly
+          type="text"
+        />
+      </Field>
+      <Field>
+        <FieldLabel htmlFor={amountId}>{t(($) => $.sendInputAmountLabel)}</FieldLabel>
+        <Input
+          defaultValue={amount.toString()}
+          disabled
+          id={amountId}
+          min="1"
+          placeholder={t(($) => $.sendInputAmountPlaceholder)}
+          readOnly
+          required
+          step="any"
+          type="number"
+        />
+      </Field>
+    </FieldGroup>
   )
 }


### PR DESCRIPTION
## Description

Some more refactoring that takes the concept of multiple recipients to the confirm screen.

It should still be functionally the same as how it was before (1 destination with 1 amount), what's left now is to update the UI to configure multiple of these.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor transaction confirmation logic to support multiple recipients in `portfolio` package.
> 
>   - **Behavior**:
>     - Refactor `PortfolioTxSendInput` in `use-portfolio-tx-send.tsx` to use `recipients` array instead of `amount` and `destination`.
>     - Update `portfolioTxSendMutationOptions` to handle multiple recipients for both SOL and SPL transactions.
>     - Modify `PortfolioFeatureModalConfirm` to pass `recipients` to `PortfolioUiSendConfirm`.
>   - **Functions**:
>     - Add `getAmountForMint` in `get-amount-for-mint.ts` to convert UI amount to BigInt based on mint type.
>   - **UI**:
>     - Update `PortfolioUiSendConfirm` to render multiple recipient fields using `PortfolioUiSendConfirmDestination`.
>     - Add `PortfolioUiSendConfirmDestination` component to handle individual recipient display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c01a2bd448f9261a21c8a16fbabec361eb5019ad. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->