### PR TITLE
feat(explorer): add tabs to account detail page

### DIFF
--- a/packages/explorer/src/explorer-feature-account.tsx
+++ b/packages/explorer/src/explorer-feature-account.tsx
@@ -2,6 +2,7 @@ import { assertIsAddress } from '@solana/kit'
 import { solanaAddressSchema } from '@workspace/db/solana/solana-address-schema'
 import { useNetworkActive } from '@workspace/db-react/use-network-active'
 import { UiPage } from '@workspace/ui/components/ui-page'
+import { UiTabRoutes } from '@workspace/ui/components/ui-tab-routes'
 import { useParams } from 'react-router'
 import { useExplorerBackButtonTo } from './data-access/use-explorer-back-button-to.tsx'
 import { ExplorerFeatureAccountOverview } from './explorer-feature-account-overview.tsx'
@@ -26,7 +27,16 @@ export function ExplorerFeatureAccount({ basePath }: { basePath: string }) {
           basePath={basePath}
           network={network}
         />
-        <ExplorerFeatureAccountTransactions address={address} basePath={basePath} network={network} />
+        <UiTabRoutes
+          basePath={`${basePath}/address/${address}`}
+          tabs={[
+            {
+              element: <ExplorerFeatureAccountTransactions address={address} basePath={basePath} network={network} />,
+              label: 'Transactions',
+              path: 'transactions',
+            },
+          ]}
+        />
       </div>
     </UiPage>
   )

--- a/packages/explorer/src/explorer-routes.tsx
+++ b/packages/explorer/src/explorer-routes.tsx
@@ -11,7 +11,7 @@ import { ExplorerFeatureTransaction } from './explorer-feature-transaction.tsx'
 export default function ExplorerRoutes({ basePath }: { basePath: string }) {
   return useRoutes([
     { element: <ExplorerFeatureIndex basePath={basePath} />, index: true },
-    { element: <ExplorerFeatureAccount basePath={basePath} />, path: 'address/:address' },
+    { element: <ExplorerFeatureAccount basePath={basePath} />, path: 'address/:address/*' },
     { element: <ExplorerFeatureTransaction basePath={basePath} />, path: 'tx/:signature' },
     { element: <ExplorerFeatureBookmarkAccountList basePath={basePath} />, path: 'bookmarks/account' },
     { element: <ExplorerFeatureBookmarkTransactionList basePath={basePath} />, path: 'bookmarks/transaction' },


### PR DESCRIPTION
## Description

Adds tabs to the detail page with currently a single 'transactions'  tab. 

## Screenshots / Video

<img width="915" height="931" alt="image" src="https://github.com/user-attachments/assets/544be7f6-9b8e-457a-8f36-980aa8ab0b97" />
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tabbed navigation to account detail page with a 'transactions' tab in `explorer-feature-account.tsx`.
> 
>   - **UI Changes**:
>     - Add `UiTabRoutes` to `ExplorerFeatureAccount` in `explorer-feature-account.tsx` for tabbed navigation.
>     - Introduce 'Transactions' tab displaying `ExplorerFeatureAccountTransactions`.
>   - **Routing**:
>     - Update path in `explorer-routes.tsx` to `address/:address/*` to support nested routes for tabs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for edede1bc295676b35f9b7339327ba57c249a861a. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->