### PR TITLE
feat: add transaction inspector tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -555,6 +555,7 @@
         "@solana-program/token": "catalog:",
         "@solana-program/token-2022": "catalog:",
         "@solana/kit": "catalog:",
+        "@workspace/core": "workspace:*",
         "ws": "catalog:",
       },
       "devDependencies": {

--- a/packages/explorer/src/ui/explorer-ui-link-signature.tsx
+++ b/packages/explorer/src/ui/explorer-ui-link-signature.tsx
@@ -19,12 +19,7 @@ export function ExplorerUiLinkSignature({
   const { pathname: from } = useLocation()
   return (
     <span className={cn('flex items-center gap-2', className)}>
-      <Link
-        className="cursor-pointer font-mono text-sm"
-        state={{ from }}
-        title={signature}
-        to={`${basePath}/tx/${signature}`}
-      >
+      <Link className="cursor-pointer font-mono" state={{ from }} title={signature} to={`${basePath}/tx/${signature}`}>
         {label?.length ? label : <ExplorerUiSignature signature={signature} />}
       </Link>
       <UiTextCopyIcon text={signature} title="Copy signature to clipboard" toast="Signature copied to clipboard" />

--- a/packages/explorer/src/ui/explorer-ui-signature.tsx
+++ b/packages/explorer/src/ui/explorer-ui-signature.tsx
@@ -3,11 +3,11 @@ import { ellipsify } from '@workspace/ui/lib/ellipsify'
 
 export function ExplorerUiSignature({ signature }: { signature: Signature }) {
   return (
-    <>
+    <span className="text-muted-foreground hover:text-foreground">
       <span className="hidden lg:block">{ellipsify(signature, 16)}</span>
       <span className="lg:hidden" title={signature}>
         {ellipsify(signature, 8)}
       </span>
-    </>
+    </span>
   )
 }

--- a/packages/solana-client-react/src/use-parse-transaction-inspector-input.tsx
+++ b/packages/solana-client-react/src/use-parse-transaction-inspector-input.tsx
@@ -1,0 +1,22 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import { parseTransactionInspectorInput } from '@workspace/solana-client/parse-transaction-inspector-input'
+
+export function parseTransactionInspectorInputQueryOptions(input: string) {
+  const normalizedInput = input.trim()
+
+  return queryOptions({
+    enabled: normalizedInput.length > 0,
+    queryFn: () => parseTransactionInspectorInput(normalizedInput),
+    queryKey: ['parseTransactionInspectorInput', normalizedInput],
+  })
+}
+
+export function useParseTransactionInspectorInput(input: string) {
+  const query = useQuery(parseTransactionInspectorInputQueryOptions(input))
+
+  return {
+    data: query.data,
+    error: query.error ?? undefined,
+    isLoading: query.isLoading,
+  }
+}

--- a/packages/solana-client/package.json
+++ b/packages/solana-client/package.json
@@ -4,6 +4,7 @@
     "@solana-program/token": "catalog:",
     "@solana-program/token-2022": "catalog:",
     "@solana/kit": "catalog:",
+    "@workspace/core": "workspace:*",
     "ws": "catalog:"
   },
   "devDependencies": {

--- a/packages/solana-client/src/parse-transaction-inspector-input.ts
+++ b/packages/solana-client/src/parse-transaction-inspector-input.ts
@@ -1,0 +1,321 @@
+import type { Address, CompiledTransactionMessage, ReadonlyUint8Array, Signature } from '@solana/kit'
+import {
+  getBase58Decoder,
+  getBase58Encoder,
+  getBase64Decoder,
+  getBase64Encoder,
+  getCompiledTransactionMessageDecoder,
+  getTransactionDecoder,
+  signatureBytes,
+  verifySignature,
+} from '@solana/kit'
+import { tryCatch } from '@workspace/core/try-catch'
+
+export const MIN_TRANSACTION_MESSAGE_LENGTH =
+  3 + // header
+  1 + // accounts length
+  32 + // accounts, must have at least one address for fees
+  32 + // recent blockhash
+  1 // instructions length
+
+export type TransactionInspectorEncoding = 'base58' | 'base64'
+
+export interface TransactionInspectorAccountReference {
+  address: Address | undefined
+  key: string
+  lookupTableAddress: Address | undefined
+  lookupTableIndex: number | undefined
+  source: 'readonly lookup' | 'static' | 'writable lookup'
+}
+
+export interface TransactionInspectorInstruction {
+  accountAddresses: (Address | undefined)[]
+  accountIndices: number[]
+  accountReferences: (TransactionInspectorAccountReference | undefined)[]
+  dataBase58: string
+  dataBase64: string
+  programAddress: Address | undefined
+  programAddressIndex: number
+  programAccountReference: TransactionInspectorAccountReference | undefined
+}
+
+export interface TransactionInspectorSignature {
+  address: Address
+  signature: Signature | undefined
+  verified: boolean | undefined
+}
+
+export interface TransactionInspectorResult {
+  accountReferences: TransactionInspectorAccountReference[]
+  addressTableLookups: TransactionInspectorAddressTableLookup[]
+  compiledMessage: CompiledTransactionMessage
+  encoding: TransactionInspectorEncoding
+  feePayer: Address | undefined
+  instructions: TransactionInspectorInstruction[]
+  rawMessage: ReadonlyUint8Array
+  rawMessageBase64: string
+  signatures: TransactionInspectorSignature[]
+  sourceBytes: ReadonlyUint8Array
+  sourceBytesLength: number
+  version: CompiledTransactionMessage['version']
+}
+
+export interface TransactionInspectorAddressTableLookup {
+  lookupTableAddress: Address
+  readonlyIndexes: readonly number[]
+  writableIndexes: readonly number[]
+}
+
+interface ParsedTransactionBytes {
+  rawMessage: ReadonlyUint8Array
+  signatures: TransactionInspectorSignature[]
+}
+
+interface ParsedTransactionInspectorInput extends ParsedTransactionBytes {
+  compiledMessage: CompiledTransactionMessage
+}
+
+export async function parseTransactionInspectorInput(input: string): Promise<TransactionInspectorResult> {
+  const { bytes, compiledMessage, encoding, rawMessage, signatures } = await decodeTransactionInspectorInput(input)
+  const addressTableLookups = getAddressTableLookups(compiledMessage)
+  const accountReferences = getTransactionInspectorAccountReferences({
+    addressTableLookups,
+    staticAccounts: compiledMessage.staticAccounts,
+  })
+  const staticAccounts = compiledMessage.staticAccounts
+  const verifiedSignatures = await verifyTransactionSignatures({ rawMessage, signatures })
+
+  return {
+    accountReferences,
+    addressTableLookups,
+    compiledMessage,
+    encoding,
+    feePayer: staticAccounts[0],
+    instructions: getInstructions(compiledMessage, accountReferences),
+    rawMessage,
+    rawMessageBase64: getBase64Decoder().decode(rawMessage),
+    signatures: verifiedSignatures,
+    sourceBytes: bytes,
+    sourceBytesLength: bytes.length,
+    version: compiledMessage.version,
+  }
+}
+
+async function decodeTransactionInspectorInput(input: string): Promise<{
+  bytes: ReadonlyUint8Array
+  compiledMessage: CompiledTransactionMessage
+  encoding: TransactionInspectorEncoding
+  rawMessage: ReadonlyUint8Array
+  signatures: TransactionInspectorSignature[]
+}> {
+  const normalizedInput = input.replace(/\s+/g, '')
+
+  if (!normalizedInput) {
+    throw new Error('Input is required.')
+  }
+
+  const decodedCandidates = (
+    await Promise.all([
+      decodeTransactionInspectorInputCandidate(normalizedInput, 'base58'),
+      decodeTransactionInspectorInputCandidate(normalizedInput, 'base64'),
+    ])
+  ).filter((candidate) => candidate !== undefined)
+
+  if (!decodedCandidates.length) {
+    throw new Error('Input must be base58 or base64 encoded.')
+  }
+
+  const parsedCandidates = await Promise.all(
+    decodedCandidates.map(async (candidate) => ({
+      candidate,
+      parsed: await tryCatch(Promise.resolve().then(() => parseTransactionInspectorBytes(candidate.bytes))),
+    })),
+  )
+  const validCandidate = parsedCandidates.find(({ parsed }) => !parsed.error)
+
+  if (validCandidate?.parsed.data) {
+    return { ...validCandidate.candidate, ...validCandidate.parsed.data }
+  }
+
+  const parseError = parsedCandidates.find(({ parsed }) => parsed.error)?.parsed.error
+  throw parseError ?? new Error('Input must be base58 or base64 encoded.')
+}
+
+async function decodeTransactionInspectorInputCandidate(
+  input: string,
+  encoding: TransactionInspectorEncoding,
+): Promise<
+  | {
+      bytes: ReadonlyUint8Array
+      encoding: TransactionInspectorEncoding
+    }
+  | undefined
+> {
+  const encoder = encoding === 'base58' ? getBase58Encoder() : getBase64Encoder()
+  const { data: bytes, error } = await tryCatch(Promise.resolve().then(() => encoder.encode(input)))
+
+  return error ? undefined : { bytes, encoding }
+}
+
+function getAddressTableLookups(message: CompiledTransactionMessage): TransactionInspectorAddressTableLookup[] {
+  if (message.version !== 0 || !message.addressTableLookups) {
+    return []
+  }
+
+  return message.addressTableLookups.map((lookup) => ({
+    lookupTableAddress: lookup.lookupTableAddress,
+    readonlyIndexes: lookup.readonlyIndexes,
+    writableIndexes: lookup.writableIndexes,
+  }))
+}
+
+export function getTransactionInspectorAccountReferences({
+  addressTableLookups,
+  staticAccounts,
+}: {
+  addressTableLookups: TransactionInspectorAddressTableLookup[]
+  staticAccounts: Address[]
+}): TransactionInspectorAccountReference[] {
+  return [
+    ...staticAccounts.map((address, index) => ({
+      address,
+      key: `static-${address}-${index}`,
+      lookupTableAddress: undefined,
+      lookupTableIndex: undefined,
+      source: 'static' as const,
+    })),
+    ...addressTableLookups.flatMap((lookup, lookupIndex) => [
+      ...lookup.writableIndexes.map((lookupTableIndex) => ({
+        address: undefined,
+        key: `writable-${lookupIndex}-${lookup.lookupTableAddress}-${lookupTableIndex}`,
+        lookupTableAddress: lookup.lookupTableAddress,
+        lookupTableIndex,
+        source: 'writable lookup' as const,
+      })),
+      ...lookup.readonlyIndexes.map((lookupTableIndex) => ({
+        address: undefined,
+        key: `readonly-${lookupIndex}-${lookup.lookupTableAddress}-${lookupTableIndex}`,
+        lookupTableAddress: lookup.lookupTableAddress,
+        lookupTableIndex,
+        source: 'readonly lookup' as const,
+      })),
+    ]),
+  ]
+}
+
+function getInstructionAccounts(staticAccounts: Address[], accountIndices: number[]) {
+  return accountIndices.map((index) => staticAccounts[index])
+}
+
+function getInstructions(
+  message: CompiledTransactionMessage,
+  accountReferences: TransactionInspectorAccountReference[],
+): TransactionInspectorInstruction[] {
+  const staticAccounts = message.staticAccounts
+
+  if (message.version === 1) {
+    return message.instructionHeaders.map((header, index) => {
+      const payload = message.instructionPayloads[index]
+      const accountIndices = payload?.instructionAccountIndices ?? []
+      const data = payload?.instructionData ?? new Uint8Array()
+
+      return {
+        accountAddresses: getInstructionAccounts(staticAccounts, accountIndices),
+        accountIndices,
+        accountReferences: accountIndices.map((accountIndex) => accountReferences[accountIndex]),
+        dataBase58: getBase58Decoder().decode(data),
+        dataBase64: getBase64Decoder().decode(data),
+        programAccountReference: accountReferences[header.programAccountIndex],
+        programAddress: staticAccounts[header.programAccountIndex],
+        programAddressIndex: header.programAccountIndex,
+      }
+    })
+  }
+
+  return message.instructions.map((instruction) => {
+    const accountIndices = instruction.accountIndices ?? []
+    const data = instruction.data ?? new Uint8Array()
+
+    return {
+      accountAddresses: getInstructionAccounts(staticAccounts, accountIndices),
+      accountIndices,
+      accountReferences: accountIndices.map((accountIndex) => accountReferences[accountIndex]),
+      dataBase58: getBase58Decoder().decode(data),
+      dataBase64: getBase64Decoder().decode(data),
+      programAccountReference: accountReferences[instruction.programAddressIndex],
+      programAddress: staticAccounts[instruction.programAddressIndex],
+      programAddressIndex: instruction.programAddressIndex,
+    }
+  })
+}
+
+function parseTransactionInspectorBytes(bytes: ReadonlyUint8Array): ParsedTransactionInspectorInput {
+  if (bytes.length < MIN_TRANSACTION_MESSAGE_LENGTH) {
+    throw new Error('Input is not long enough to be a valid transaction message.')
+  }
+
+  const { rawMessage, signatures } = parseTransactionBytes(bytes)
+
+  if (rawMessage.length < MIN_TRANSACTION_MESSAGE_LENGTH) {
+    throw new Error('Input is not long enough to be a valid transaction message.')
+  }
+
+  const compiledMessage = getCompiledTransactionMessageDecoder().decode(rawMessage)
+
+  return { compiledMessage, rawMessage, signatures }
+}
+
+function parseTransactionBytes(bytes: ReadonlyUint8Array): ParsedTransactionBytes {
+  try {
+    const transaction = getTransactionDecoder().decode(bytes as Uint8Array)
+
+    return {
+      rawMessage: transaction.messageBytes,
+      signatures: Object.entries(transaction.signatures).map(([address, signature]) => {
+        const rawSignature = signature ? signatureBytes(signature) : undefined
+
+        return {
+          address: address as Address,
+          signature: rawSignature ? (getBase58Decoder().decode(rawSignature) as Signature) : undefined,
+          verified: undefined,
+        }
+      }),
+    }
+  } catch {
+    return { rawMessage: bytes, signatures: [] }
+  }
+}
+
+async function createPublicKeyFromAddress(address: Address): Promise<CryptoKey> {
+  return await crypto.subtle.importKey('raw', getBase58Encoder().encode(address), { name: 'Ed25519' }, false, [
+    'verify',
+  ])
+}
+
+async function verifyTransactionSignatures({
+  rawMessage,
+  signatures,
+}: {
+  rawMessage: ReadonlyUint8Array
+  signatures: TransactionInspectorSignature[]
+}): Promise<TransactionInspectorSignature[]> {
+  return await Promise.all(
+    signatures.map(async (item) => {
+      if (!item.signature) {
+        return item
+      }
+
+      const { data: publicKey, error: publicKeyError } = await tryCatch(createPublicKeyFromAddress(item.address))
+
+      if (publicKeyError || !publicKey) {
+        return { ...item, verified: false }
+      }
+
+      const { data: verified } = await tryCatch(
+        verifySignature(publicKey, signatureBytes(getBase58Encoder().encode(item.signature)), rawMessage),
+      )
+
+      return { ...item, verified: verified ?? false }
+    }),
+  )
+}

--- a/packages/solana-client/test/parse-transaction-inspector-input.test.ts
+++ b/packages/solana-client/test/parse-transaction-inspector-input.test.ts
@@ -1,0 +1,178 @@
+import { type Address, getBase64Decoder, getBase64Encoder } from '@solana/kit'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getTransactionInspectorAccountReferences,
+  parseTransactionInspectorInput,
+} from '../src/parse-transaction-inspector-input.ts'
+
+const DEVNET_TRANSACTION_BASE58 =
+  '3vniymnVePee2wjJptnvNVpnNPAJqzUpuhdEFf67AFZNjn4YjKSTLMckESMmaAWU1MdTkS7N2HW5psF5t4RnnMHdFCKFBuLdwbzD4tZ6tGpHrXWch5Kn9nimKP3ZEyuj7fHHzNXpqRA7Q7Z4ZDr5L6i1ugmS4NXFZY2P18ahfJLn54NLtgDxnTU59bkFDtiL1gqAPyW8bPk5aUUnjNM2Np6NM2KkKBs1w99S9tnSuART2qDpNVdX2wKJN5zvhxsDNnZskV1BnMDmPtmrjXMQH6oJ5KQra5BTffMPd'
+const DEVNET_TRANSACTION_BASE64 =
+  'AQ6bxHQd02AvW2jIzS9oRjbxqj+ST2jvbsBy9yJre+uSbRrVecKhE6ejj7lS0JU6aP9Br/w43ol+yueyRddNRAcBAAEDQMJrwX8tEY9Hthtph0uMLm0j4fV5vU4/955t0/r1c3nd1vbjXabKYKyz/QkZfCENNQUwIffPl8dY6fbLsKu9rQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI2ST38CdjGDzn6ocuQJnEIFUWOvGRsHgKTwkWkRC9/MBAgIAAQwCAAAA6AMAAAAAAAA='
+const DEVNET_TRANSACTION_SIGNATURE =
+  'HwXNNDpDQHPh66GrcsopydvPNWxtED97PHPGyWoww21XXZKMW1iaNZnPDbUWjMPC8pRoWXr3y8QdpEJskdR8WEi'
+const OVERLAPPING_ALPHABET_BASE64_MESSAGE =
+  'AAAAATAs9qo8CPVRVn6pNt65hdk41Zr16ZEXkERFuExsMXwYuX9bvxkBGL228i69T2fAUAWnwho52RCkEcLwvYoquhkA'
+
+describe('parse-transaction-inspector-input', () => {
+  describe('expected behavior', () => {
+    it('should parse a devnet base64 encoded transaction', async () => {
+      // ARRANGE
+      expect.assertions(12)
+
+      // ACT
+      const result = await parseTransactionInspectorInput(DEVNET_TRANSACTION_BASE64)
+
+      // ASSERT
+      expect(result.accountReferences).toHaveLength(3)
+      expect(result.accountReferences[0]).toStrictEqual({
+        address: '5Mo3HtvCT73PmRdzoQVFuU6o7U862BDGeRd8jafzgGSC',
+        key: 'static-5Mo3HtvCT73PmRdzoQVFuU6o7U862BDGeRd8jafzgGSC-0',
+        lookupTableAddress: undefined,
+        lookupTableIndex: undefined,
+        source: 'static',
+      })
+      expect(result.encoding).toBe('base64')
+      expect(result.feePayer).toBe('5Mo3HtvCT73PmRdzoQVFuU6o7U862BDGeRd8jafzgGSC')
+      expect(result.instructions).toHaveLength(1)
+      expect(result.instructions[0]?.programAccountReference).toBe(result.accountReferences[2])
+      expect(result.rawMessageBase64).toBe(
+        'AQABA0DCa8F/LRGPR7YbaYdLjC5tI+H1eb1OP/eebdP69XN53db2412mymCss/0JGXwhDTUFMCH3z5fHWOn2y7Crva0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACNkk9/AnYxg85+qHLkCZxCBVFjrxkbB4Ck8JFpEQvfzAQICAAEMAgAAAOgDAAAAAAAA',
+      )
+      expect(result.signatures).toHaveLength(1)
+      expect(result.signatures[0]?.signature).toBe(DEVNET_TRANSACTION_SIGNATURE)
+      expect(result.signatures[0]?.verified).toBe(true)
+      expect(result.sourceBytesLength).toBe(215)
+      expect(result.version).toBe('legacy')
+    })
+
+    it('should build account references with static and lookup accounts in message index order', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const lookupTableAddress = '7CZdLj9f5bgLwv77JRMSoravvVGyEpEJndRbWNsJCkUB' as Address
+      const staticAccount = '11111111111111111111111111111111' as Address
+
+      // ACT
+      const result = getTransactionInspectorAccountReferences({
+        addressTableLookups: [
+          {
+            lookupTableAddress,
+            readonlyIndexes: [3, 5],
+            writableIndexes: [2],
+          },
+        ],
+        staticAccounts: [staticAccount],
+      })
+
+      // ASSERT
+      expect(result).toStrictEqual([
+        {
+          address: staticAccount,
+          key: `static-${staticAccount}-0`,
+          lookupTableAddress: undefined,
+          lookupTableIndex: undefined,
+          source: 'static',
+        },
+        {
+          address: undefined,
+          key: `writable-0-${lookupTableAddress}-2`,
+          lookupTableAddress,
+          lookupTableIndex: 2,
+          source: 'writable lookup',
+        },
+        {
+          address: undefined,
+          key: `readonly-0-${lookupTableAddress}-3`,
+          lookupTableAddress,
+          lookupTableIndex: 3,
+          source: 'readonly lookup',
+        },
+        {
+          address: undefined,
+          key: `readonly-0-${lookupTableAddress}-5`,
+          lookupTableAddress,
+          lookupTableIndex: 5,
+          source: 'readonly lookup',
+        },
+      ])
+    })
+
+    it('should parse a devnet base58 encoded transaction', async () => {
+      // ARRANGE
+      expect.assertions(5)
+
+      // ACT
+      const result = await parseTransactionInspectorInput(DEVNET_TRANSACTION_BASE58)
+
+      // ASSERT
+      expect(result.encoding).toBe('base58')
+      expect(result.instructions[0]?.programAddress).toBe('11111111111111111111111111111111')
+      expect(result.signatures[0]?.signature).toBe(DEVNET_TRANSACTION_SIGNATURE)
+      expect(result.signatures[0]?.verified).toBe(true)
+      expect(result.version).toBe('legacy')
+    })
+
+    it('should parse a valid base64 transaction message when base58 decoding also succeeds', async () => {
+      // ARRANGE
+      expect.assertions(3)
+
+      // ACT
+      const result = await parseTransactionInspectorInput(OVERLAPPING_ALPHABET_BASE64_MESSAGE)
+
+      // ASSERT
+      expect(result.encoding).toBe('base64')
+      expect(result.sourceBytesLength).toBe(69)
+      expect(result.version).toBe('legacy')
+    })
+
+    it('should mark a tampered devnet transaction signature as invalid', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const bytes = new Uint8Array(getBase64Encoder().encode(DEVNET_TRANSACTION_BASE64))
+      bytes[bytes.length - 1] = (bytes[bytes.length - 1] ?? 0) ^ 1
+
+      // ACT
+      const result = await parseTransactionInspectorInput(getBase64Decoder().decode(bytes))
+
+      // ASSERT
+      expect(result.signatures[0]?.signature).toBe(DEVNET_TRANSACTION_SIGNATURE)
+      expect(result.signatures[0]?.verified).toBe(false)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when input is empty', async () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT & ASSERT
+      await expect(parseTransactionInspectorInput('')).rejects.toThrow('Input is required.')
+    })
+
+    it('should throw an error when input is not encoded transaction data', async () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT & ASSERT
+      await expect(parseTransactionInspectorInput('not-valid-transaction-data')).rejects.toThrow(
+        'Input must be base58 or base64 encoded.',
+      )
+    })
+
+    it('should throw an error when input is whitespace only', async () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT & ASSERT
+      await expect(parseTransactionInspectorInput('   \n\t  ')).rejects.toThrow('Input is required.')
+    })
+  })
+})

