### PR TITLE
fix(explorer): change address hover to boolean

### DIFF
--- a/packages/explorer/src/data-access/use-address-hover.ts
+++ b/packages/explorer/src/data-access/use-address-hover.ts
@@ -5,15 +5,15 @@ export function useAddressHover(address: Address) {
   const queryClient = useQueryClient()
   const queryKey = ['address-hover', address]
 
-  const { data: hoverCount } = useQuery({
-    initialData: 0,
-    queryFn: () => 0,
+  const { data: isHovered } = useQuery({
+    initialData: false,
+    queryFn: () => false,
     queryKey,
     staleTime: Infinity,
   })
 
-  const onMouseEnter = () => queryClient.setQueryData(queryKey, (old: number = 0) => old + 1)
-  const onMouseLeave = () => queryClient.setQueryData(queryKey, (old: number = 0) => Math.max(0, old - 1))
+  const onMouseEnter = () => queryClient.setQueryData(queryKey, () => true)
+  const onMouseLeave = () => queryClient.setQueryData(queryKey, () => false)
 
-  return { isHovered: (hoverCount ?? 0) > 0, onMouseEnter, onMouseLeave }
+  return { isHovered, onMouseEnter, onMouseLeave }
 }


### PR DESCRIPTION
## Description

This simplifies the logic for the address hover hook to ensure we don't get cached stale hovers. 

Someone either hovers over an address or they don't, we're not interested in the amount. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies address hover logic in `use-address-hover.ts` by changing hover state from count to boolean.
> 
>   - **Behavior**:
>     - Changes hover state from count to boolean in `useAddressHover()` in `use-address-hover.ts`.
>     - `onMouseEnter` sets hover state to `true`, `onMouseLeave` sets it to `false`.
>     - Removes logic for incrementing/decrementing hover count.
>   - **Misc**:
>     - Updates `data` variable from `hoverCount` to `isHovered` in `use-address-hover.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 6cf0f8114d4d633e11c9eb84ab8b5cdc9c693e45. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->