### PR TITLE
fix: ensure airdrop amount is greater than 0

### DIFF
--- a/packages/tools/src/ui/tools-ui-airdrop-form.tsx
+++ b/packages/tools/src/ui/tools-ui-airdrop-form.tsx
@@ -28,7 +28,7 @@ import { z } from 'zod'
 
 const formSchema = z.object({
   address: solanaAddressSchema,
-  amount: z.number().min(0),
+  amount: z.number().gt(0, 'Amount must be greater than 0'),
 })
 
 export type AirdropFormSchema = z.infer<typeof formSchema>


### PR DESCRIPTION
## Description

Ensure airdrop tools form amount is greater than 0

Closes #792

## Screenshots / Video

<img width="396" height="444" alt="image" src="https://github.com/user-attachments/assets/1afd78a5-2370-4643-930c-b2e1f20f9d4b" />
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `amount` in `tools-ui-airdrop-form.tsx` is validated to be greater than 0.
> 
>   - **Validation**:
>     - Update `formSchema` in `tools-ui-airdrop-form.tsx` to require `amount` to be greater than 0 using `z.number().gt(0, 'Amount must be greater than 0')`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 23dc81c921765a96687cad1fe0219c7cacc03b57. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->