### PR TITLE
chore: replace ts-expect-error with assertion

### DIFF
--- a/examples/basic/src/components/sign-transaction.tsx
+++ b/examples/basic/src/components/sign-transaction.tsx
@@ -1,6 +1,7 @@
 import {
   address,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -51,13 +52,11 @@ export function SignTransaction({ account }: SignTransactionProps) {
         const signedTransaction = await signTransactionMessageWithSigners(transactionMessage)
         console.log('Signed Transaction:', signedTransaction)
 
-        await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-          // @ts-expect-error TODO: Figure out "Property lastValidBlockHeight is missing in type TransactionDurableNonceLifetime but required in type"
-          signedTransaction,
-          {
-            commitment: 'confirmed',
-          },
-        )
+        assertIsTransactionWithBlockhashLifetime(signedTransaction)
+
+        await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(signedTransaction, {
+          commitment: 'confirmed',
+        })
         const transactionSignature = getSignatureFromTransaction(signedTransaction)
         console.log('Transaction Signature:', transactionSignature)
       }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `@ts-expect-error` with `assertIsTransactionWithBlockhashLifetime` in `sign-transaction.tsx` for type safety.
> 
>   - **Behavior**:
>     - Replaces `@ts-expect-error` with `assertIsTransactionWithBlockhashLifetime` in `sign-transaction.tsx` to ensure `signedTransaction` has `blockhash` lifetime.
>   - **Functions**:
>     - Adds `assertIsTransactionWithBlockhashLifetime` call before `sendAndConfirmTransactionFactory` to validate transaction type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3da0a5b670f26a919bd4962644752065f22d5a03. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->