### PR TITLE
refactor: use consistent toast links

### DIFF
--- a/packages/explorer/src/ui/explorer-ui-explorer-link.tsx
+++ b/packages/explorer/src/ui/explorer-ui-explorer-link.tsx
@@ -14,14 +14,14 @@ export function ExplorerUiExplorerLink({
   const name = getExplorerName(props.provider)
   return (
     <a
-      className={cn('link inline-flex gap-1 font-mono', className)}
+      className={cn('inline-flex items-center gap-1 font-mono hover:underline', className)}
       href={href}
       rel="noopener noreferrer"
       target="_blank"
       title={`View in ${name}`}
     >
       {label ?? name}
-      <UiIcon className="size-3" icon="externalLink" />
+      <UiIcon className="size-3 shrink-0" icon="externalLink" />
     </a>
   )
 }

--- a/packages/solana-client-react/src/use-request-airdrop.tsx
+++ b/packages/solana-client-react/src/use-request-airdrop.tsx
@@ -3,6 +3,7 @@ import type { Network } from '@workspace/db/network/network'
 import type { RequestAirdropOption } from '@workspace/solana-client/request-airdrop'
 import { requestAirdrop } from '@workspace/solana-client/request-airdrop'
 import type { SolanaClient } from '@workspace/solana-client/solana-client'
+import { UiToastLink } from '@workspace/ui/components/ui-toast-link'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { getAccountInfoQueryOptions } from './use-get-account-info.tsx'
@@ -14,14 +15,14 @@ export function requestAirdropMutationOptions(client: SolanaClient, queryClient:
     mutationFn: (input: RequestAirdropOption) => requestAirdrop(client, input),
     onError: () => {
       toastError(
-        <a
-          className="block cursor-pointer underline hover:no-underline"
-          href="https://faucet.solana.com/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          Failed to request airdrop. Click here to try the faucet directly.
-        </a>,
+        network.type === 'solana:localnet' ? (
+          'Failed to request airdrop. Make sure your local validator is running.'
+        ) : (
+          <UiToastLink
+            href="https://faucet.solana.com/"
+            label="Failed to request airdrop. Click here to try the faucet directly."
+          />
+        ),
       )
     },
     onSuccess: (_, { address }) => {

--- a/packages/ui/src/components/ui-toast-link.tsx
+++ b/packages/ui/src/components/ui-toast-link.tsx
@@ -1,0 +1,16 @@
+import { UiIcon } from '@workspace/ui/components/ui-icon'
+import { cn } from '@workspace/ui/lib/utils'
+
+export function UiToastLink({ className, label, href }: { className?: string; label?: string; href: string }) {
+  return (
+    <a
+      className={cn('inline-flex items-center gap-1 font-mono hover:underline', className)}
+      href={href}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <span>{label}</span>
+      <UiIcon className="size-3 shrink-0" icon="externalLink" />
+    </a>
+  )
+}


### PR DESCRIPTION
## Description

The view in explorer variation was removed in https://github.com/samui-build/samui-wallet/pull/795 but this change creates a reusable ui toast link component to replace the toast error used when a airdrop failed. This can be reused going forward for other links we may use in toasts.

Closes https://github.com/samui-build/samui-wallet/issues/790

## Screenshots / Video

<img width="415" height="147" alt="image" src="https://github.com/user-attachments/assets/a2b74227-88ee-43f1-b035-e752a55592e3" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce `UiToastLink` for consistent toast link styling and update `use-request-airdrop.tsx` to use it for error links.
> 
>   - **Components**:
>     - Introduce `UiToastLink` in `ui-toast-link.tsx` for consistent toast link styling.
>     - Update `ExplorerUiExplorerLink` in `explorer-ui-explorer-link.tsx` to refine link styling.
>   - **Behavior**:
>     - Replace inline error link with `UiToastLink` in `use-request-airdrop.tsx` for failed airdrop errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 3c43809b649007e883a3c0d78d99aa4565f65b42. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->