### PR TITLE
fix(settings): use type-safe useParams instead of type assertions

### DIFF
--- a/packages/explorer/src/explorer-feature-account-redirect.tsx
+++ b/packages/explorer/src/explorer-feature-account-redirect.tsx
@@ -4,7 +4,7 @@ import { ExplorerUiErrorPage } from './ui/explorer-ui-error-page.tsx'
 
 export function ExplorerFeatureAccountRedirect({ basePath }: { basePath: string }) {
   const location = useLocation()
-  const { address } = useParams()
+  const { address } = useParams<{ address: string }>()
   if (!address || !solanaAddressSchema.safeParse(address).success) {
     return <ExplorerUiErrorPage message="The provided address is not a valid Solana address." title="Invalid address" />
   }

--- a/packages/explorer/src/explorer-feature-account.tsx
+++ b/packages/explorer/src/explorer-feature-account.tsx
@@ -13,7 +13,7 @@ import { ExplorerUiErrorPage } from './ui/explorer-ui-error-page.tsx'
 export function ExplorerFeatureAccount({ basePath }: { basePath: string }) {
   const network = useNetworkActive()
   const backButtonTo = useExplorerBackButtonTo({ basePath })
-  const { address } = useParams()
+  const { address } = useParams<{ address: string }>()
   if (!address || !solanaAddressSchema.safeParse(address).success) {
     return <ExplorerUiErrorPage message="The provided address is not a valid Solana address." title="Invalid address" />
   }

--- a/packages/explorer/src/explorer-feature-transaction.tsx
+++ b/packages/explorer/src/explorer-feature-transaction.tsx
@@ -13,7 +13,7 @@ import { ExplorerUiExplorers } from './ui/explorer-ui-explorers.tsx'
 export function ExplorerFeatureTransaction({ basePath }: { basePath: string }) {
   const network = useNetworkActive()
   const backButtonTo = useExplorerBackButtonTo({ basePath })
-  const { signature } = useParams() as { signature: string }
+  const { signature } = useParams<{ signature: string }>()
   if (!signature || !solanaSignatureSchema.safeParse(signature).success) {
     return (
       <ExplorerUiErrorPage

--- a/packages/settings/src/settings-feature-account-generate-vanity.tsx
+++ b/packages/settings/src/settings-feature-account-generate-vanity.tsx
@@ -12,7 +12,6 @@ import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
 import { useEffect, useReducer, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
-
 import {
   SettingsUiWalletFormGenerateVanity,
   type VanityWalletFormFields,
@@ -129,7 +128,11 @@ function useVanityGenerator() {
 
 export function SettingsFeatureAccountGenerateVanity() {
   const navigate = useNavigate()
-  const { walletId } = useParams() as { walletId: string }
+  const { walletId } = useParams<{ walletId: string }>()
+  if (!walletId) {
+    throw new Error('Parameter walletId is required')
+  }
+
   const wallet = useWalletFindUnique({ id: walletId })
   const createAccountMutation = useAccountCreate()
   const { cancel, start, state } = useVanityGenerator()

--- a/packages/settings/src/settings-feature-network-update.tsx
+++ b/packages/settings/src/settings-feature-network-update.tsx
@@ -9,7 +9,11 @@ import { SettingsUiNetworkFormUpdate } from './ui/settings-ui-network-form-updat
 export function SettingsFeatureNetworkUpdate() {
   const { t } = useTranslation('settings')
   const navigate = useNavigate()
-  const { networkId } = useParams() as { networkId: string }
+  const { networkId } = useParams<{ networkId: string }>()
+  if (!networkId) {
+    throw new Error('Parameter networkId is required')
+  }
+
   const updateMutation = useNetworkUpdate()
   const network = useNetworkFindUnique({ id: networkId })
 

--- a/packages/settings/src/settings-feature-wallet-add-account.tsx
+++ b/packages/settings/src/settings-feature-wallet-add-account.tsx
@@ -21,7 +21,11 @@ import { SettingsUiWalletItem } from './ui/settings-ui-wallet-item.tsx'
 
 export function SettingsFeatureWalletAddAccount() {
   const { t } = useTranslation('settings')
-  const { walletId } = useParams() as { walletId: string }
+  const { walletId } = useParams<{ walletId: string }>()
+  if (!walletId) {
+    throw new Error('Parameter walletId is required')
+  }
+
   const wallet = useWalletFindUnique({ id: walletId })
   const deriveAccount = useDeriveAndCreateAccount()
   const createAccountMutation = useAccountCreate()

--- a/packages/settings/src/settings-feature-wallet-details.tsx
+++ b/packages/settings/src/settings-feature-wallet-details.tsx
@@ -21,7 +21,11 @@ import { SettingsUiWalletItem } from './ui/settings-ui-wallet-item.tsx'
 export function SettingsFeatureWalletDetails() {
   const { t } = useTranslation('settings')
   const { pathname: from } = useLocation()
-  const { walletId } = useParams() as { walletId: string }
+  const { walletId } = useParams<{ walletId: string }>()
+  if (!walletId) {
+    throw new Error('Parameter walletId is required')
+  }
+
   const deleteMutation = useAccountDelete({
     onError: (error) => toastError(error.message),
     onSuccess: () => toastSuccess('Account deleted'),

--- a/packages/settings/src/settings-feature-wallet-update.tsx
+++ b/packages/settings/src/settings-feature-wallet-update.tsx
@@ -9,7 +9,11 @@ import { SettingsUiWalletFormUpdate } from './ui/settings-ui-wallet-form-update.
 export function SettingsFeatureWalletUpdate() {
   const { t } = useTranslation('settings')
   const navigate = useNavigate()
-  const { walletId } = useParams() as { walletId: string }
+  const { walletId } = useParams<{ walletId: string }>()
+  if (!walletId) {
+    throw new Error('Parameter walletId is required')
+  }
+
   const { state } = useLocation()
   const from = state?.from ?? `/settings/wallets/${walletId}`
   const updateMutation = useWalletUpdate()


### PR DESCRIPTION
fix #399 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve type safety by using type-safe `useParams` and handle undefined parameters across multiple components.
> 
>   - **Type Safety**:
>     - Replace type assertions with type-safe `useParams` in `explorer-feature-transaction.tsx`, `settings-feature-account-generate-vanity.tsx`, `settings-feature-network-update.tsx`, `settings-feature-wallet-add-account.tsx`, `settings-feature-wallet-details.tsx`, and `settings-feature-wallet-update.tsx`.
>     - Handle undefined parameters in `useAccountsForWalletLive`, `useNetworkFindUnique`, and `useWalletFindUnique` by returning empty or null results.
>   - **Error Handling**:
>     - Add error handling for missing `walletId` and `networkId` in `settings-feature-account-generate-vanity.tsx`, `settings-feature-network-update.tsx`, `settings-feature-wallet-add-account.tsx`, `settings-feature-wallet-details.tsx`, and `settings-feature-wallet-update.tsx` using `UiError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for abb9bd03b3ce632f560ed79633dd512c5bc45988. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->