--- a/packages/tools/src/tools-feature-transaction-inspector.tsx
+++ b/packages/tools/src/tools-feature-transaction-inspector.tsx
@@ -1,0 +1,233 @@
+import { ExplorerUiLinkAddress } from '@workspace/explorer/ui/explorer-ui-link-address'
+import { ExplorerUiLinkSignature } from '@workspace/explorer/ui/explorer-ui-link-signature'
+import type {
+  TransactionInspectorAccountReference,
+  TransactionInspectorResult,
+} from '@workspace/solana-client/parse-transaction-inspector-input'
+import { useParseTransactionInspectorInput } from '@workspace/solana-client-react/use-parse-transaction-inspector-input'
+import { Badge } from '@workspace/ui/components/badge'
+import { Button } from '@workspace/ui/components/button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@workspace/ui/components/table'
+import { Textarea } from '@workspace/ui/components/textarea'
+import { UiCard } from '@workspace/ui/components/ui-card'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+
+const EXPLORER_BASE_PATH = '/explorer'
+
+export default function ToolsFeatureTransactionInspector() {
+  const [input, setInput] = useState('')
+  const { data, error, isLoading } = useParseTransactionInspectorInput(input)
+
+  return (
+    <UiCard
+      action={
+        input ? (
+          <Button onClick={() => setInput('')} type="button" variant="outline">
+            Clear
+          </Button>
+        ) : null
+      }
+      backButtonTo="/tools"
+      contentProps={{ className: 'space-y-4' }}
+      title="Transaction Inspector"
+    >
+      <Textarea
+        className="min-h-36 font-mono text-xs md:text-sm"
+        onChange={(event) => setInput(event.target.value)}
+        placeholder="Paste a base58 or base64 encoded transaction or transaction message"
+        value={input}
+      />
+      {isLoading ? <p className="text-muted-foreground text-sm">Parsing transaction...</p> : null}
+      {error ? <p className="text-destructive text-sm">{error.message}</p> : null}
+      {data ? <TransactionInspectorResultView result={data} /> : null}
+    </UiCard>
+  )
+}
+
+function TransactionInspectorResultView({ result }: { result: TransactionInspectorResult }) {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-2 rounded-md border p-3 text-sm md:grid-cols-2">
+        <InspectorField label="Encoding" value={result.encoding} />
+        <InspectorField
+          label="Fee payer"
+          value={
+            result.feePayer ? (
+              <ExplorerUiLinkAddress address={result.feePayer} basePath={EXPLORER_BASE_PATH} className="text-xs" />
+            ) : (
+              'Unknown'
+            )
+          }
+        />
+        <InspectorField label="Message bytes" value={result.rawMessage.length.toString()} />
+        <InspectorField label="Signatures" value={result.signatures.length.toString()} />
+        <InspectorField label="Source bytes" value={result.sourceBytesLength.toString()} />
+        <InspectorField label="Version" value={result.version.toString()} />
+      </div>
+      <SignatureTable result={result} />
+      <AccountTable result={result} />
+      <InstructionTable result={result} />
+    </div>
+  )
+}
+
+function AccountTable({ result }: { result: TransactionInspectorResult }) {
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead>Account</TableHead>
+            <TableHead className="w-[96px] text-right">Index</TableHead>
+            <TableHead className="w-[140px] text-right">Source</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {result.accountReferences.map((accountReference, index) => (
+            <TableRow className="hover:bg-transparent" key={accountReference.key}>
+              <TableCell>
+                <AccountReferenceValue accountReference={accountReference} />
+              </TableCell>
+              <TableCell className="w-[96px] text-right">{index}</TableCell>
+              <TableCell className="w-[140px] text-right capitalize">{accountReference.source}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function AccountReferenceValue({ accountReference }: { accountReference: TransactionInspectorAccountReference }) {
+  if (accountReference.address) {
+    return (
+      <ExplorerUiLinkAddress address={accountReference.address} basePath={EXPLORER_BASE_PATH} className="text-xs" />
+    )
+  }
+
+  if (!accountReference.lookupTableAddress || accountReference.lookupTableIndex === undefined) {
+    return <span className="text-muted-foreground text-xs">Unknown</span>
+  }
+
+  return (
+    <div className="space-y-1">
+      <ExplorerUiLinkAddress
+        address={accountReference.lookupTableAddress}
+        basePath={EXPLORER_BASE_PATH}
+        className="text-xs"
+      />
+      <div className="text-muted-foreground text-xs">Lookup index #{accountReference.lookupTableIndex}</div>
+    </div>
+  )
+}
+
+function InspectorField({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-muted-foreground text-xs">{label}</div>
+      <div className="break-all font-mono">{value}</div>
+    </div>
+  )
+}
+
+function InstructionTable({ result }: { result: TransactionInspectorResult }) {
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead>Program</TableHead>
+            <TableHead>Accounts</TableHead>
+            <TableHead>Data</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {result.instructions.map((instruction, index) => {
+            return (
+              <TableRow className="hover:bg-transparent" key={`${instruction.programAddressIndex}-${index}`}>
+                <TableCell>
+                  {instruction.programAccountReference ? (
+                    <AccountReferenceValue accountReference={instruction.programAccountReference} />
+                  ) : (
+                    `Account #${instruction.programAddressIndex}`
+                  )}
+                </TableCell>
+                <TableCell className="space-y-1 align-top">
+                  {instruction.accountIndices.length ? (
+                    instruction.accountIndices.map((accountIndex, itemIndex) => {
+                      const accountReference = instruction.accountReferences[itemIndex]
+
+                      return (
+                        <div className="flex flex-wrap items-center gap-2" key={`${accountIndex}-${itemIndex}`}>
+                          <Badge variant="outline">#{accountIndex}</Badge>
+                          {accountReference ? (
+                            <AccountReferenceValue accountReference={accountReference} />
+                          ) : (
+                            <span className="text-muted-foreground text-xs">Unknown</span>
+                          )}
+                        </div>
+                      )
+                    })
+                  ) : (
+                    <span className="text-muted-foreground">None</span>
+                  )}
+                </TableCell>
+                <TableCell className="max-w-64 break-all font-mono text-xs">
+                  {instruction.dataBase58 || 'Empty'}
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function SignatureTable({ result }: { result: TransactionInspectorResult }) {
+  if (!result.signatures.length) {
+    return null
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead>Signer</TableHead>
+            <TableHead>Signature</TableHead>
+            <TableHead className="w-[120px] text-right">Validity</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {result.signatures.map(({ address, signature, verified }) => (
+            <TableRow className="hover:bg-transparent" key={address}>
+              <TableCell>
+                <ExplorerUiLinkAddress address={address} basePath={EXPLORER_BASE_PATH} className="text-xs" />
+              </TableCell>
+              <TableCell>
+                {signature ? (
+                  <ExplorerUiLinkSignature basePath={EXPLORER_BASE_PATH} className="text-xs" signature={signature} />
+                ) : (
+                  'Missing'
+                )}
+              </TableCell>
+              <TableCell className="w-[120px] text-right">
+                <SignatureValidityBadge verified={verified} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function SignatureValidityBadge({ verified }: { verified: boolean | undefined }) {
+  if (verified === undefined) {
+    return <Badge variant="outline">N/A</Badge>
+  }
+
+  return <Badge variant={verified ? 'success' : 'destructive'}>{verified ? 'Valid' : 'Invalid'}</Badge>
+}

--- a/packages/tools/src/tools-routes.tsx
+++ b/packages/tools/src/tools-routes.tsx
@@ -8,6 +8,7 @@ const ToolsFeatureAirdrop = lazy(() => import('./tools-feature-airdrop.tsx'))
 const ToolsFeatureCreateToken = lazy(() => import('./tools-feature-create-token.tsx'))
 const ToolsFeatureMintToken = lazy(() => import('./tools-feature-mint-token.tsx'))
 const ToolsFeatureOverview = lazy(() => import('./tools-feature-overview.tsx'))
+const ToolsFeatureTransactionInspector = lazy(() => import('./tools-feature-transaction-inspector.tsx'))
 
 export default function ToolsRoutes() {
   const account = useAccountActive()
@@ -18,6 +19,7 @@ export default function ToolsRoutes() {
     { element: <ToolsFeatureCreateToken account={account} network={network} />, path: 'create-token' },
     { element: <ToolsFeatureMintToken />, path: 'mint-token' },
     { element: <ToolsFeatureMintToken />, path: 'create-nft' },
+    { element: <ToolsFeatureTransactionInspector />, path: 'transaction-inspector' },
   ])
 
   return <UiPage>{routes}</UiPage>

--- a/packages/tools/src/tools.tsx
+++ b/packages/tools/src/tools.tsx
@@ -9,4 +9,5 @@ export interface Tool {
 export const tools: Tool[] = [
   { icon: 'airdrop', label: 'Airdrop', path: '/tools/airdrop' },
   { icon: 'coins', label: 'Token Creator', path: '/tools/create-token' },
+  { icon: 'search', label: 'Transaction Inspector', path: '/tools/transaction-inspector' },
 ]

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -17,6 +17,8 @@ const badgeVariants = cva(
           'border-transparent bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90',
         outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
         secondary: 'border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        success:
+          'border-transparent bg-success text-success-foreground focus-visible:ring-success/20 dark:bg-success/60 dark:focus-visible:ring-success/40 [a&]:hover:bg-success/90',
       },
     },
   },

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -23,6 +23,8 @@
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.577 0.245 27.325);
+  --success: var(--color-green-500);
+  --success-foreground: oklch(1 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -59,6 +61,8 @@
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
   --destructive-foreground: oklch(0.637 0.237 25.331);
+  --success: var(--color-green-500);
+  --success-foreground: oklch(1 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.556 0 0);
@@ -94,6 +98,8 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);


### PR DESCRIPTION
Parse base58 and base64 transaction inspector input in solana-client.

Expose the parser through solana-client-react and the wallet tools route.

Add Devnet transaction fixtures for base58 and base64 parsing.
<img width="733" height="1164" alt="image" src="https://github.com/user-attachments/assets/a0def150-55db-465d-8767-94b766f9bd30" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction Inspector UI: paste base58/base64 Solana transactions to view metadata, accounts, instructions, signatures, and links; lazily loaded route.
  * Parsing utilities and React hook: client-side parser and hook to normalize input, parse transactions, and surface results to the UI.

* **Tests**
  * Unit tests covering parsing, encoding selection, signature verification, tamper detection, and invalid-input errors.

* **Style**
  * Added a "success" badge variant and minor signature link rendering tweaks.

* **Chores**
  * Small dependency update for runtime package resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->