### PR TITLE
refactor(db): remove activeWalletId setting and infer active wallet from active account

### DIFF
--- a/packages/db-react/src/use-wallet-active.tsx
+++ b/packages/db-react/src/use-wallet-active.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react'
-import { useSetting } from './use-setting.tsx'
+import { useAccountActive } from './use-account-active.tsx'
 import { useWalletLive } from './use-wallet-live.tsx'
 
 export function useWalletActive() {
+  const account = useAccountActive()
   const wallets = useWalletLive()
-  const [activeWalletId] = useSetting('activeWalletId')
-  const activeWallet = useMemo(() => wallets.find((item) => item.id === activeWalletId), [activeWalletId, wallets])
+  const activeWallet = useMemo(() => wallets.find((item) => item.id === account.walletId), [account.walletId, wallets])
   if (!activeWallet) {
     throw new Error('No active wallet set.')
   }

--- a/packages/db/src/account/account-set-active.ts
+++ b/packages/db/src/account/account-set-active.ts
@@ -1,6 +1,4 @@
 import type { Database } from '../database.ts'
-import { settingFindUnique } from '../setting/setting-find-unique.ts'
-import type { SettingKey } from '../setting/setting-key.ts'
 import { settingSetValue } from '../setting/setting-set-value.ts'
 import { accountFindUnique } from './account-find-unique.ts'
 
@@ -14,17 +12,6 @@ export async function accountSetActive(db: Database, id: string) {
     }
     const accountId = found.id
 
-    // set the `activeAccountId` setting to the new value
-    const keyWallet: SettingKey = 'activeWalletId'
-    const keyAccount: SettingKey = 'activeAccountId'
-    // get the `activeWalletId` setting
-    const activeWallet = await settingFindUnique(db, keyWallet)
-
-    // ensure that the request `Account.walletId` is equal to `activeWalletId`
-    if (found.walletId !== activeWallet?.value) {
-      await settingSetValue(db, keyWallet, found.walletId)
-    }
-
-    await settingSetValue(db, keyAccount, accountId)
+    await settingSetValue(db, 'activeAccountId', accountId)
   })
 }

--- a/packages/db/src/setting/setting-key-schema.ts
+++ b/packages/db/src/setting/setting-key-schema.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 export const settingKeySchema = z.enum([
   'activeAccountId',
   'activeNetworkId',
-  'activeWalletId',
   'apiEndpoint',
   'language',
   'theme',

--- a/packages/db/src/wallet/wallet-create.ts
+++ b/packages/db/src/wallet/wallet-create.ts
@@ -2,8 +2,6 @@ import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from '../database.ts'
 import { randomId } from '../random-id.ts'
-import { settingFindUnique } from '../setting/setting-find-unique.ts'
-import { settingSetValue } from '../setting/setting-set-value.ts'
 import { walletCreateDetermineOrder } from './wallet-create-determine-order.ts'
 import type { WalletCreateInput } from './wallet-create-input.ts'
 import { walletCreateSchema } from './wallet-create-schema.ts'
@@ -30,10 +28,6 @@ export async function walletCreate(db: Database, input: WalletCreateInput): Prom
       throw new Error(`Error creating wallet`)
     }
 
-    const activeWalletId = (await settingFindUnique(db, 'activeWalletId'))?.value
-    if (!activeWalletId) {
-      await settingSetValue(db, 'activeWalletId', data)
-    }
     return data
   })
 }

--- a/packages/db/src/wallet/wallet-delete.ts
+++ b/packages/db/src/wallet/wallet-delete.ts
@@ -1,12 +1,17 @@
 import { tryCatch } from '@workspace/core/try-catch'
 import { accountFindMany } from '../account/account-find-many.ts'
