### PR TITLE
feat(explorer): add accounts and logs to tx details

### DIFF
--- a/cspell.config.mts
+++ b/cspell.config.mts
@@ -60,6 +60,7 @@ const config: CSpellSettings = {
     'skia',
     'solscan',
     'surfpool',
+    'sysvar',
     'testnet',
     'tobeycodes',
     'unimodules',

--- a/packages/explorer/src/data-access/use-explorer-get-transaction.ts
+++ b/packages/explorer/src/data-access/use-explorer-get-transaction.ts
@@ -33,7 +33,7 @@ export type ExplorerGetTransactionResult = Awaited<ReturnType<typeof getTransact
 async function getTransaction(client: SolanaClient, signature: Signature) {
   return client.rpc
     .getTransaction(signature, {
-      encoding: 'json',
+      encoding: 'jsonParsed',
       maxSupportedTransactionVersion: 0,
     })
     .send()

--- a/packages/explorer/src/explorer-feature-transaction.tsx
+++ b/packages/explorer/src/explorer-feature-transaction.tsx
@@ -8,6 +8,7 @@ import { useExplorerBackButtonTo } from './data-access/use-explorer-back-button-
 import { ExplorerFeatureBookmarkTransactionButton } from './explorer-feature-bookmark-transaction-button.tsx'
 import { ExplorerFeatureTransactionDetails } from './explorer-feature-transaction-details.tsx'
 import { ExplorerUiErrorPage } from './ui/explorer-ui-error-page.tsx'
+import { ExplorerUiExplorers } from './ui/explorer-ui-explorers.tsx'
 
 export function ExplorerFeatureTransaction({ basePath }: { basePath: string }) {
   const network = useNetworkActive()
@@ -32,6 +33,7 @@ export function ExplorerFeatureTransaction({ basePath }: { basePath: string }) {
           </div>
         }
         backButtonTo={backButtonTo}
+        description={<ExplorerUiExplorers network={network} path={`/tx/${signature}`} />}
         title="Transaction"
       >
         <ExplorerFeatureTransactionDetails basePath={basePath} network={network} signature={signature} />

--- a/packages/explorer/src/ui/explorer-ui-balance-sol-diff.tsx
+++ b/packages/explorer/src/ui/explorer-ui-balance-sol-diff.tsx
@@ -1,0 +1,24 @@
+import { type Lamports, lamports } from '@solana/kit'
+import { Badge } from '@workspace/ui/components/badge'
+import { getColorByName } from '@workspace/ui/lib/get-initials-colors'
+import { cn } from '@workspace/ui/lib/utils'
+import { formatBalance } from '../data-access/format-balance.tsx'
+
+export function ExplorerUiBalanceSolDiff({ post, pre }: { post?: Lamports | undefined; pre?: Lamports | undefined }) {
+  const green = getColorByName('green')
+  const red = getColorByName('red')
+  const diff = (post ?? lamports(0n)) - (pre ?? lamports(0n))
+
+  return (
+    <Badge
+      className={cn({
+        [`${green.bg} ${green.text}`]: diff > 0,
+        [`${red.bg} ${red.text}`]: diff < 0,
+      })}
+      variant={diff === 0n ? 'outline' : undefined}
+    >
+      {diff > 0 ? '+' : null}
+      {formatBalance({ balance: diff, decimals: 9 })}
+    </Badge>
+  )
+}

--- a/packages/explorer/src/ui/explorer-ui-program-label.tsx
+++ b/packages/explorer/src/ui/explorer-ui-program-label.tsx
@@ -1,14 +1,18 @@
-import type { Address } from '@solana/kit'
+import { type Address, address } from '@solana/kit'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from '@workspace/solana-client/constants'
 import { Badge } from '@workspace/ui/components/badge'
+import { ExplorerUiAddress } from './explorer-ui-address.tsx'
+
+const tokens = new Map<Address, string>()
+  .set(TOKEN_2022_PROGRAM_ADDRESS, 'Token 2022')
+  .set(TOKEN_PROGRAM_ADDRESS, 'Token')
+  .set(address('11111111111111111111111111111111'), 'System Program')
+  .set(address('SysvarRent111111111111111111111111111111111'), 'Sysvar: Rent')
 
 export function ExplorerUiProgramLabel({ address }: { address: Address }) {
-  switch (address) {
-    case TOKEN_PROGRAM_ADDRESS:
-      return <Badge variant="outline">Token</Badge>
-    case TOKEN_2022_PROGRAM_ADDRESS:
-      return <Badge variant="outline">Token 2022</Badge>
-    default:
-      return null
+  const found = tokens.get(address)
+  if (!found) {
+    return <ExplorerUiAddress address={address} />
   }
+  return <Badge variant="outline">{found}</Badge>
 }

--- a/packages/explorer/src/ui/explorer-ui-tx-accounts.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-accounts.tsx
@@ -1,0 +1,57 @@
+import { lamports } from '@solana/kit'
+import { useTranslation } from '@workspace/i18n'
+import { Badge } from '@workspace/ui/components/badge'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
+import { formatBalance } from '../data-access/format-balance.tsx'
+import type { ExplorerGetTransactionResult } from '../data-access/use-explorer-get-transaction.ts'
+import { ExplorerUiBalanceSolDiff } from './explorer-ui-balance-sol-diff.tsx'
+import { ExplorerUiLinkAddress } from './explorer-ui-link-address.tsx'
+import { ExplorerUiProgramLabel } from './explorer-ui-program-label.tsx'
+
+export function ExplorerUiTxAccounts({ basePath, tx }: { basePath: string; tx: ExplorerGetTransactionResult }) {
+  const { t } = useTranslation('explorer')
+  if (!tx) {
+    return null
+  }
+  const accounts = tx.transaction.message.accountKeys
+  if (!accounts) {
+    return null
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="hover:bg-transparent">
+          <TableHead>{t(($) => $.account)}</TableHead>
+          <TableHead>{t(($) => $.change)} (SOL)</TableHead>
+          <TableHead>{t(($) => $.postBalance)} (SOL)</TableHead>
+          <TableHead>{t(($) => $.details)}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {accounts.map((item, idx) => (
+          <TableRow key={item.pubkey}>
+            <TableCell className="md:w-[350px]">
+              <ExplorerUiLinkAddress
+                address={item.pubkey}
+                basePath={basePath}
+                className="text-xs"
+                label={<ExplorerUiProgramLabel address={item.pubkey} />}
+              />
+            </TableCell>
+            <TableCell className="font-mono md:w-[100px]">
+              <ExplorerUiBalanceSolDiff post={tx.meta?.postBalances[idx]} pre={tx.meta?.preBalances[idx]} />
+            </TableCell>
+            <TableCell className="font-mono text-xs">
+              {formatBalance({ balance: tx.meta?.postBalances[idx] ?? lamports(0n), decimals: 9 })}
+            </TableCell>
+            <TableCell className="space-x-2">
+              {item.signer ? <Badge variant="secondary">Signer</Badge> : null}
+              {item.writable ? <Badge variant="destructive">Writable</Badge> : null}
+              {idx === 0 ? <Badge variant="default">Fee payer</Badge> : null}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/packages/explorer/src/ui/explorer-ui-tx-details.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-details.tsx
@@ -1,11 +1,13 @@
+import type { Signature } from '@solana/kit'
 import type { Network } from '@workspace/db/network/network'
 import { Separator } from '@workspace/ui/components/separator'
 import { UiDebug } from '@workspace/ui/components/ui-debug'
 import type { ExplorerGetTransactionResult } from '../data-access/use-explorer-get-transaction.ts'
 import { ExplorerUiDetailGrid } from './explorer-ui-detail-grid.tsx'
 import { ExplorerUiDetailRow } from './explorer-ui-detail-row.tsx'
-import { ExplorerUiExplorers } from './explorer-ui-explorers.tsx'
 import { ExplorerUiLinkAddress } from './explorer-ui-link-address.tsx'
+import { ExplorerUiSignature } from './explorer-ui-signature.tsx'
+import { ExplorerUiTxAccounts } from './explorer-ui-tx-accounts.tsx'
 import { ExplorerUiTxTimestamp } from './explorer-ui-tx-timestamp.tsx'
 
 function getTxStatus(tx: ExplorerGetTransactionResult) {
@@ -21,7 +23,7 @@ export function ExplorerUiTxDetails({
 }: {
   basePath: string
   network: Network
-  signature: string
+  signature: Signature
   tx: ExplorerGetTransactionResult
 }) {
   if (!tx) {
@@ -30,22 +32,21 @@ export function ExplorerUiTxDetails({
   const feePayer = tx.transaction.message.accountKeys[0]
   return (
     <ExplorerUiDetailGrid>
-      <ExplorerUiDetailRow
-        label="View on Explorer"
-        value={<ExplorerUiExplorers network={network} path={`/tx/${signature}`} />}
-      />
-      <Separator />
-      <ExplorerUiDetailRow label="Signature" value={signature} />
+      <ExplorerUiDetailRow label="Signature" value={<ExplorerUiSignature signature={signature} />} />
       <Separator />
       <ExplorerUiDetailGrid cols={2}>
         <ExplorerUiDetailRow label="Status" value={getTxStatus(tx)} />
         <ExplorerUiDetailRow label="Network" value={network.type} />
         <ExplorerUiDetailRow
           label="Fee Payer"
-          value={feePayer ? <ExplorerUiLinkAddress address={feePayer} basePath={basePath} /> : <div />}
+          value={feePayer ? <ExplorerUiLinkAddress address={feePayer.pubkey} basePath={basePath} /> : <div />}
         />
         <ExplorerUiDetailRow label="Timestamp" value={<ExplorerUiTxTimestamp blockTime={tx.blockTime} />} />
       </ExplorerUiDetailGrid>
+      <Separator />
+      <ExplorerUiTxAccounts basePath={basePath} tx={tx} />
+      <Separator />
+      <ExplorerUiDetailRow label="Program Instruction Logs" value={<UiDebug data={tx.meta?.logMessages ?? []} />} />
       <Separator />
       <ExplorerUiDetailRow label="Raw TX" value={<UiDebug data={tx} />} />
     </ExplorerUiDetailGrid>

--- a/packages/i18n/locales/en/explorer.json
+++ b/packages/i18n/locales/en/explorer.json
@@ -26,6 +26,8 @@
   "bookmarkTransactionDescription": "List of transactions you bookmarked",
   "bookmarkTransactionEmpty": "You have no transaction bookmarks yet.",
   "bookmarkTransactionTitle": "Transaction bookmarks",
+  "change": "Change",
+  "details": "Details",
   "editLabel": "Edit label",
   "inputSearchPlaceholder": "Search account or transaction",
   "label": "Label",
@@ -36,5 +38,6 @@
   "owner": "Owner",
   "pageExplorerDescription": "Search and explore accounts or transactions",
   "pageExplorerTitle": "Explorer",
+  "postBalance": "Post balance",
   "signature": "Signature"
 }

--- a/packages/i18n/locales/es/explorer.json
+++ b/packages/i18n/locales/es/explorer.json
@@ -26,6 +26,8 @@
   "bookmarkTransactionDescription": "Lista de transacciones etiquetadas",
   "bookmarkTransactionEmpty": "Aún no tienes transacciones etiquetadas",
   "bookmarkTransactionTitle": "Transacciones etiquetadas",
+  "change": "Cambio",
+  "details": "Detalles",
   "editLabel": "Editar nombre",
   "inputSearchPlaceholder": "Buscar cuenta o transacción",
   "label": "Etiqueta",
@@ -36,5 +38,6 @@
   "owner": "Owner",
   "pageExplorerDescription": "Buscar y explorar cuentas o transacciones",
   "pageExplorerTitle": "Explorador",
+  "postBalance": "Saldo posterior",
   "signature": "Firma"
 }

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -28,6 +28,8 @@ interface Resources {
     bookmarkTransactionDescription: 'List of transactions you bookmarked'
     bookmarkTransactionEmpty: 'You have no transaction bookmarks yet.'
     bookmarkTransactionTitle: 'Transaction bookmarks'
+    change: 'Change'
+    details: 'Details'
     editLabel: 'Edit label'
     inputSearchPlaceholder: 'Search account or transaction'
     label: 'Label'
@@ -38,6 +40,7 @@ interface Resources {
     owner: 'Owner'
     pageExplorerDescription: 'Search and explore accounts or transactions'
     pageExplorerTitle: 'Explorer'
+    postBalance: 'Post balance'
     signature: 'Signature'
   }
   onboarding: {


### PR DESCRIPTION
## Description

Render tx accounts and program logs.

## Screenshots / Video

<img width="838" height="1192" alt="image" src="https://github.com/user-attachments/assets/250db3f1-d240-45e1-909d-1f356f8ffed6" />
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add transaction account and program log rendering to explorer with new UI components and i18n updates.
> 
>   - **Behavior**:
>     - Render transaction accounts and program logs in `explorer-ui-tx-details.tsx`.
>     - Change transaction fetching to `jsonParsed` encoding in `use-explorer-get-transaction.ts`.
>   - **UI Components**:
>     - Add `ExplorerUiBalanceSolDiff` to display SOL balance differences.
>     - Add `ExplorerUiProgramLabel` to label program addresses.
>     - Add `ExplorerUiTxAccounts` to list transaction accounts.
>   - **i18n**:
>     - Add new labels `change`, `details`, and `postBalance` to `en/explorer.json` and `es/explorer.json`.
>   - **Misc**:
>     - Add `sysvar` to `cspell.config.mts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for a1f59d59f8364e395ee4adcb18d9f48b22e77dd6. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->