### PR TITLE
feat(db): add function to update account order

### DIFF
--- a/packages/db/src/account/account-update-order-input.ts
+++ b/packages/db/src/account/account-update-order-input.ts
@@ -1,0 +1,5 @@
+import type { z } from 'zod'
+
+import type { accountUpdateOrderSchema } from './account-update-order-schema.ts'
+
+export type AccountUpdateOrderInput = z.infer<typeof accountUpdateOrderSchema>

--- a/packages/db/src/account/account-update-order-schema.ts
+++ b/packages/db/src/account/account-update-order-schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const accountUpdateOrderSchema = z.object({
+  id: z.string(),
+  order: z.number(),
+})

--- a/packages/db/src/account/account-update-order.ts
+++ b/packages/db/src/account/account-update-order.ts
@@ -1,0 +1,51 @@
+import { tryCatch } from '@workspace/core/try-catch'
+import type { Database } from '../database.ts'
+import type { Account } from './account.ts'
+import type { AccountUpdateOrderInput } from './account-update-order-input.ts'
+import { accountUpdateOrderSchema } from './account-update-order-schema.ts'
+
+export async function accountUpdateOrder(db: Database, input: AccountUpdateOrderInput): Promise<void> {
+  const { id, order } = accountUpdateOrderSchema.parse(input)
+
+  return db.transaction('rw', db.accounts, async () => {
+    const [account, accountCount] = await Promise.all([db.accounts.get(id), db.accounts.count()])
+    if (!account) {
+      throw new Error(`Account with id ${id} not found`)
+    }
+    if (accountCount === 0) {
+      return
+    }
+
+    const newOrder = Math.max(0, Math.min(order, accountCount - 1))
+    const oldOrder = account.order
+
+    if (oldOrder === newOrder) {
+      return
+    }
+
+    // If the new order is less than the old order, we are moving the account up (incrementing the order of others)
+    // If the new order is greater than the old order, we are moving the account down (decrementing the order of others)
+    const increment = newOrder < oldOrder
+    const lower = increment ? newOrder : oldOrder + 1
+    const upper = increment ? oldOrder - 1 : newOrder
+    const { error: updateAccountsError } = await tryCatch(
+      db.accounts
+        .where('order')
+        .between(lower, upper, true, true)
+        .modify((account: Account) => {
+          account.order = increment ? account.order + 1 : account.order - 1
+        }),
+    )
+    if (updateAccountsError) {
+      throw new Error(`Error updating account order (${increment ? 'increment' : 'decrement'})`)
+    }
+
+    // Finally, update the moved account's order
+    const { error: updateError } = await tryCatch(db.accounts.update(id, { order: newOrder }))
+
+    if (updateError) {
+      console.log(updateError)
+      throw new Error(`Error moving account with id ${id}`)
+    }
+  })
+}

