### PR TITLE
chore: replace renovate with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  - package-ecosystem: bun
+    commit-message:
+      include: scope
+      prefix: chore
+    cooldown:
+      default-days: 5
+    directory: /
+    schedule:
+      day: sunday
+      interval: weekly
+      time: "00:00"
+      timezone: UTC
+
+  - package-ecosystem: github-actions
+    commit-message:
+      include: scope
+      prefix: chore
+    cooldown:
+      default-days: 5
+    directory: /
+    schedule:
+      day: sunday
+      interval: weekly
+      time: "00:00"
+      timezone: UTC

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,4 @@
 [install]
 exact = true
 linker = "isolated"
-minimumReleaseAge = 86400
+minimumReleaseAge = 432000

--- a/cspell.config.mts
+++ b/cspell.config.mts
@@ -41,6 +41,7 @@ const config: CSpellSettings = {
     'blockhash',
     'bootsplash',
     'bunx',
+    'cooldown',
     'cypherpunk',
     'datetimepicker',
     'devnet',

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "schedule:daily"],
-  "minimumReleaseAge": "1 day"
-}


### PR DESCRIPTION
Add Dependabot config for Bun and GitHub Actions with a 5 day cooldown.
Raise Bun's minimum release age to 5 days.
Add cooldown to cspell and remove the old Renovate config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency updates for build and runtime ecosystems.
  * Increased package installation minimum release age from 1 day to 5 days.
  * Added a custom word to the project spell-check dictionary.
  * Consolidated dependency update tooling to rely on a single scheduled updater.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->