### PR TITLE
feat(settings): add menu options to update Account order

### DIFF
--- a/packages/db-react/src/options-account.tsx
+++ b/packages/db-react/src/options-account.tsx
@@ -6,6 +6,8 @@ import { accountFindMany } from '@workspace/db/account/account-find-many'
 import type { AccountFindManyInput } from '@workspace/db/account/account-find-many-input'
 import { accountReadSecretKey } from '@workspace/db/account/account-read-secret-key'
 import { accountSetActive } from '@workspace/db/account/account-set-active'
+import { accountUpdateOrder } from '@workspace/db/account/account-update-order'
+import type { AccountUpdateOrderInput } from '@workspace/db/account/account-update-order-input'
 import { db } from '@workspace/db/db'
 import { optionsSetting } from './options-setting.tsx'
 import { queryClient } from './query-client.tsx'
@@ -14,6 +16,7 @@ export type AccountCreateMutateOptions = MutateOptions<string, Error, { input: A
 export type AccountDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
 export type AccountReadSecretKeyMutateOptions = MutateOptions<string | undefined, Error, { id: string }>
 export type AccountSetActiveMutateOptions = MutateOptions<void, Error, { id: string }>
+export type AccountUpdateOrderMutateOptions = MutateOptions<void, Error, { input: AccountUpdateOrderInput }>
 
 export const optionsAccount = {
   create: (props: AccountCreateMutateOptions = {}) =>
@@ -48,6 +51,14 @@ export const optionsAccount = {
       mutationFn: ({ id }: { id: string }) => accountSetActive(db, id),
       onSuccess: () => {
         queryClient.invalidateQueries(optionsSetting.findMany({}))
+      },
+      ...props,
+    }),
+  updateOrder: (props: AccountUpdateOrderMutateOptions = {}) =>
+    mutationOptions({
+      mutationFn: ({ input }: { input: AccountUpdateOrderInput }) => accountUpdateOrder(db, input),
+      onSuccess: () => {
+        queryClient.invalidateQueries(optionsAccount.findMany({}))
       },
       ...props,
     }),

--- a/packages/db-react/src/use-account-update-order.tsx
+++ b/packages/db-react/src/use-account-update-order.tsx
@@ -1,0 +1,7 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AccountUpdateOrderMutateOptions } from './options-account.tsx'
+import { optionsAccount } from './options-account.tsx'
+
+export function useAccountUpdateOrder(props: AccountUpdateOrderMutateOptions = {}) {
+  return useMutation(optionsAccount.updateOrder(props))
+}

--- a/packages/i18n/locales/en/settings.json
+++ b/packages/i18n/locales/en/settings.json
@@ -15,6 +15,8 @@
   "actionEditWalletMessage": "Add account to this wallet",
   "actionGenerate": "Generate",
   "actionImport": "Import",
+  "actionMoveAccountDown": "Move down",
+  "actionMoveAccountUp": "Move up",
   "actionMoveWalletDown": "Move down",
   "actionMoveWalletUp": "Move up",
   "actionRequestAirdrop": "Request airdrop",

--- a/packages/i18n/locales/es/settings.json
+++ b/packages/i18n/locales/es/settings.json
@@ -15,6 +15,8 @@
   "actionEditWalletMessage": "Añadir cuenta a esta billetera",
   "actionGenerate": "Generar",
   "actionImport": "Importar",
