### PR TITLE
feat(explorer): highlight accounts on hover

### DIFF
--- a/packages/explorer/src/data-access/use-address-hover.ts
+++ b/packages/explorer/src/data-access/use-address-hover.ts
@@ -1,0 +1,19 @@
+import type { Address } from '@solana/kit'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+export function useAddressHover(address: Address) {
+  const queryClient = useQueryClient()
+  const queryKey = ['address-hover', address]
+
+  const { data: hoverCount } = useQuery({
+    initialData: 0,
+    queryFn: () => 0,
+    queryKey,
+    staleTime: Infinity,
+  })
+
+  const onMouseEnter = () => queryClient.setQueryData(queryKey, (old: number = 0) => old + 1)
+  const onMouseLeave = () => queryClient.setQueryData(queryKey, (old: number = 0) => Math.max(0, old - 1))
+
+  return { isHovered: (hoverCount ?? 0) > 0, onMouseEnter, onMouseLeave }
+}

--- a/packages/explorer/src/ui/explorer-ui-address-hover.tsx
+++ b/packages/explorer/src/ui/explorer-ui-address-hover.tsx
@@ -1,0 +1,28 @@
+import type { Address } from '@solana/kit'
+import { cn } from '@workspace/ui/lib/utils'
+import type { ComponentProps } from 'react'
+import { useAddressHover } from '../data-access/use-address-hover.ts'
+
+export function ExplorerUiAddressHover({
+  address,
+  className,
+  children,
+  ...props
+}: { address: Address } & ComponentProps<'div'>) {
+  const { isHovered, onMouseEnter, onMouseLeave } = useAddressHover(address)
+
+  return (
+    <span
+      className={cn('transition-colors duration-200', className, {
+        'text-foreground': isHovered,
+        'text-muted-foreground': !isHovered,
+      })}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      role="tooltip"
+      {...props}
+    >
+      {children}
+    </span>
+  )
+}

--- a/packages/explorer/src/ui/explorer-ui-address.tsx
+++ b/packages/explorer/src/ui/explorer-ui-address.tsx
@@ -1,13 +1,14 @@
 import type { Address } from '@solana/kit'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { ExplorerUiAddressHover } from './explorer-ui-address-hover.tsx'
 
 export function ExplorerUiAddress({ address }: { address: Address }) {
   return (
-    <>
+    <ExplorerUiAddressHover address={address}>
       <span className="hidden lg:block">{address}</span>
       <span className="lg:hidden" title={address}>
         {ellipsify(address, 6, '...')}
       </span>
-    </>
+    </ExplorerUiAddressHover>
   )
 }

--- a/packages/explorer/src/ui/explorer-ui-program-label.tsx
+++ b/packages/explorer/src/ui/explorer-ui-program-label.tsx
@@ -11,6 +11,7 @@ const tokens = new Map<Address, string>()
 
 export function ExplorerUiProgramLabel({ address }: { address: Address }) {
   const found = tokens.get(address)
+
   if (!found) {
     return <ExplorerUiAddress address={address} />
   }


### PR DESCRIPTION
## Description

If you hover over an account, all other occurrences of that account on the page will be highlighted.

## Screenshots / Video
<img width="1055" height="356" alt="image" src="https://github.com/user-attachments/assets/026252a7-8341-4b86-be7a-2c28a6ef1b2f" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds hover effect to highlight all occurrences of an account address on the explorer page.
> 
>   - **Behavior**:
>     - Introduces hover effect for account addresses, highlighting all occurrences on the page.
>     - `useAddressHover` hook in `use-address-hover.ts` manages hover state using `react-query`.
>   - **Components**:
>     - New `ExplorerUiAddressHover` component in `explorer-ui-address-hover.tsx` applies hover effect with `onMouseEnter` and `onMouseLeave` handlers.
>     - Updates `ExplorerUiAddress` in `explorer-ui-address.tsx` to wrap address display with `ExplorerUiAddressHover`.
>     - Adjusts `ExplorerUiProgramLabel` in `explorer-ui-program-label.tsx` to use updated `ExplorerUiAddress`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for c41c78730c3edd5eb4cfb67096324a9bddfd2b14. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->