### PR TITLE
fix(ui): add clipboard fallback

### DIFF
--- a/packages/ui/src/lib/handle-copy-text.ts
+++ b/packages/ui/src/lib/handle-copy-text.ts
@@ -2,13 +2,55 @@ export async function handleCopyText(text: string) {
   if (!text) {
     return
   }
-  if (
-    typeof globalThis === 'undefined' ||
-    !globalThis.navigator ||
-    !globalThis.navigator.clipboard ||
-    !globalThis.navigator.clipboard.writeText
-  ) {
+  let clipboardError: unknown
+  if (globalThis.navigator?.clipboard?.writeText) {
+    try {
+      await globalThis.navigator.clipboard.writeText(text)
+      return
+    } catch (error) {
+      if (!isClipboardWritePermissionDenied(error)) {
+        throw error
+      }
+      clipboardError = error
+    }
+  }
+  if (copyTextWithExecCommand(text)) {
     return
   }
-  await globalThis.navigator.clipboard.writeText(text)
+  throw clipboardError instanceof Error ? clipboardError : new Error('Clipboard API is not available')
+}
+
+function copyTextWithExecCommand(text: string) {
+  if (!globalThis.document?.body?.appendChild || !globalThis.document.execCommand) {
+    return false
+  }
+  const textArea = globalThis.document.createElement('textarea')
+  textArea.value = text
+  textArea.setAttribute('readonly', '')
+  textArea.style.left = '0'
+  textArea.style.opacity = '0'
+  textArea.style.pointerEvents = 'none'
+  textArea.style.position = 'fixed'
+  textArea.style.top = '0'
+  globalThis.document.body.appendChild(textArea)
+  try {
+    textArea.focus()
+    textArea.select()
+    textArea.setSelectionRange(0, text.length)
+    return globalThis.document.execCommand('copy')
+  } catch {
+    return false
+  } finally {
+    textArea.remove()
+  }
+}
+
+function isClipboardWritePermissionDenied(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return (
+    (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'NotAllowedError') ||
+    error.message.includes('Write permission denied')
+  )
 }


### PR DESCRIPTION
## Description

Use the Clipboard API when available.

Fall back to execCommand for browser permission failures and surface failed copies.

This fixes failing to copy in embedded browsers:

## Screenshots / Video

<img width="1226" height="1729" alt="image" src="https://github.com/user-attachments/assets/7dc4f84e-4444-4b33-9f7c-955e91d3ae8d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy-to-clipboard reliability: better detection of clipboard availability, refined error handling for permission issues, and a robust fallback so copying works more consistently across browsers and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->