+import { accountFindUnique } from '../account/account-find-unique.ts'
 import type { Database } from '../database.ts'
 import { settingFindUnique } from '../setting/setting-find-unique.ts'
 
 export async function walletDelete(db: Database, id: string): Promise<void> {
   return db.transaction('rw', db.accounts, db.settings, db.wallets, async () => {
-    const activeWalletId = (await settingFindUnique(db, 'activeWalletId'))?.value
-    if (id === activeWalletId) {
+    const activeAccountId = (await settingFindUnique(db, 'activeAccountId'))?.value
+    if (!activeAccountId) {
+      throw new Error('No active account set.')
+    }
+    const activeAccount = await accountFindUnique(db, activeAccountId)
+    if (id === activeAccount?.walletId) {
       throw new Error('You cannot delete the active wallet. Please change wallets and try again.')
     }
     const accounts = await accountFindMany(db, { walletId: id })

--- a/packages/db/test/account-set-active.test.ts
+++ b/packages/db/test/account-set-active.test.ts
@@ -17,7 +17,7 @@ describe('account-set-active', () => {
   describe('expected behavior', () => {
     it('should set an account and its related wallet to active', async () => {
       // ARRANGE
-      expect.assertions(4)
+      expect.assertions(2)
       const inputWallet1 = testWalletCreateInput()
       const inputWallet2 = testWalletCreateInput()
       const idWallet1 = await walletCreate(db, inputWallet1)
@@ -29,17 +29,13 @@ describe('account-set-active', () => {
       const idAccount2 = await accountCreate(db, inputAccount2)
 
       // ACT
-      const activeWalletIdBefore = await settingFindUnique(db, 'activeWalletId')
       const activeAccountIdBefore = await settingFindUnique(db, 'activeAccountId')
 
       await accountSetActive(db, idAccount2)
-      const activeWalletIdAfter = await settingFindUnique(db, 'activeWalletId')
       const activeAccountIdAfter = await settingFindUnique(db, 'activeAccountId')
 
       // ASSERT
-      expect(activeWalletIdBefore?.value).toBe(idWallet1)
       expect(activeAccountIdBefore?.value).toBe(idAccount1)
-      expect(activeWalletIdAfter?.value).toBe(idWallet2)
       expect(activeAccountIdAfter?.value).toBe(idAccount2)
     })
   })

--- a/packages/db/test/wallet-create.test.ts
+++ b/packages/db/test/wallet-create.test.ts
@@ -1,9 +1,7 @@
 import type { PromiseExtended } from 'dexie'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { settingFindUnique } from '../src/setting/setting-find-unique.ts'
 import { walletCreate } from '../src/wallet/wallet-create.ts'
-import { walletFindMany } from '../src/wallet/wallet-find-many.ts'
 import { walletFindUnique } from '../src/wallet/wallet-find-unique.ts'
 import { createDbTest, testWalletCreateInput } from './test-helpers.ts'
 
@@ -45,22 +43,6 @@ describe('wallet-create', () => {
       const item = await walletFindUnique(db, result)
       expect(item?.description).toBe(input.description)
       expect(item?.name).toBe(input.name)
-    })
-
-    it('should create a wallet and set activeWalletId setting', async () => {
-      // ARRANGE
-      expect.assertions(3)
-      const input = testWalletCreateInput()
-      // ACT
-      const activeWalletIdBefore = await settingFindUnique(db, 'activeWalletId')
-      const result = await walletCreate(db, input)
-      const activeWalletIdAfter = await settingFindUnique(db, 'activeWalletId')
-
-      // ASSERT
-      const items = await walletFindMany(db)
-      expect(items.map((i) => i.name)).toContain(input.name)
-      expect(activeWalletIdBefore).toBeNull()
-      expect(activeWalletIdAfter?.value).toBe(result)
     })
   })
 

--- a/packages/db/test/wallet-delete.test.ts
+++ b/packages/db/test/wallet-delete.test.ts
@@ -3,16 +3,16 @@ import type { PromiseExtended } from 'dexie'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { accountCreate } from '../src/account/account-create.ts'
 import { accountFindUnique } from '../src/account/account-find-unique.ts'
-import { settingSetValue } from '../src/setting/setting-set-value.ts'
 import { walletCreate } from '../src/wallet/wallet-create.ts'
 import { walletDelete } from '../src/wallet/wallet-delete.ts'
 import { walletFindUnique } from '../src/wallet/wallet-find-unique.ts'
-import { createDbTest, testAccountCreateInput, testSettingSetInput, testWalletCreateInput } from './test-helpers.ts'
+import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
 
 const db = createDbTest()
 
 describe('wallet-delete', () => {
   beforeEach(async () => {
+    await db.accounts.clear()
     await db.settings.clear()
     await db.wallets.clear()
   })
@@ -22,7 +22,8 @@ describe('wallet-delete', () => {
       // ARRANGE
       expect.assertions(1)
       // We create the first wallet so that will be the default. The second is the one that will be deleted.
-      await walletCreate(db, testWalletCreateInput())
+      const first = await walletCreate(db, testWalletCreateInput())
+      await accountCreate(db, testAccountCreateInput({ walletId: first }))
       const input = testWalletCreateInput()
       const id = await walletCreate(db, input)
 
@@ -38,7 +39,8 @@ describe('wallet-delete', () => {
       // ARRANGE
       expect.assertions(2)
       // We create the first wallet so that will be the default. The second is the one that will be deleted.
-      await walletCreate(db, testWalletCreateInput())
+      const first = await walletCreate(db, testWalletCreateInput())
+      await accountCreate(db, testAccountCreateInput({ walletId: first }))
       const input = testWalletCreateInput()
       const id = await walletCreate(db, input)
       const accountId = await accountCreate(db, testAccountCreateInput({ walletId: id }))
@@ -68,9 +70,7 @@ describe('wallet-delete', () => {
       expect.assertions(1)
       const input = testWalletCreateInput()
       const id = await walletCreate(db, input)
-      const [_, value] = testSettingSetInput(id)
-
-      await settingSetValue(db, 'activeWalletId', value)
+      await accountCreate(db, testAccountCreateInput({ walletId: id }))
 
       // ACT & ASSERT
       await expect(walletDelete(db, id)).rejects.toThrow(
@@ -81,7 +81,10 @@ describe('wallet-delete', () => {
     it('should throw an error when deleting a wallet fails', async () => {
       // ARRANGE
       expect.assertions(1)
-      const id = 'test-id'
+      const first = await walletCreate(db, testWalletCreateInput())
+      await accountCreate(db, testAccountCreateInput({ walletId: first }))
+      const id = await walletCreate(db, testWalletCreateInput())
+      // const id = 'test-id'
       vi.spyOn(db.wallets, 'delete').mockImplementationOnce(
         () => Promise.reject(new Error('Test error')) as PromiseExtended<void>,
       )

--- a/packages/settings/src/settings-feature-wallet-list.tsx
+++ b/packages/settings/src/settings-feature-wallet-list.tsx
@@ -1,4 +1,4 @@
-import { useSetting } from '@workspace/db-react/use-setting'
+import { useAccountActive } from '@workspace/db-react/use-account-active'
 import { useWalletDelete } from '@workspace/db-react/use-wallet-delete'
 import { useWalletLive } from '@workspace/db-react/use-wallet-live'
 import { useTranslation } from '@workspace/i18n'
@@ -18,8 +18,8 @@ export function SettingsFeatureWalletList() {
     onError: (error) => toastError(error.message),
     onSuccess: () => toastSuccess('Wallet deleted'),
   })
+  const account = useAccountActive()
   const wallets = useWalletLive()
-  const [activeWalletId] = useSetting('activeWalletId')
   return wallets.length ? (
     <UiCard
       action={
@@ -31,7 +31,7 @@ export function SettingsFeatureWalletList() {
       title={page.name}
     >
       <SettingsUiWalletList
-        activeId={activeWalletId}
+        activeId={account.walletId}
         deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })}
         items={wallets}
       />

--- a/packages/shell/src/data-access/root-route-loader.tsx
+++ b/packages/shell/src/data-access/root-route-loader.tsx
@@ -11,8 +11,8 @@ export function rootRouteLoader() {
     const result = await rootLoader()
     const { settings, networks } = result
 
-    const activeWalletId = settings.find((s) => s.key === 'activeWalletId')?.value
-    if (!activeWalletId && !pathname.startsWith('/onboarding')) {
+    const activeAccountId = settings.find((s) => s.key === 'activeAccountId')?.value
+    if (!activeAccountId && !pathname.startsWith('/onboarding')) {
       return redirectToOnboarding()
     }
 


### PR DESCRIPTION
## Description

I realized we imperatively managed the `activeWalletId` but we can infer this from the active `Account.walletId`.

## Checklist

- [x] Tests have been added for my change

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to remove `activeWalletId` setting, inferring active wallet from `Account.walletId`, and update related logic and tests.
> 
>   - **Behavior**:
>     - Remove `activeWalletId` setting and infer active wallet from `Account.walletId` in `useWalletActive()`.
>     - Update `walletDelete()` to check against `activeAccount.walletId` instead of `activeWalletId`.
>     - Modify `rootRouteLoader()` to check `activeAccountId` for onboarding redirection.
>   - **Database**:
>     - Remove `activeWalletId` from `settingKeySchema`.
>     - Simplify `accountSetActive()` by removing `activeWalletId` logic.
>   - **Tests**:
>     - Update `account-set-active.test.ts` to remove assertions related to `activeWalletId`.
>     - Remove `activeWalletId` test in `wallet-create.test.ts`.
>     - Adjust `wallet-delete.test.ts` to reflect changes in active wallet logic.
>   - **Misc**:
>     - Replace `useSetting('activeWalletId')` with `useAccountActive()` in `settings-feature-wallet-list.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for bc2f64ab4a647cc0c6354d8466b603cb4cb6c59f. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->