+  "actionMoveAccountDown": "Mover abajo",
+  "actionMoveAccountUp": "Mover arriba",
   "actionMoveWalletDown": "Mover abajo",
   "actionMoveWalletUp": "Mover arriba",
   "actionRequestAirdrop": "Solicitar airdrop",

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -109,6 +109,8 @@ interface Resources {
     actionEditWalletMessage: 'Add account to this wallet'
     actionGenerate: 'Generate'
     actionImport: 'Import'
+    actionMoveAccountDown: 'Move down'
+    actionMoveAccountUp: 'Move up'
     actionMoveWalletDown: 'Move down'
     actionMoveWalletUp: 'Move up'
     actionRequestAirdrop: 'Request airdrop'

--- a/packages/settings/src/settings-feature-wallet-details.tsx
+++ b/packages/settings/src/settings-feature-wallet-details.tsx
@@ -1,5 +1,7 @@
+import type { Account } from '@workspace/db/account/account'
 import { useAccountActive } from '@workspace/db-react/use-account-active'
 import { useAccountDelete } from '@workspace/db-react/use-account-delete'
+import { useAccountUpdateOrder } from '@workspace/db-react/use-account-update-order'
 import { useAccountsForWalletLive } from '@workspace/db-react/use-accounts-for-wallet-live'
 import { useNetworkActive } from '@workspace/db-react/use-network-active'
 import { useWalletFindUnique } from '@workspace/db-react/use-wallet-find-unique'
@@ -24,6 +26,10 @@ export function SettingsFeatureWalletDetails() {
     onError: (error) => toastError(error.message),
     onSuccess: () => toastSuccess('Account deleted'),
   })
+  const updateOrderMutation = useAccountUpdateOrder({
+    onError: (error) => toastError(error.message),
+    onSuccess: () => toastSuccess('Account order updated'),
+  })
   const activeAccount = useAccountActive()
   const wallet = useWalletFindUnique({ id: walletId })
   const accounts = useAccountsForWalletLive({ walletId })
@@ -32,6 +38,10 @@ export function SettingsFeatureWalletDetails() {
 
   if (!wallet) {
     return <UiNotFound />
+  }
+
+  function handleMove(item: Account, adjustment: number) {
+    return updateOrderMutation.mutateAsync({ input: { id: item.id, order: item.order + adjustment } })
   }
 
   return (
@@ -63,6 +73,8 @@ export function SettingsFeatureWalletDetails() {
         deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })}
         items={accounts}
         networkType={activeNetwork.type}
+        onMoveDown={(item: Account) => handleMove(item, 1)}
+        onMoveUp={(item: Account) => handleMove(item, -1)}
         requestAirdrop={async (item) => {
           await requestAirdropMutation.mutateAsync({ address: item.publicKey, amount: solToLamports('1') })
         }}

--- a/packages/settings/src/ui/settings-ui-account-list-item.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list-item.tsx
@@ -1,22 +1,16 @@
 import type { Account } from '@workspace/db/account/account'
-import type { NetworkType } from '@workspace/db/network/network-type'
 import { Badge } from '@workspace/ui/components/badge'
 import { Item, ItemActions, ItemContent, ItemTitle } from '@workspace/ui/components/item'
 import { SettingsUiAccountItem } from './settings-ui-account-item.tsx'
