### PR TITLE
fix: validate send destination submit

### DIFF
--- a/packages/portfolio/src/ui/portfolio-ui-send-destination.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-send-destination.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import { tryCatch } from '@workspace/core/try-catch'
 import { solanaAddressSchema } from '@workspace/db/solana/solana-address-schema'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
@@ -24,7 +25,9 @@ export function PortfolioUiSendDestination({
   const { t } = useTranslation('portfolio')
   const destinationId = useId()
   const formSchema = z.object({
-    destination: solanaAddressSchema,
+    destination: z.string().refine((value) => !value || solanaAddressSchema.safeParse(value).success, {
+      message: 'Invalid Solana address',
+    }),
   })
 
   type PortfolioUiSendMintInput = z.infer<typeof formSchema>
@@ -36,9 +39,16 @@ export function PortfolioUiSendDestination({
     mode: 'all',
     resolver: zodResolver(formSchema),
   })
+  const destination = form.watch('destination')
 
   async function handleSubmit(data: PortfolioUiSendMintInput) {
-    await submit({ destination: data.destination })
+    if (!data.destination) {
+      return
+    }
+    const { error: submitError } = await tryCatch(submit({ destination: data.destination }))
+    if (submitError) {
+      return
+    }
   }
 
   return (
@@ -75,7 +85,7 @@ export function PortfolioUiSendDestination({
             </FieldSet>
 
             <Field className="flex justify-end" orientation="horizontal">
-              <Button disabled={!form.formState.isValid || isLoading} type="submit">
+              <Button disabled={!destination || !form.formState.isValid || isLoading} type="submit">
                 {isLoading ? <UiLoader className="size-4" /> : null}
                 {t(($) => $.actionSend)}
               </Button>


### PR DESCRIPTION
Allow an empty destination while editing the form and disable submit until a value is present.

Ignore empty submits, then wrap destination submission with tryCatch so submit errors are handled without throwing from the form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent "Invalid Solana address" error message for address validation.
  * Submit button now correctly enables/disables based on the destination field value.
  * Submission stops if destination is empty and now handles submit errors gracefully to prevent invalid processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->