### PR TITLE
fix: undo broken editorconfig-checker version bump

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -17,5 +17,5 @@
   "PassedFiles": [],
   "SpacesAfterTabs": false,
   "Verbose": false,
-  "Version": "v3.6.1"
+  "Version": "v3.6.0"
 }


### PR DESCRIPTION
Refs: 68ba943 (chore: update editorconfig-checker version)

That change put the repo in a broken state literally.

bun ec and the pre-commit hook failed with:
Version from config file is not the same as the version of the binary
Binary: v3.6.0, Config v3.6.1

Findings:
- 68ba943 changed only .editorconfig-checker.json.
- It bumped the config pin from v3.6.0 to v3.6.1.
- It did not update package.json, bun.lock, or lefthook.
- editorconfig-checker@6.1.1 is the JS wrapper.
- The bundled core ec binary in this install is still v3.6.0.
- Reverting the config pin to v3.6.0 restores bun ec.
