### PR TITLE
feat(portfolio): add `useGetActiveAccountKeyPairSigner` hook

### DIFF
--- a/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
@@ -17,15 +17,21 @@ export function createAndSendSolTransactionMutationOptions(
   network: Network,
 ) {
   return mutationOptions({
-    mutationFn: async ({ recipients, sender }: { recipients: TransferRecipient[]; sender: KeyPairSigner }) => {
-      const senderBalance = await getBalance(client, { address: sender.address })
+    mutationFn: async ({
+      recipients,
+      transactionSigner,
+    }: {
+      recipients: TransferRecipient[]
+      transactionSigner: KeyPairSigner
+    }) => {
+      const senderBalance = await getBalance(client, { address: transactionSigner.address })
       if (!senderBalance?.value) {
         throw new Error('Balance not available')
       }
       return createAndSendSolTransaction(client, {
         recipients,
         senderBalance: senderBalance.value,
-        transactionSigner: sender,
+        transactionSigner,
       })
     },
     onSuccess: () => {

--- a/packages/portfolio/src/data-access/use-get-active-account-key-pair-signer.tsx
+++ b/packages/portfolio/src/data-access/use-get-active-account-key-pair-signer.tsx
@@ -1,0 +1,17 @@
+import type { KeyPairSigner } from '@solana/kit'
+import { useAccountActive } from '@workspace/db-react/use-account-active'
+import { useAccountReadSecretKey } from '@workspace/db-react/use-account-read-secret-key'
+import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
+
+export function useGetActiveAccountKeyPairSigner(): () => Promise<KeyPairSigner> {
+  const account = useAccountActive()
+  const readSecretKeyMutation = useAccountReadSecretKey()
+
+  return async () => {
+    const json = await readSecretKeyMutation.mutateAsync({ id: account.id })
+    if (!json) {
+      throw new Error(`No secret key for this account`)
+    }
+    return await createKeyPairSignerFromJson({ json })
+  }
+}


### PR DESCRIPTION
## Description


Adds a `useGetActiveAccountKeyPairSigner` hook to avoid repeating the same logic.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `useGetActiveAccountKeyPairSigner` hook to streamline key pair signer retrieval, refactoring transaction functions to use it.
> 
>   - **New Hook**:
>     - Adds `useGetActiveAccountKeyPairSigner` to `use-get-active-account-key-pair-signer.tsx` to fetch `KeyPairSigner` for active accounts.
>   - **Refactoring**:
>     - Replaces inline secret key reading and signer creation with `useGetActiveAccountKeyPairSigner` in `use-portfolio-tx-send.tsx` and `use-create-and-send-sol-transaction.tsx`.
>     - Updates `portfolioTxSendMutationOptions` to use `transactionSigner` instead of `sender`.
>   - **Misc**:
>     - Removes unused imports in `use-portfolio-tx-send.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 56bc12dacb9e4a582ee41d055e383490800fc37e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->