### PR TITLE
feat(explorer): add token balances to transaction detail screen

### DIFF
--- a/packages/explorer/src/ui/explorer-ui-balance-diff.tsx
+++ b/packages/explorer/src/ui/explorer-ui-balance-diff.tsx
@@ -4,7 +4,15 @@ import { getColorByName } from '@workspace/ui/lib/get-initials-colors'
 import { cn } from '@workspace/ui/lib/utils'
 import { formatBalance } from '../data-access/format-balance.tsx'
 
-export function ExplorerUiBalanceSolDiff({ post, pre }: { post?: Lamports | undefined; pre?: Lamports | undefined }) {
+export function ExplorerUiBalanceDiff({
+  decimals,
+  post,
+  pre,
+}: {
+  decimals: number
+  post?: Lamports | bigint | undefined
+  pre?: Lamports | bigint | undefined
+}) {
   const green = getColorByName('green')
   const red = getColorByName('red')
   const diff = (post ?? lamports(0n)) - (pre ?? lamports(0n))
@@ -18,7 +26,7 @@ export function ExplorerUiBalanceSolDiff({ post, pre }: { post?: Lamports | unde
       variant={diff === 0n ? 'outline' : undefined}
     >
       {diff > 0 ? '+' : null}
-      {formatBalance({ balance: diff, decimals: 9 })}
+      {formatBalance({ balance: diff, decimals })}
     </Badge>
   )
 }

--- a/packages/explorer/src/ui/explorer-ui-tx-accounts.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-accounts.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@workspace/ui/components/badge'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
 import { formatBalance } from '../data-access/format-balance.tsx'
 import type { ExplorerGetTransactionResult } from '../data-access/use-explorer-get-transaction.ts'
-import { ExplorerUiBalanceSolDiff } from './explorer-ui-balance-sol-diff.tsx'
+import { ExplorerUiBalanceDiff } from './explorer-ui-balance-diff.tsx'
 import { ExplorerUiLinkAddress } from './explorer-ui-link-address.tsx'
 import { ExplorerUiProgramLabel } from './explorer-ui-program-label.tsx'
 
@@ -39,7 +39,7 @@ export function ExplorerUiTxAccounts({ basePath, tx }: { basePath: string; tx: E
               />
             </TableCell>
             <TableCell className="font-mono md:w-[100px]">
-              <ExplorerUiBalanceSolDiff post={tx.meta?.postBalances[idx]} pre={tx.meta?.preBalances[idx]} />
+              <ExplorerUiBalanceDiff decimals={9} post={tx.meta?.postBalances[idx]} pre={tx.meta?.preBalances[idx]} />
             </TableCell>
             <TableCell className="font-mono text-xs">
               {formatBalance({ balance: tx.meta?.postBalances[idx] ?? lamports(0n), decimals: 9 })}

--- a/packages/explorer/src/ui/explorer-ui-tx-details.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-details.tsx
@@ -9,6 +9,7 @@ import { ExplorerUiLinkAddress } from './explorer-ui-link-address.tsx'
 import { ExplorerUiSignature } from './explorer-ui-signature.tsx'
 import { ExplorerUiTxAccounts } from './explorer-ui-tx-accounts.tsx'
 import { ExplorerUiTxTimestamp } from './explorer-ui-tx-timestamp.tsx'
+import { ExplorerUiTxTokenBalances } from './explorer-ui-tx-token-balances.tsx'
 
 function getTxStatus(tx: ExplorerGetTransactionResult) {
   // @ts-expect-error figure out how to properly type the 'Ok' property.
@@ -45,6 +46,7 @@ export function ExplorerUiTxDetails({
       </ExplorerUiDetailGrid>
       <Separator />
       <ExplorerUiTxAccounts basePath={basePath} tx={tx} />
+      <ExplorerUiTxTokenBalances basePath={basePath} tx={tx} />
       <Separator />
       <ExplorerUiDetailRow label="Program Instruction Logs" value={<UiDebug data={tx.meta?.logMessages ?? []} />} />
       <Separator />

--- a/packages/explorer/src/ui/explorer-ui-tx-token-balances.tsx
+++ b/packages/explorer/src/ui/explorer-ui-tx-token-balances.tsx
@@ -1,0 +1,65 @@
+import { useTranslation } from '@workspace/i18n'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
+import type { ExplorerGetTransactionResult } from '../data-access/use-explorer-get-transaction.ts'
+import { ExplorerUiBalanceDiff } from './explorer-ui-balance-diff.tsx'
+import { ExplorerUiLinkAddress } from './explorer-ui-link-address.tsx'
+import { ExplorerUiProgramLabel } from './explorer-ui-program-label.tsx'
+
+export function ExplorerUiTxTokenBalances({ basePath, tx }: { basePath: string; tx: ExplorerGetTransactionResult }) {
+  const { t } = useTranslation('explorer')
+  if (!tx) {
+    return null
+  }
+  const accountKeys = tx.transaction.message.accountKeys ?? []
+  const preTokenBalances = tx.meta?.preTokenBalances
+  const postTokenBalances = tx.meta?.postTokenBalances
+  if (!postTokenBalances?.length || !preTokenBalances?.length) {
+    return null
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="hover:bg-transparent">
+          <TableHead>{t(($) => $.address)}</TableHead>
+          <TableHead>{t(($) => $.token)}</TableHead>
+          <TableHead className="text-right">{t(($) => $.change)}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {postTokenBalances.map((item) => {
+          const token = accountKeys[item.accountIndex]?.pubkey
+          const decimals = item.uiTokenAmount.decimals ?? 0
+          const postBalance = BigInt(item.uiTokenAmount.amount)
+          const preBalance = BigInt(
+            preTokenBalances.find((pre) => pre.accountIndex === item.accountIndex)?.uiTokenAmount.amount ?? 0n,
+          )
+          return (
+            <TableRow key={item.accountIndex.toString()}>
+              <TableCell className="md:w-[350px]">
+                {token ? (
+                  <ExplorerUiLinkAddress
+                    address={token}
+                    basePath={basePath}
+                    className="text-xs"
+                    label={<ExplorerUiProgramLabel address={token} />}
+                  />
+                ) : null}
+              </TableCell>
+              <TableCell className="font-mono md:w-[100px]">
+                <ExplorerUiLinkAddress
+                  address={item.mint}
+                  basePath={basePath}
+                  className="text-xs"
+                  label={<ExplorerUiProgramLabel address={item.mint} />}
+                />
+              </TableCell>
+              <TableCell className="text-right font-mono text-xs">
+                <ExplorerUiBalanceDiff decimals={decimals} post={postBalance} pre={preBalance} />
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}

--- a/packages/i18n/locales/en/explorer.json
+++ b/packages/i18n/locales/en/explorer.json
@@ -39,5 +39,6 @@
   "pageExplorerDescription": "Search and explore accounts or transactions",
   "pageExplorerTitle": "Explorer",
   "postBalance": "Post balance",
-  "signature": "Signature"
+  "signature": "Signature",
+  "token": "Token"
 }

--- a/packages/i18n/locales/es/explorer.json
+++ b/packages/i18n/locales/es/explorer.json
@@ -39,5 +39,6 @@
   "pageExplorerDescription": "Buscar y explorar cuentas o transacciones",
   "pageExplorerTitle": "Explorador",
   "postBalance": "Saldo posterior",
-  "signature": "Firma"
+  "signature": "Firma",
+  "token": "Tokens"
 }

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -42,6 +42,7 @@ interface Resources {
     pageExplorerTitle: 'Explorer'
     postBalance: 'Post balance'
     signature: 'Signature'
+    token: 'Token'
   }
   onboarding: {
     generateButtonCreate: 'Create wallet'


### PR DESCRIPTION
## Description

Shows the changes in token balances similar to how Solana Explorer does this.

## Screenshots / Video

<img width="899" height="505" alt="image" src="https://github.com/user-attachments/assets/69a6b19f-e97c-4bb6-bc4d-316730e5e24b" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds token balance changes to transaction details, renames a component, and updates translations.
> 
>   - **Behavior**:
>     - Adds `ExplorerUiTxTokenBalances` component in `explorer-ui-tx-token-balances.tsx` to display token balance changes.
>     - Updates `ExplorerUiTxDetails` in `explorer-ui-tx-details.tsx` to include token balances.
>   - **Components**:
>     - Renames `ExplorerUiBalanceSolDiff` to `ExplorerUiBalanceDiff` and updates its parameters to handle decimals.
>     - Updates `ExplorerUiTxAccounts` in `explorer-ui-tx-accounts.tsx` to use `ExplorerUiBalanceDiff` with decimals.
>   - **Translations**:
>     - Adds "token" key to `explorer.json` in both `en` and `es` locales.
>     - Updates `resources.d.ts` to include the new "token" translation key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for bd1308f090c69dfc58048893694b4e3341c0b62b. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->