--- a/packages/db/test/account-update-order.test.ts
+++ b/packages/db/test/account-update-order.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Account } from '../src/account/account.ts'
+import { accountCreate } from '../src/account/account-create.ts'
+import { accountFindMany } from '../src/account/account-find-many.ts'
+import { accountUpdateOrder } from '../src/account/account-update-order.ts'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('accountUpdateOrder', () => {
+  let walletId: string
+  beforeEach(async () => {
+    await db.wallets.clear()
+    await db.accounts.clear()
+    walletId = await walletCreate(db, testWalletCreateInput())
+  })
+
+  describe('expected behavior', () => {
+    let account1: Account, account2: Account, account3: Account, account4: Account
+
+    beforeEach(async () => {
+      await Promise.all([
+        accountCreate(db, testAccountCreateInput({ name: 'Account 1', walletId })),
+        accountCreate(db, testAccountCreateInput({ name: 'Account 2', walletId })),
+        accountCreate(db, testAccountCreateInput({ name: 'Account 3', walletId })),
+        accountCreate(db, testAccountCreateInput({ name: 'Account 4', walletId })),
+      ])
+      const accounts = await accountFindMany(db)
+      account1 = accounts.find((a) => a.name === 'Account 1') as Account
+      account2 = accounts.find((a) => a.name === 'Account 2') as Account
+      account3 = accounts.find((a) => a.name === 'Account 3') as Account
+      account4 = accounts.find((a) => a.name === 'Account 4') as Account
+    })
+
+    it('should move an account to a lower order', async () => {
+      // ARRANGE
+      expect.assertions(4)
+
+      // ACT
+      await accountUpdateOrder(db, { id: account4.id, order: 1 })
+      const result = await accountFindMany(db)
+
+      // ASSERT
+      expect(result.find((a) => a.id === account1.id)?.order).toBe(0)
+      expect(result.find((a) => a.id === account4.id)?.order).toBe(1)
+      expect(result.find((a) => a.id === account2.id)?.order).toBe(2)
+      expect(result.find((a) => a.id === account3.id)?.order).toBe(3)
+    })
+
+    it('should move an account to a higher order', async () => {
+      // ARRANGE
+      expect.assertions(4)
+
+      // ACT
+      await accountUpdateOrder(db, { id: account1.id, order: 3 })
+      const result = await accountFindMany(db)
+
+      // ASSERT
+      expect(result.find((a) => a.id === account2.id)?.order).toBe(0)
+      expect(result.find((a) => a.id === account3.id)?.order).toBe(1)
+      expect(result.find((a) => a.id === account4.id)?.order).toBe(2)
+      expect(result.find((a) => a.id === account1.id)?.order).toBe(3)
+    })
+
+    it('should not change order if moving to the same position', async () => {
+      // ARRANGE
+      expect.assertions(4)
+
+      // ACT
+      await accountUpdateOrder(db, { id: account2.id, order: 1 })
+      const result = await accountFindMany(db)
+
+      // ASSERT
+      expect(result.find((a) => a.id === account1.id)?.order).toBe(0)
+      expect(result.find((a) => a.id === account2.id)?.order).toBe(1)
+      expect(result.find((a) => a.id === account3.id)?.order).toBe(2)
+      expect(result.find((a) => a.id === account4.id)?.order).toBe(3)
+    })
+
+    it('should clamp order if out of bounds (lower)', async () => {
+      // ARRANGE
+      expect.assertions(4)
+
+      // ACT
+      await accountUpdateOrder(db, { id: account3.id, order: -100 })
+      const result = await accountFindMany(db)
+
+      // ASSERT
+      expect(result.find((a) => a.id === account3.id)?.order).toBe(0)
+      expect(result.find((a) => a.id === account1.id)?.order).toBe(1)
+      expect(result.find((a) => a.id === account2.id)?.order).toBe(2)
+      expect(result.find((a) => a.id === account4.id)?.order).toBe(3)
+    })
+
+    it('should clamp order if out of bounds (higher)', async () => {
+      // ARRANGE
+      expect.assertions(4)
+
+      // ACT
+      await accountUpdateOrder(db, { id: account2.id, order: 100 })
+      const result = await accountFindMany(db)
+
+      // ASSERT
+      expect(result.find((a) => a.id === account1.id)?.order).toBe(0)
+      expect(result.find((a) => a.id === account3.id)?.order).toBe(1)
+      expect(result.find((a) => a.id === account4.id)?.order).toBe(2)
+      expect(result.find((a) => a.id === account2.id)?.order).toBe(3)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when account is not found', async () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT & ASSERT
+      await expect(accountUpdateOrder(db, { id: 'non-existent', order: 0 })).rejects.toThrow(
+        'Account with id non-existent not found',
+      )
+    })
+  })
+})


### PR DESCRIPTION
<!-- ⚠️ NOTE: Pull requests without a linked issue may be closed. Please link an existing issue or open one first. -->

## Description

<!-- Please include a summary of the change and the motivation behind it. -->

Closes #

## Screenshots / Video

<!-- Please include screenshots or video if UI changes are made. -->

## Checklist

- [ ] Tests have been added for my change
- [ ] Docs have been updated for my change

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `accountUpdateOrder` function to update account order with validation and tests.
> 
>   - **Functionality**:
>     - Adds `accountUpdateOrder` function in `account-update-order.ts` to update account order in the database.
>     - Validates input using `accountUpdateOrderSchema` from `account-update-order-schema.ts`.
>     - Adjusts orders of other accounts when an account's order changes.
>     - Clamps order to valid range (0 to account count - 1).
>     - Throws error if account not found.
>   - **Types**:
>     - Defines `AccountUpdateOrderInput` type in `account-update-order-input.ts` using `zod`.
>   - **Tests**:
>     - Adds tests in `account-update-order.test.ts` for moving accounts to higher/lower orders, clamping out-of-bounds orders, and handling non-existent accounts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for f2c414f5ff562afd1141e4fa695fb5538c9df98e. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->