-import { SettingsUiAccountMenu } from './settings-ui-account-menu.tsx'
+import { SettingsUiAccountMenu, type SettingsUiAccountMenuProps } from './settings-ui-account-menu.tsx'
 
 export function SettingsUiAccountListItem({
   activeId,
-  deleteItem,
-  networkType,
-  requestAirdrop,
   item,
-}: {
+  ...props
+}: Omit<SettingsUiAccountMenuProps, 'account'> & {
   activeId: null | string
-  deleteItem: (item: Account) => Promise<void>
   item: Account
-  networkType: NetworkType
-  requestAirdrop: (item: Account) => Promise<void>
 }) {
   return (
     <Item key={item.id} role="listitem" variant={activeId === item.id ? 'muted' : 'outline'}>
@@ -27,12 +21,7 @@ export function SettingsUiAccountListItem({
       </ItemContent>
       <ItemActions>
         <Badge variant="outline">{item.type}</Badge>
-        <SettingsUiAccountMenu
-          account={item}
-          deleteItem={deleteItem}
-          networkType={networkType}
-          requestAirdrop={requestAirdrop}
-        />
+        <SettingsUiAccountMenu {...props} account={item} />
       </ItemActions>
     </Item>
   )

--- a/packages/settings/src/ui/settings-ui-account-list.tsx
+++ b/packages/settings/src/ui/settings-ui-account-list.tsx
@@ -8,23 +8,31 @@ export function SettingsUiAccountList({
   deleteItem,
   items,
   networkType,
+  onMoveDown,
+  onMoveUp,
   requestAirdrop,
 }: {
   activeId: null | string
   deleteItem: (item: Account) => Promise<void>
   items: Array<{ accounts?: Account[] } & Account>
   networkType: NetworkType
+  onMoveDown: (item: Account) => Promise<void>
+  onMoveUp: (item: Account) => Promise<void>
   requestAirdrop: (item: Account) => Promise<void>
 }) {
   return (
     <ItemGroup className="gap-2 md:gap-4">
-      {items.map((item) => (
+      {items.map((item, index) => (
         <SettingsUiAccountListItem
           activeId={activeId}
           deleteItem={deleteItem}
+          isFirst={index === 0}
+          isLast={index === items.length - 1}
           item={item}
           key={item.id}
           networkType={networkType}
+          onMoveDown={onMoveDown}
+          onMoveUp={onMoveUp}
           requestAirdrop={requestAirdrop}
         />
       ))}

--- a/packages/settings/src/ui/settings-ui-account-menu.tsx
+++ b/packages/settings/src/ui/settings-ui-account-menu.tsx
@@ -14,17 +14,27 @@ import { Fragment, useState } from 'react'
 import { Link, useLocation } from 'react-router'
 import { SettingsUiBottomSheetExportAccountSecretKey } from './settings-ui-bottom-sheet-export-account-secret-key.tsx'
 
+export interface SettingsUiAccountMenuProps {
+  account: Account
+  deleteItem: (item: Account) => Promise<void>
+  isFirst?: boolean
+  isLast?: boolean
+  networkType: NetworkType
+  onMoveDown?: (item: Account) => Promise<void>
+  onMoveUp?: (item: Account) => Promise<void>
+  requestAirdrop: (item: Account) => Promise<void>
+}
+
 export function SettingsUiAccountMenu({
   account,
   deleteItem,
+  isFirst,
+  isLast,
   networkType,
+  onMoveDown,
+  onMoveUp,
   requestAirdrop,
-}: {
-  account: Account
-  deleteItem: (item: Account) => Promise<void>
-  networkType: NetworkType
-  requestAirdrop: (item: Account) => Promise<void>
-}) {
+}: SettingsUiAccountMenuProps) {
   const { t } = useTranslation('settings')
   const { pathname: from } = useLocation()
   const [openDelete, setOpenDelete] = useState(false)
@@ -42,6 +52,20 @@ export function SettingsUiAccountMenu({
             <Link state={{ from }} to={`/explorer/address/${account.publicKey}`}>
               {t(($) => $.actionViewAccount)}
             </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            disabled={isFirst || !onMoveUp}
+            onClick={() => onMoveUp?.(account)}
+          >
+            {t(($) => $.actionMoveAccountUp)}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            disabled={isLast || !onMoveDown}
+            onClick={() => onMoveDown?.(account)}
+          >
+            {t(($) => $.actionMoveAccountDown)}
           </DropdownMenuItem>
           <DropdownMenuItem
             className="cursor-pointer"


### PR DESCRIPTION
Closes #256 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds functionality to update account order in wallet settings, including UI and translations.
> 
>   - **Behavior**:
>     - Adds `updateOrder` function to `optionsAccount` in `options-account.tsx` to update account order.
>     - Introduces `useAccountUpdateOrder` hook in `use-account-update-order.tsx` for mutation handling.
>     - Implements `handleMove` function in `settings-feature-wallet-details.tsx` to adjust account order.
>   - **UI**:
>     - Updates `SettingsUiAccountMenu` in `settings-ui-account-menu.tsx` to include "Move up" and "Move down" options.
>     - Modifies `SettingsUiAccountList` and `SettingsUiAccountListItem` to handle account order changes.
>   - **Translations**:
>     - Adds `actionMoveAccountUp` and `actionMoveAccountDown` to English and Spanish `settings.json` files.
>     - Updates `resources.d.ts` to include new translation keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=samui-build%2Fsamui-wallet&utm_source=github&utm_medium=referral)<sup> for 450bf51c790b969eb9d49b8f043023371807e9fe. You can [customize](https://app.ellipsis.dev/samui-build/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->