### PR TITLE
feat(tools): add tool for Solana staking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -551,6 +551,7 @@
       "name": "@workspace/solana-client",
       "version": "0.0.0",
       "dependencies": {
+        "@solana-program/stake": "catalog:",
         "@solana-program/system": "catalog:",
         "@solana-program/token": "catalog:",
         "@solana-program/token-2022": "catalog:",
@@ -572,6 +573,7 @@
       "dependencies": {
         "@solana/kit": "catalog:",
         "@tanstack/react-query": "catalog:",
+        "@workspace/core": "workspace:*",
         "@workspace/db": "workspace:*",
         "@workspace/db-react": "workspace:*",
         "@workspace/keypair": "workspace:*",
@@ -595,8 +597,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "catalog:",
+        "@solana-program/stake": "catalog:",
         "@solana/kit": "catalog:",
         "@tanstack/react-query": "catalog:",
+        "@workspace/core": "workspace:*",
         "@workspace/db": "workspace:*",
         "@workspace/db-react": "workspace:*",
         "@workspace/explorer": "workspace:*",
@@ -625,6 +629,7 @@
       "name": "@workspace/ui",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "1.4.0",
         "@hookform/resolvers": "catalog:",
         "@nkzw/use-relative-time": "1.2.3",
         "@radix-ui/react-accordion": "1.2.12",
@@ -717,6 +722,7 @@
     "@playwright/test": "1.57.0",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-slot": "1.2.4",
+    "@solana-program/stake": "0.6.0",
     "@solana-program/system": "0.12.0",
     "@solana-program/token": "0.13.0",
     "@solana-program/token-2022": "0.9.0",
@@ -845,6 +851,10 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@base-ui/react": ["@base-ui/react@1.4.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.2.7", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg=="],
+
+    "@base-ui/utils": ["@base-ui/utils@0.2.7", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
 
@@ -1162,13 +1172,13 @@
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
-    "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
 
-    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
-    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@hapi/address": ["@hapi/address@5.1.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA=="],
 
@@ -1541,6 +1551,8 @@
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
     "@socketsecurity/bun-security-scanner": ["@socketsecurity/bun-security-scanner@1.1.2", "", {}, "sha512-TdsAg6SMolubyZ6HfIjLWlANfHvhV6i7pdWof4OQ33zPEwXJm2ilA755levHMR618MKq22+06Ag8efiVKowxqA=="],
+
+    "@solana-program/stake": ["@solana-program/stake@0.6.0", "", { "peerDependencies": { "@solana/kit": "^6.0" } }, "sha512-s2b2s1OUevNpPW4qkI2gbasdTnojGAt6mMqyoLzjycIpAqx68meSH+QTkHCGHAPDnmNACE81iz0qxTYZ9lxKkw=="],
 
     "@solana-program/system": ["@solana-program/system@0.12.0", "", { "peerDependencies": { "@solana/kit": "^6.1.0" } }, "sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng=="],
 
@@ -3278,6 +3290,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
+
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
@@ -3774,6 +3788,10 @@
 
     "@babel/traverse/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
+    "@base-ui/react/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@base-ui/utils/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@cloudflare/vite-plugin/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg=="],
 
     "@cloudflare/vite-plugin/miniflare": ["miniflare@4.20260415.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260415.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng=="],
@@ -3871,6 +3889,8 @@
     "@radix-ui/react-menu/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-popper/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -4306,6 +4326,8 @@
 
     "@octokit/request/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
+    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
     "@solana-program/token-2022/@solana/sysvars/@solana/accounts": ["@solana/accounts@5.4.0", "", { "dependencies": { "@solana/addresses": "5.4.0", "@solana/codecs-core": "5.4.0", "@solana/codecs-strings": "5.4.0", "@solana/errors": "5.4.0", "@solana/rpc-spec": "5.4.0", "@solana/rpc-types": "5.4.0" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qHtAtwCcCFTXcya6JOOG1nzYicivivN/JkcYNHr10qOp9b4MVRkfW1ZAAG1CNzjMe5+mwtEl60RwdsY9jXNb+Q=="],
 
     "@solana-program/token-2022/@solana/sysvars/@solana/codecs": ["@solana/codecs@5.4.0", "", { "dependencies": { "@solana/codecs-core": "5.4.0", "@solana/codecs-data-structures": "5.4.0", "@solana/codecs-numbers": "5.4.0", "@solana/codecs-strings": "5.4.0", "@solana/options": "5.4.0" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-IbDCUvNX0MrkQahxiXj9rHzkd/fYfp1F2nTJkHGH8v+vPfD+YPjl007ZBM38EnCeXj/Xn+hxqBBivPvIHP29dA=="],
@@ -4657,6 +4679,10 @@
     "@cloudflare/vite-plugin/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260415.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ=="],
 
     "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
+
+    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
     "@solana-program/token-2022/@solana/sysvars/@solana/accounts/@solana/addresses": ["@solana/addresses@5.4.0", "", { "dependencies": { "@solana/assertions": "5.4.0", "@solana/codecs-core": "5.4.0", "@solana/codecs-strings": "5.4.0", "@solana/errors": "5.4.0", "@solana/nominal-types": "5.4.0" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YRHiH30S8qDV4bZ+mtEk589PGfBuXHzD/fK2Z+YI5f/+s+yi/5le/fVw7PN6LxnnmVQKiRCDUiNF+WmFFKi6QQ=="],
 

--- a/cspell.config.mts
+++ b/cspell.config.mts
@@ -70,6 +70,7 @@ const config: CSpellSettings = {
     'tobeycodes',
     'unimodules',
     'unruggable',
+    'unstake',
     'viewpager',
     'vitaly',
     'wordlist',

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@playwright/test": "1.57.0",
     "@radix-ui/react-select": "2.2.6",
     "@radix-ui/react-slot": "1.2.4",
+    "@solana-program/stake": "0.6.0",
     "@solana-program/system": "0.12.0",
     "@solana-program/token": "0.13.0",
     "@solana-program/token-2022": "0.9.0",

--- a/packages/solana-client-react/package.json
+++ b/packages/solana-client-react/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@solana/kit": "catalog:",
     "@tanstack/react-query": "catalog:",
+    "@workspace/core": "workspace:*",
     "@workspace/db": "workspace:*",
     "@workspace/db-react": "workspace:*",
     "@workspace/keypair": "workspace:*",

--- a/packages/solana-client-react/src/get-transaction-signer.ts
+++ b/packages/solana-client-react/src/get-transaction-signer.ts
@@ -1,0 +1,22 @@
+import { tryCatch } from '@workspace/core/try-catch'
+import type { Account } from '@workspace/db/account/account'
+import { createKeyPairSignerFromJson } from '@workspace/keypair/create-key-pair-signer-from-json'
+
+export async function getTransactionSigner(
+  account: Account,
+  readSecretKey: (input: { id: string }) => Promise<string | undefined>,
+) {
+  const { data, error } = await tryCatch(
+    Promise.resolve().then(async () => {
+      const secretKey = await readSecretKey({ id: account.id })
+      if (!secretKey) {
+        throw new Error('Missing account secret key')
+      }
+      return createKeyPairSignerFromJson({ json: secretKey })
+    }),
+  )
+  if (error) {
+    throw error
+  }
+  return data
+}

--- a/packages/solana-client-react/src/use-close-stake-account.tsx
+++ b/packages/solana-client-react/src/use-close-stake-account.tsx
@@ -1,0 +1,84 @@
+import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { Account } from '@workspace/db/account/account'
+import type { Network } from '@workspace/db/network/network'
+import { useAccountReadSecretKey } from '@workspace/db-react/use-account-read-secret-key'
+import { closeStakeAccount } from '@workspace/solana-client/close-stake-account'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { getTransactionSigner } from './get-transaction-signer.ts'
+import { getBalanceQueryOptions } from './use-get-balance.tsx'
+import { getStakeAccountsQueryOptions } from './use-get-stake-accounts.tsx'
+import { useSolanaClient } from './use-solana-client.tsx'
+
+export function closeStakeAccountMutationOptions({
+  account,
+  client,
+  queryClient,
+  readSecretKey,
+  network,
+}: {
+  account: Account
+  client: SolanaClient
+  queryClient: QueryClient
+  readSecretKey: (input: { id: string }) => Promise<string | undefined>
+  network: Network
+}) {
+  return mutationOptions({
+    mutationFn: async (stakeAccount: StakeAccount) => {
+      const transactionSigner = await getTransactionSigner(account, readSecretKey)
+      return closeStakeAccount(client, {
+        amount: stakeAccount.lamports,
+        recipient: transactionSigner.address,
+        stake: stakeAccount.pubkey,
+        transactionSigner,
+      })
+    },
+    onError: () => {
+      toastError('Failed to close stake account.')
+    },
+    onSuccess: async (signature) => {
+      await invalidateStakeAccountQueries({ account, client, network, queryClient })
+      toastSuccess(`Stake account closed: ${ellipsify(signature, 6, '...')}`)
+    },
+  })
+}
+
+export function useCloseStakeAccount({ account, network }: { account: Account; network: Network }) {
+  const client = useSolanaClient({ network })
+  const queryClient = useQueryClient()
+  const readSecretKeyMutation = useAccountReadSecretKey()
+
+  return useMutation(
+    closeStakeAccountMutationOptions({
+      account,
+      client,
+      network,
+      queryClient,
+      readSecretKey: readSecretKeyMutation.mutateAsync,
+    }),
+  )
+}
+
+async function invalidateStakeAccountQueries({
+  account,
+  client,
+  queryClient,
+  network,
+}: {
+  account: Account
+  client: SolanaClient
+  queryClient: QueryClient
+  network: Network
+}) {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: getBalanceQueryOptions({ address: account.publicKey, client, network }).queryKey,
+    }),
+    queryClient.invalidateQueries({
+      queryKey: getStakeAccountsQueryOptions({ address: account.publicKey, client, network }).queryKey,
+    }),
+  ])
+}

--- a/packages/solana-client-react/src/use-create-stake-account.tsx
+++ b/packages/solana-client-react/src/use-create-stake-account.tsx
@@ -1,0 +1,88 @@
+import type { Address, Lamports } from '@solana/kit'
+import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { Account } from '@workspace/db/account/account'
+import type { Network } from '@workspace/db/network/network'
+import { useAccountReadSecretKey } from '@workspace/db-react/use-account-read-secret-key'
+import { createStakeAccount } from '@workspace/solana-client/create-stake-account'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { getTransactionSigner } from './get-transaction-signer.ts'
+import { getBalanceQueryOptions } from './use-get-balance.tsx'
+import { getStakeAccountsQueryOptions } from './use-get-stake-accounts.tsx'
+import { useSolanaClient } from './use-solana-client.tsx'
+
+export interface CreateStakeAccountInput {
+  amount: Lamports
+  vote: Address
+}
+
+export function createStakeAccountMutationOptions({
+  account,
+  client,
+  queryClient,
+  readSecretKey,
+  network,
+}: {
+  account: Account
+  client: SolanaClient
+  queryClient: QueryClient
+  readSecretKey: (input: { id: string }) => Promise<string | undefined>
+  network: Network
+}) {
+  return mutationOptions({
+    mutationFn: async ({ amount, vote }: CreateStakeAccountInput) => {
+      const transactionSigner = await getTransactionSigner(account, readSecretKey)
+      return createStakeAccount(client, {
+        amount,
+        transactionSigner,
+        vote,
+      })
+    },
+    onError: () => {
+      toastError('Failed to stake SOL.')
+    },
+    onSuccess: async ({ signature }) => {
+      await invalidateStakeAccountQueries({ account, client, network, queryClient })
+      toastSuccess(`Stake transaction confirmed: ${ellipsify(signature, 6, '...')}`)
+    },
+  })
+}
+
+export function useCreateStakeAccount({ account, network }: { account: Account; network: Network }) {
+  const client = useSolanaClient({ network })
+  const queryClient = useQueryClient()
+  const readSecretKeyMutation = useAccountReadSecretKey()
+
+  return useMutation(
+    createStakeAccountMutationOptions({
+      account,
+      client,
+      network,
+      queryClient,
+      readSecretKey: readSecretKeyMutation.mutateAsync,
+    }),
+  )
+}
+
+async function invalidateStakeAccountQueries({
+  account,
+  client,
+  queryClient,
+  network,
+}: {
+  account: Account
+  client: SolanaClient
+  queryClient: QueryClient
+  network: Network
+}) {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: getBalanceQueryOptions({ address: account.publicKey, client, network }).queryKey,
+    }),
+    queryClient.invalidateQueries({
+      queryKey: getStakeAccountsQueryOptions({ address: account.publicKey, client, network }).queryKey,
+    }),
+  ])
+}

--- a/packages/solana-client-react/src/use-deactivate-stake-account.tsx
+++ b/packages/solana-client-react/src/use-deactivate-stake-account.tsx
@@ -1,0 +1,62 @@
+import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { Account } from '@workspace/db/account/account'
+import type { Network } from '@workspace/db/network/network'
+import { useAccountReadSecretKey } from '@workspace/db-react/use-account-read-secret-key'
+import { deactivateStakeAccount } from '@workspace/solana-client/deactivate-stake-account'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { getTransactionSigner } from './get-transaction-signer.ts'
+import { getStakeAccountsQueryOptions } from './use-get-stake-accounts.tsx'
+import { useSolanaClient } from './use-solana-client.tsx'
+
+export function deactivateStakeAccountMutationOptions({
+  account,
+  client,
+  queryClient,
+  readSecretKey,
+  network,
+}: {
+  account: Account
+  client: SolanaClient
+  queryClient: QueryClient
+  readSecretKey: (input: { id: string }) => Promise<string | undefined>
+  network: Network
+}) {
+  return mutationOptions({
+    mutationFn: async (stakeAccount: StakeAccount) => {
+      const transactionSigner = await getTransactionSigner(account, readSecretKey)
+      return deactivateStakeAccount(client, {
+        stake: stakeAccount.pubkey,
+        transactionSigner,
+      })
+    },
+    onError: () => {
+      toastError('Failed to unstake account.')
+    },
+    onSuccess: async (signature) => {
+      await queryClient.invalidateQueries({
+        queryKey: getStakeAccountsQueryOptions({ address: account.publicKey, client, network }).queryKey,
+      })
+      toastSuccess(`Stake account deactivated: ${ellipsify(signature, 6, '...')}`)
+    },
+  })
+}
+
+export function useDeactivateStakeAccount({ account, network }: { account: Account; network: Network }) {
+  const client = useSolanaClient({ network })
+  const queryClient = useQueryClient()
+  const readSecretKeyMutation = useAccountReadSecretKey()
+
+  return useMutation(
+    deactivateStakeAccountMutationOptions({
+      account,
+      client,
+      network,
+      queryClient,
+      readSecretKey: readSecretKeyMutation.mutateAsync,
+    }),
+  )
+}

--- a/packages/solana-client-react/src/use-get-stake-account-rent-reserve.tsx
+++ b/packages/solana-client-react/src/use-get-stake-account-rent-reserve.tsx
@@ -1,0 +1,25 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import type { Network } from '@workspace/db/network/network'
+import { STAKE_ACCOUNT_SPACE } from '@workspace/solana-client/create-stake-account'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
+import { useSolanaClient } from './use-solana-client.tsx'
+
+export function getStakeAccountRentReserveQueryOptions({
+  client,
+  network,
+}: {
+  client: SolanaClient
+  network: Network
+}) {
+  return queryOptions({
+    queryFn: async () => await client.rpc.getMinimumBalanceForRentExemption(STAKE_ACCOUNT_SPACE).send(),
+    queryKey: ['stake-rent-reserve', { networkId: network.id }],
+    retry: 1,
+    staleTime: Infinity,
+  })
+}
+
+export function useGetStakeAccountRentReserve({ network }: { network: Network }) {
+  const client = useSolanaClient({ network })
+  return useQuery(getStakeAccountRentReserveQueryOptions({ client, network }))
+}

--- a/packages/solana-client-react/src/use-get-stake-accounts.tsx
+++ b/packages/solana-client-react/src/use-get-stake-accounts.tsx
@@ -1,0 +1,27 @@
+import type { Address } from '@solana/kit'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import type { Network } from '@workspace/db/network/network'
+import { getStakeAccounts } from '@workspace/solana-client/get-stake-accounts'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
+import { useSolanaClient } from './use-solana-client.tsx'
+
+export function getStakeAccountsQueryOptions({
+  address,
+  client,
+  network,
+}: {
+  address: Address
+  client: SolanaClient
+  network: Network
+}) {
+  return queryOptions({
+    queryFn: async () => await getStakeAccounts(client, { address }),
+    queryKey: ['stake', { address, networkId: network.id }],
+    retry: 1,
+  })
+}
+
+export function useGetStakeAccounts({ address, network }: { address: Address; network: Network }) {
+  const client = useSolanaClient({ network })
+  return useQuery(getStakeAccountsQueryOptions({ address, client, network }))
+}

--- a/packages/solana-client-react/src/use-get-vote-accounts.tsx
+++ b/packages/solana-client-react/src/use-get-vote-accounts.tsx
@@ -1,0 +1,21 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import type { Network } from '@workspace/db/network/network'
+import { getVoteAccounts } from '@workspace/solana-client/get-vote-accounts'
+import type { SolanaClient } from '@workspace/solana-client/solana-client'
+import { useSolanaClient } from './use-solana-client.tsx'
+
+export type VoteAccount = Awaited<ReturnType<typeof getVoteAccounts>>[number]
+
+export function getVoteAccountsQueryOptions({ client, network }: { client: SolanaClient; network: Network }) {
+  return queryOptions({
+    queryFn: async () => await getVoteAccounts(client),
+    queryKey: ['stake', { networkId: network.id }],
+    retry: 1,
+    staleTime: 10 * 60 * 1000,
+  })
+}
+
+export function useGetVoteAccounts({ network }: { network: Network }) {
+  const client = useSolanaClient({ network })
+  return useQuery(getVoteAccountsQueryOptions({ client, network }))
+}

--- a/packages/solana-client/package.json
+++ b/packages/solana-client/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@solana-program/stake": "catalog:",
     "@solana-program/system": "catalog:",
     "@solana-program/token": "catalog:",
     "@solana-program/token-2022": "catalog:",

--- a/packages/solana-client/src/close-stake-account.ts
+++ b/packages/solana-client/src/close-stake-account.ts
@@ -1,0 +1,38 @@
+import type { Address, Lamports, Signature, TransactionSigner } from '@solana/kit'
+import { getWithdrawInstruction } from '@solana-program/stake'
+import { tryCatch } from '@workspace/core/try-catch'
+import type { LatestBlockhash } from './get-latest-blockhash.ts'
+import { signAndSendTransaction } from './sign-and-send-transaction.ts'
+import type { SolanaClient } from './solana-client.ts'
+
+export interface CloseStakeAccountOptions {
+  amount: Lamports
+  latestBlockhash?: LatestBlockhash | undefined
+  recipient: Address
+  stake: Address
+  transactionSigner: TransactionSigner
+}
+
+export async function closeStakeAccount(
+  client: SolanaClient,
+  { amount, latestBlockhash, recipient, stake, transactionSigner }: CloseStakeAccountOptions,
+): Promise<Signature> {
+  const { data: signature, error } = await tryCatch(
+    signAndSendTransaction(client, {
+      instructions: [
+        getWithdrawInstruction({
+          args: amount,
+          recipient,
+          stake,
+          withdrawAuthority: transactionSigner,
+        }),
+      ],
+      latestBlockhash,
+      transactionSigner,
+    }),
+  )
+  if (error) {
+    throw error
+  }
+  return signature
+}

--- a/packages/solana-client/src/constants.ts
+++ b/packages/solana-client/src/constants.ts
@@ -6,6 +6,6 @@ export const NATIVE_LOADER = address('NativeLoader111111111111111111111111111111
 export const BPF_LOADER = address('BPFLoader2111111111111111111111111111111111')
 export const TRANSACTION_FEE_LAMPORTS = BigInt(5000)
 
+export { STAKE_PROGRAM_ADDRESS } from '@solana-program/stake'
 export { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token'
-
 export { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022'

--- a/packages/solana-client/src/create-stake-account.ts
+++ b/packages/solana-client/src/create-stake-account.ts
@@ -1,0 +1,81 @@
+import {
+  type Address,
+  address,
+  generateKeyPairSigner,
+  type Lamports,
+  type Signature,
+  type TransactionSigner,
+} from '@solana/kit'
+import { getDelegateStakeInstruction, getInitializeInstruction } from '@solana-program/stake'
+import { getCreateAccountInstruction } from '@solana-program/system'
+import { STAKE_PROGRAM_ADDRESS } from './constants.ts'
+import type { LatestBlockhash } from './get-latest-blockhash.ts'
+import { signAndSendTransaction } from './sign-and-send-transaction.ts'
+import type { SolanaClient } from './solana-client.ts'
+
+export const STAKE_ACCOUNT_SPACE = 200n
+const STAKE_CONFIG_ADDRESS = address('StakeConfig11111111111111111111111111111111')
+
+export interface CreateStakeAccountOptions {
+  amount: Lamports
+  latestBlockhash?: LatestBlockhash | undefined
+  stakeAccount?: TransactionSigner
+  transactionSigner: TransactionSigner
+  vote: Address
+}
+
+export interface CreateStakeAccount {
+  signature: Signature
+  stakeAccount: Address
+}
+
+export async function createStakeAccount(
+  client: SolanaClient,
+  { amount, latestBlockhash, stakeAccount, transactionSigner, vote }: CreateStakeAccountOptions,
+): Promise<CreateStakeAccount> {
+  stakeAccount = stakeAccount ?? (await generateKeyPairSigner())
+
+  const rent = await client.rpc.getMinimumBalanceForRentExemption(STAKE_ACCOUNT_SPACE).send()
+  if (amount <= rent) {
+    throw new Error(`Stake amount must be greater than the rent exempt reserve.`)
+  }
+
+  const createAccountInstruction = getCreateAccountInstruction({
+    lamports: amount,
+    newAccount: stakeAccount,
+    payer: transactionSigner,
+    programAddress: STAKE_PROGRAM_ADDRESS,
+    space: STAKE_ACCOUNT_SPACE,
+  })
+
+  const initializeInstruction = getInitializeInstruction({
+    arg0: {
+      staker: transactionSigner.address,
+      withdrawer: transactionSigner.address,
+    },
+    arg1: {
+      custodian: transactionSigner.address,
+      epoch: 0n,
+      unixTimestamp: 0n,
+    },
+    stake: stakeAccount.address,
+  })
+
+  const delegateStakeInstruction = getDelegateStakeInstruction({
+    stake: stakeAccount.address,
+    stakeAuthority: transactionSigner,
+    unused: STAKE_CONFIG_ADDRESS,
+    vote,
+  })
+
+  const signature = await signAndSendTransaction(client, {
+    instructions: [createAccountInstruction, initializeInstruction, delegateStakeInstruction],
+    latestBlockhash,
+    transactionSigner,
+  })
+
+  return {
+    signature,
+    stakeAccount: stakeAccount.address,
+  }
+}

--- a/packages/solana-client/src/deactivate-stake-account.ts
+++ b/packages/solana-client/src/deactivate-stake-account.ts
@@ -1,0 +1,34 @@
+import type { Address, Signature, TransactionSigner } from '@solana/kit'
+import { getDeactivateInstruction } from '@solana-program/stake'
+import { tryCatch } from '@workspace/core/try-catch'
+import type { LatestBlockhash } from './get-latest-blockhash.ts'
+import { signAndSendTransaction } from './sign-and-send-transaction.ts'
+import type { SolanaClient } from './solana-client.ts'
+
+export interface DeactivateStakeAccountOptions {
+  latestBlockhash?: LatestBlockhash | undefined
+  stake: Address
+  transactionSigner: TransactionSigner
+}
+
+export async function deactivateStakeAccount(
+  client: SolanaClient,
+  { latestBlockhash, stake, transactionSigner }: DeactivateStakeAccountOptions,
+): Promise<Signature> {
+  const { data: signature, error } = await tryCatch(
+    signAndSendTransaction(client, {
+      instructions: [
+        getDeactivateInstruction({
+          stake,
+          stakeAuthority: transactionSigner,
+        }),
+      ],
+      latestBlockhash,
+      transactionSigner,
+    }),
+  )
+  if (error) {
+    throw error
+  }
+  return signature
+}

--- a/packages/solana-client/src/get-stake-accounts.ts
+++ b/packages/solana-client/src/get-stake-accounts.ts
@@ -1,0 +1,74 @@
+import type { Address, Base58EncodedBytes, Lamports } from '@solana/kit'
+import { STAKE_PROGRAM_ADDRESS } from './constants.ts'
+import type { SolanaClient } from './solana-client.ts'
+
+export interface StakeAccount {
+  data: StakeAccountData
+  lamports: Lamports
+  pubkey: Address
+}
+
+export interface StakeAccountData {
+  meta: {
+    authorized: {
+      staker: Address
+      withdrawer: Address
+    }
+    lockup: {
+      custodian: Address
+      epoch: string
+      unixTimestamp: string
+    }
+    rentExemptReserve: string
+  }
+  stake: {
+    creditsObserved: string
+    delegation: {
+      activationEpoch: string
+      deactivationEpoch: string
+      stake: string
+      voter: Address
+      warmupCooldownRate: number
+    }
+  } | null
+}
+
+interface ParsedStakeAccountData {
+  parsed: {
+    info: StakeAccountData
+  }
+}
+
+export async function getStakeAccounts(
+  client: SolanaClient,
+  { address }: { address: Address },
+): Promise<StakeAccount[]> {
+  const accounts = await client.rpc
+    .getProgramAccounts(STAKE_PROGRAM_ADDRESS, {
+      encoding: 'jsonParsed',
+      filters: [
+        {
+          memcmp: {
+            bytes: address.toString() as Base58EncodedBytes,
+            encoding: 'base58',
+            offset: 44n, // Offset for Withdraw Authority
+          },
+        },
+      ],
+    })
+    .send()
+
+  return accounts.flatMap((acc) => {
+    const info = (acc.account.data as Partial<ParsedStakeAccountData>)?.parsed?.info
+    if (!info) {
+      return []
+    }
+    return [
+      {
+        data: info,
+        lamports: acc.account.lamports,
+        pubkey: acc.pubkey,
+      },
+    ]
+  })
+}

--- a/packages/solana-client/src/get-vote-accounts.ts
+++ b/packages/solana-client/src/get-vote-accounts.ts
@@ -1,0 +1,12 @@
+import { tryCatch } from '@workspace/core/try-catch'
+import type { SolanaClient } from './solana-client.ts'
+
+export async function getVoteAccounts(client: SolanaClient) {
+  const { data: accounts, error } = await tryCatch(client.rpc.getVoteAccounts().send())
+  if (error) {
+    console.log(error)
+    throw new Error('Error fetching vote accounts')
+  }
+
+  return accounts.current ?? []
+}

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
     "@hookform/resolvers": "catalog:",
+    "@solana-program/stake": "catalog:",
     "@solana/kit": "catalog:",
     "@tanstack/react-query": "catalog:",
+    "@workspace/core": "workspace:*",
     "@workspace/db": "workspace:*",
     "@workspace/db-react": "workspace:*",
     "@workspace/explorer": "workspace:*",

--- a/packages/tools/src/tools-feature-stake.tsx
+++ b/packages/tools/src/tools-feature-stake.tsx
@@ -1,0 +1,135 @@
+import { tryCatch } from '@workspace/core/try-catch'
+import type { Account } from '@workspace/db/account/account'
+import type { Network } from '@workspace/db/network/network'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import { useCloseStakeAccount } from '@workspace/solana-client-react/use-close-stake-account'
+import { useCreateStakeAccount } from '@workspace/solana-client-react/use-create-stake-account'
+import { useDeactivateStakeAccount } from '@workspace/solana-client-react/use-deactivate-stake-account'
+import { useGetBalance } from '@workspace/solana-client-react/use-get-balance'
+import { useGetStakeAccountRentReserve } from '@workspace/solana-client-react/use-get-stake-account-rent-reserve'
+import { useGetStakeAccounts } from '@workspace/solana-client-react/use-get-stake-accounts'
+import { useGetVoteAccounts } from '@workspace/solana-client-react/use-get-vote-accounts'
+import { UiCard } from '@workspace/ui/components/ui-card'
+import { UiDebug } from '@workspace/ui/components/ui-debug'
+import { UiEmpty } from '@workspace/ui/components/ui-empty'
+import { UiLoader } from '@workspace/ui/components/ui-loader'
+import { Navigate, Route, Routes, useNavigate, useParams } from 'react-router'
+import type { StakeAccountActions } from './ui/tools-ui-stake-account-action.tsx'
+import { ToolsUiStakeAccountDetail } from './ui/tools-ui-stake-account-detail.tsx'
+import { ToolsUiStakeAccountsIndex } from './ui/tools-ui-stake-accounts-index.tsx'
+import { ToolsUiStakeCreateForm } from './ui/tools-ui-stake-create-form.tsx'
+
+export default function ToolsFeatureStake({ account, network }: { account: Account; network: Network }) {
+  return (
+    <div className="space-y-2 md:space-y-6">
+      <UiCard backButtonTo="/tools" contentProps={{ className: 'space-y-2 md:space-y-6' }} title="Stake">
+        <Routes>
+          <Route element={<Navigate replace to="/tools/stake/accounts" />} index />
+          <Route element={<ToolsFeatureStakeAccounts account={account} network={network} />} path="accounts/*" />
+          <Route element={<Navigate replace to="/tools/stake/accounts" />} path="*" />
+        </Routes>
+      </UiCard>
+    </div>
+  )
+}
+
+export function ToolsFeatureStakeAccounts({ account, network }: { account: Account; network: Network }) {
+  const accountsQuery = useGetStakeAccounts({ address: account.publicKey, network })
+  const closeStakeAccountMutation = useCloseStakeAccount({ account, network })
+  const deactivateStakeAccountMutation = useDeactivateStakeAccount({ account, network })
+  const accounts = accountsQuery.data ?? []
+  const actions: StakeAccountActions = {
+    close: async (stakeAccount) => {
+      const { error } = await tryCatch(closeStakeAccountMutation.mutateAsync(stakeAccount))
+      return !error
+    },
+    deactivate: async (stakeAccount) => {
+      const { error } = await tryCatch(deactivateStakeAccountMutation.mutateAsync(stakeAccount))
+      return !error
+    },
+    isPending: closeStakeAccountMutation.isPending || deactivateStakeAccountMutation.isPending,
+  }
+
+  return accountsQuery.isLoading ? (
+    <UiLoader />
+  ) : accountsQuery.error ? (
+    <UiDebug data={accountsQuery.error} />
+  ) : (
+    <Routes>
+      <Route
+        element={<ToolsUiStakeAccountsIndex accounts={accounts} actions={actions} authority={account.publicKey} />}
+        index
+      />
+      <Route element={<ToolsFeatureStakeCreate account={account} network={network} />} path="stake" />
+      <Route
+        element={<ToolsFeatureStakeAccountDetail account={account} accounts={accounts} actions={actions} />}
+        path=":address"
+      />
+      <Route element={<Navigate replace to="." />} path="*" />
+    </Routes>
+  )
+}
+
+function ToolsFeatureStakeAccountDetail({
+  accounts,
+  actions,
+  account,
+}: {
+  accounts: StakeAccount[]
+  actions: StakeAccountActions
+  account: Account
+}) {
+  const { address } = useParams<{ address: string }>()
+  const navigate = useNavigate()
+  const stakeAccount = accounts.find((item) => item.pubkey.toString() === address)
+
+  if (!stakeAccount) {
+    return <UiEmpty description="Stake account not found for the active wallet." />
+  }
+
+  return (
+    <ToolsUiStakeAccountDetail
+      account={stakeAccount}
+      actions={actions}
+      authority={account.publicKey}
+      close={async () => {
+        const closed = await actions.close(stakeAccount)
+        if (closed) {
+          navigate('/tools/stake/accounts')
+        }
+      }}
+    />
+  )
+}
+
+function ToolsFeatureStakeCreate({ account, network }: { account: Account; network: Network }) {
+  const createStakeAccountMutation = useCreateStakeAccount({ account, network })
+  const navigate = useNavigate()
+  const rentReserveQuery = useGetStakeAccountRentReserve({ network })
+  const voteAccountsQuery = useGetVoteAccounts({ network })
+  const walletBalanceQuery = useGetBalance({ address: account.publicKey, network })
+
+  return (
+    <ToolsUiStakeCreateForm
+      account={account}
+      createStake={async (input) => {
+        const { data: result, error } = await tryCatch(createStakeAccountMutation.mutateAsync(input))
+        if (error) {
+          throw error
+        }
+        if (!result) {
+          throw new Error('Failed to stake SOL.')
+        }
+        navigate(`/tools/stake/accounts/${result.stakeAccount}`)
+      }}
+      isPending={createStakeAccountMutation.isPending}
+      rentReserve={rentReserveQuery.data}
+      rentReserveIsLoading={rentReserveQuery.isLoading}
+      validators={voteAccountsQuery.data ?? []}
+      validatorsError={voteAccountsQuery.error}
+      validatorsIsLoading={voteAccountsQuery.isLoading}
+      walletBalance={walletBalanceQuery.data?.value}
+      walletBalanceIsLoading={walletBalanceQuery.isLoading}
+    />
+  )
+}

--- a/packages/tools/src/tools-routes.tsx
+++ b/packages/tools/src/tools-routes.tsx
@@ -8,6 +8,7 @@ const ToolsFeatureAirdrop = lazy(() => import('./tools-feature-airdrop.tsx'))
 const ToolsFeatureCreateToken = lazy(() => import('./tools-feature-create-token.tsx'))
 const ToolsFeatureMintToken = lazy(() => import('./tools-feature-mint-token.tsx'))
 const ToolsFeatureOverview = lazy(() => import('./tools-feature-overview.tsx'))
+const ToolsFeatureStake = lazy(() => import('./tools-feature-stake.tsx'))
 const ToolsFeatureTransactionInspector = lazy(() => import('./tools-feature-transaction-inspector.tsx'))
 
 export default function ToolsRoutes() {
@@ -19,6 +20,7 @@ export default function ToolsRoutes() {
     { element: <ToolsFeatureCreateToken account={account} network={network} />, path: 'create-token' },
     { element: <ToolsFeatureMintToken />, path: 'mint-token' },
     { element: <ToolsFeatureMintToken />, path: 'create-nft' },
+    { element: <ToolsFeatureStake account={account} network={network} />, path: 'stake/*' },
     { element: <ToolsFeatureTransactionInspector />, path: 'transaction-inspector' },
   ])
 

--- a/packages/tools/src/tools.tsx
+++ b/packages/tools/src/tools.tsx
@@ -8,6 +8,7 @@ export interface Tool {
 
 export const tools: Tool[] = [
   { icon: 'airdrop', label: 'Airdrop', path: '/tools/airdrop' },
+  { icon: 'handCoins', label: 'Stake', path: '/tools/stake' },
   { icon: 'coins', label: 'Token Creator', path: '/tools/create-token' },
   { icon: 'search', label: 'Transaction Inspector', path: '/tools/transaction-inspector' },
 ]

--- a/packages/tools/src/ui/tools-ui-stake-account-action.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-account-action.tsx
@@ -1,0 +1,71 @@
+import type { Address } from '@solana/kit'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import { lamportsToSol } from '@workspace/solana-client/lamports-to-sol'
+import { Button } from '@workspace/ui/components/button'
+import { UiConfirm } from '@workspace/ui/components/ui-confirm'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { canCloseStakeAccount, canDeactivateStakeAccount } from './tools-ui-stake-utils.ts'
+
+export interface StakeAccountActions {
+  close: (account: StakeAccount) => Promise<boolean>
+  deactivate: (account: StakeAccount) => Promise<boolean>
+  isPending: boolean
+}
+
+export function ToolsUiStakeAccountAction({
+  account,
+  actions,
+  authority,
+  close,
+}: {
+  account: StakeAccount
+  actions: StakeAccountActions
+  authority: Address
+  close?: () => Promise<void>
+}) {
+  if (canCloseStakeAccount(account, authority)) {
+    return (
+      <UiConfirm
+        action={
+          close ??
+          (async () => {
+            await actions.close(account)
+          })
+        }
+        actionLabel="Close"
+        actionVariant="destructive"
+        description={`Withdraw ${lamportsToSol(account.lamports)} SOL and close ${ellipsify(account.pubkey, 6, '...')}.`}
+        title="Close stake account"
+        trigger={
+          <Button disabled={actions.isPending} size="sm" variant="outline">
+            Close
+          </Button>
+        }
+      />
+    )
+  }
+
+  if (canDeactivateStakeAccount(account, authority)) {
+    return (
+      <UiConfirm
+        action={async () => {
+          await actions.deactivate(account)
+        }}
+        actionLabel="Unstake"
+        description={`Deactivate ${lamportsToSol(BigInt(account.data.stake?.delegation.stake ?? 0))} SOL from ${ellipsify(
+          account.pubkey,
+          6,
+          '...',
+        )}.`}
+        title="Unstake account"
+        trigger={
+          <Button disabled={actions.isPending} size="sm" variant="outline">
+            Unstake
+          </Button>
+        }
+      />
+    )
+  }
+
+  return <span className="text-muted-foreground">-</span>
+}

--- a/packages/tools/src/ui/tools-ui-stake-account-card-field.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-account-card-field.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+
+export function ToolsUiStakeAccountCardField({
+  className,
+  label,
+  value,
+}: {
+  className?: string
+  label: string
+  value: ReactNode
+}) {
+  return (
+    <div className={className}>
+      <div className="text-muted-foreground text-xs">{label}</div>
+      <div className="mt-1 min-w-0 font-medium text-sm">{value}</div>
+    </div>
+  )
+}

--- a/packages/tools/src/ui/tools-ui-stake-account-detail.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-account-detail.tsx
@@ -1,0 +1,89 @@
+import type { Address } from '@solana/kit'
+import { ExplorerUiLinkAddress } from '@workspace/explorer/ui/explorer-ui-link-address'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import { lamportsToSol } from '@workspace/solana-client/lamports-to-sol'
+import { Badge } from '@workspace/ui/components/badge'
+import { Table, TableBody, TableCell, TableRow } from '@workspace/ui/components/table'
+import { UiBackButton } from '@workspace/ui/components/ui-back-button'
+import type { ReactNode } from 'react'
+import { type StakeAccountActions, ToolsUiStakeAccountAction } from './tools-ui-stake-account-action.tsx'
+import {
+  formatDeactivationEpoch,
+  formatStakeSol,
+  getStakeAccountBadgeVariant,
+  getStakeAccountStatus,
+} from './tools-ui-stake-utils.ts'
+
+export function ToolsUiStakeAccountDetail({
+  account,
+  actions,
+  authority,
+  close,
+}: {
+  account: StakeAccount
+  actions: StakeAccountActions
+  authority: Address
+  close: () => Promise<void>
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <UiBackButton aria-label="Back to stake accounts" to="/tools/stake/accounts" />
+          <div>
+            <div className="text-muted-foreground text-sm">Stake account</div>
+            <ExplorerUiLinkAddress address={account.pubkey} basePath="/explorer" />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={getStakeAccountBadgeVariant(account)}>{getStakeAccountStatus(account)}</Badge>
+          <ToolsUiStakeAccountAction account={account} actions={actions} authority={authority} close={close} />
+        </div>
+      </div>
+      <Table>
+        <TableBody>
+          <ToolsUiStakeAccountDetailRow label="Balance" value={`${lamportsToSol(account.lamports)} SOL`} />
+          <ToolsUiStakeAccountDetailRow label="Delegated stake" value={`${formatStakeSol(account)} SOL`} />
+          <ToolsUiStakeAccountDetailRow label="Validator" value={<ToolsUiStakeValidatorLink account={account} />} />
+          <ToolsUiStakeAccountDetailRow
+            label="Stake authority"
+            value={<ExplorerUiLinkAddress address={account.data.meta.authorized.staker} basePath="/explorer" />}
+          />
+          <ToolsUiStakeAccountDetailRow
+            label="Withdraw authority"
+            value={<ExplorerUiLinkAddress address={account.data.meta.authorized.withdrawer} basePath="/explorer" />}
+          />
+          <ToolsUiStakeAccountDetailRow
+            label="Activation epoch"
+            value={account.data.stake?.delegation.activationEpoch ?? '-'}
+          />
+          <ToolsUiStakeAccountDetailRow
+            label="Deactivation epoch"
+            value={formatDeactivationEpoch(account.data.stake?.delegation.deactivationEpoch)}
+          />
+          <ToolsUiStakeAccountDetailRow
+            label="Rent exempt reserve"
+            value={`${lamportsToSol(BigInt(account.data.meta.rentExemptReserve))} SOL`}
+          />
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function ToolsUiStakeAccountDetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <TableRow className="hover:bg-transparent">
+      <TableCell className="w-[180px] text-muted-foreground">{label}</TableCell>
+      <TableCell>{value}</TableCell>
+    </TableRow>
+  )
+}
+
+function ToolsUiStakeValidatorLink({ account }: { account: StakeAccount }) {
+  return account.data.stake ? (
+    <ExplorerUiLinkAddress address={account.data.stake.delegation.voter} basePath="/explorer" />
+  ) : (
+    <span className="text-muted-foreground">-</span>
+  )
+}

--- a/packages/tools/src/ui/tools-ui-stake-account-grid.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-account-grid.tsx
@@ -1,0 +1,68 @@
+import type { Address } from '@solana/kit'
+import { ExplorerUiLinkAddress } from '@workspace/explorer/ui/explorer-ui-link-address'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import { lamportsToSol } from '@workspace/solana-client/lamports-to-sol'
+import { Badge } from '@workspace/ui/components/badge'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { Link } from 'react-router'
+import { type StakeAccountActions, ToolsUiStakeAccountAction } from './tools-ui-stake-account-action.tsx'
+import { ToolsUiStakeAccountCardField } from './tools-ui-stake-account-card-field.tsx'
+import { formatStakeSol, getStakeAccountBadgeVariant, getStakeAccountStatus } from './tools-ui-stake-utils.ts'
+
+export function ToolsUiStakeAccountGrid({
+  accounts,
+  actions,
+  authority,
+}: {
+  accounts: StakeAccount[]
+  actions: StakeAccountActions
+  authority: Address
+}) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      {accounts
+        .toSorted((left, right) => left.pubkey.toString().localeCompare(right.pubkey.toString()))
+        .map((account) => (
+          <div className="flex min-w-0 flex-col rounded-md border bg-muted/20 p-3" key={account.pubkey}>
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-muted-foreground text-xs">Account</div>
+                <Link
+                  className="block truncate font-mono text-primary text-sm hover:underline"
+                  to={`./${account.pubkey}`}
+                >
+                  {ellipsify(account.pubkey, 6, '...')}
+                </Link>
+              </div>
+              <Badge variant={getStakeAccountBadgeVariant(account)}>{getStakeAccountStatus(account)}</Badge>
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-3">
+              <ToolsUiStakeAccountCardField label="Stake" value={`${formatStakeSol(account)} SOL`} />
+              <ToolsUiStakeAccountCardField label="Balance" value={`${lamportsToSol(account.lamports)} SOL`} />
+              <ToolsUiStakeAccountCardField
+                className="col-span-2"
+                label="Validator"
+                value={
+                  <div className="min-w-0">
+                    {account.data.stake ? (
+                      <ExplorerUiLinkAddress
+                        address={account.data.stake.delegation.voter}
+                        basePath="/explorer"
+                        className="min-w-0 [&>a]:truncate"
+                        label={ellipsify(account.data.stake.delegation.voter, 6, '...')}
+                      />
+                    ) : (
+                      <span className="text-muted-foreground">-</span>
+                    )}
+                  </div>
+                }
+              />
+            </div>
+            <div className="mt-4 flex justify-end">
+              <ToolsUiStakeAccountAction account={account} actions={actions} authority={authority} />
+            </div>
+          </div>
+        ))}
+    </div>
+  )
+}

--- a/packages/tools/src/ui/tools-ui-stake-accounts-index.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-accounts-index.tsx
@@ -1,0 +1,32 @@
+import type { Address } from '@solana/kit'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import { Button } from '@workspace/ui/components/button'
+import { UiEmpty } from '@workspace/ui/components/ui-empty'
+import { Link } from 'react-router'
+import type { StakeAccountActions } from './tools-ui-stake-account-action.tsx'
+import { ToolsUiStakeAccountGrid } from './tools-ui-stake-account-grid.tsx'
+
+export function ToolsUiStakeAccountsIndex({
+  accounts,
+  actions,
+  authority,
+}: {
+  accounts: StakeAccount[]
+  actions: StakeAccountActions
+  authority: Address
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button asChild>
+          <Link to="./stake">Stake</Link>
+        </Button>
+      </div>
+      {accounts.length ? (
+        <ToolsUiStakeAccountGrid accounts={accounts} actions={actions} authority={authority} />
+      ) : (
+        <UiEmpty description="No stake accounts found for the active wallet." />
+      )}
+    </div>
+  )
+}

--- a/packages/tools/src/ui/tools-ui-stake-create-form.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-create-form.tsx
@@ -1,0 +1,172 @@
+import type { Address, Lamports } from '@solana/kit'
+import type { Account } from '@workspace/db/account/account'
+import { ExplorerUiLinkAddress } from '@workspace/explorer/ui/explorer-ui-link-address'
+import { lamportsToSol } from '@workspace/solana-client/lamports-to-sol'
+import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
+import type { CreateStakeAccountInput } from '@workspace/solana-client-react/use-create-stake-account'
+import type { VoteAccount } from '@workspace/solana-client-react/use-get-vote-accounts'
+import { Button } from '@workspace/ui/components/button'
+import { Input } from '@workspace/ui/components/input'
+import { UiBackButton } from '@workspace/ui/components/ui-back-button'
+import { UiDebug } from '@workspace/ui/components/ui-debug'
+import { UiEmpty } from '@workspace/ui/components/ui-empty'
+import { UiLoader } from '@workspace/ui/components/ui-loader'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { type FormEvent, useId, useMemo, useState } from 'react'
+import { ToolsUiStakeAccountCardField } from './tools-ui-stake-account-card-field.tsx'
+import { ToolsUiStakeCreateValidatorCombobox } from './tools-ui-stake-create-validator-combobox.tsx'
+import { getSortedVoteAccounts, getStakeAmountValidation, toBigIntLamports } from './tools-ui-stake-utils.ts'
+
+export function ToolsUiStakeCreateForm({
+  account,
+  createStake,
+  isPending,
+  rentReserve,
+  rentReserveIsLoading,
+  validators,
+  validatorsError,
+  validatorsIsLoading,
+  walletBalance,
+  walletBalanceIsLoading,
+}: {
+  account: Account
+  createStake: (input: CreateStakeAccountInput) => Promise<void>
+  isPending: boolean
+  rentReserve: Lamports | undefined
+  rentReserveIsLoading: boolean
+  validators: readonly VoteAccount[]
+  validatorsError: unknown
+  validatorsIsLoading: boolean
+  walletBalance: Lamports | undefined
+  walletBalanceIsLoading: boolean
+}) {
+  const stakeAmountInputId = useId()
+  const [selectedVoteAccount, setSelectedVoteAccount] = useState<Address | undefined>()
+  const [stakeAmount, setStakeAmount] = useState('2')
+  const sortedVoteAccounts = useMemo(() => getSortedVoteAccounts(validators), [validators])
+  const preferredVoteAccount = sortedVoteAccounts[0]
+  const selectedVoteAddress = selectedVoteAccount ?? preferredVoteAccount?.votePubkey
+  const totalActivatedStake = useMemo(
+    () => sortedVoteAccounts.reduce((total, item) => total + toBigIntLamports(item.activatedStake), 0n),
+    [sortedVoteAccounts],
+  )
+  const stakeAmountValidation = getStakeAmountValidation({
+    amount: stakeAmount,
+    rentReserve,
+    walletBalance,
+  })
+  const canSubmitStake =
+    !!selectedVoteAddress &&
+    !isPending &&
+    !rentReserveIsLoading &&
+    !stakeAmountValidation &&
+    !walletBalanceIsLoading &&
+    rentReserve !== undefined &&
+    walletBalance !== undefined
+  const prerequisiteFailure =
+    !rentReserveIsLoading && rentReserve === undefined
+      ? 'Unable to compute rent reserve. Please retry.'
+      : !walletBalanceIsLoading && walletBalance === undefined
+        ? 'Wallet balance unavailable. Reconnect your wallet.'
+        : undefined
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!selectedVoteAddress) {
+      return
+    }
+
+    let amount: ReturnType<typeof solToLamports>
+    try {
+      if (stakeAmountValidation) {
+        throw new Error(stakeAmountValidation)
+      }
+      amount = solToLamports(stakeAmount)
+    } catch {
+      toastError(stakeAmountValidation ?? 'Enter a valid stake amount.')
+      return
+    }
+
+    try {
+      await createStake({
+        amount,
+        vote: selectedVoteAddress,
+      })
+    } catch {
+      // The mutation onError callback shows the failure toast.
+      return
+    }
+  }
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <div className="flex items-center gap-2">
+        <UiBackButton aria-label="Back to stake accounts" to="/tools/stake/accounts" />
+        <div>
+          <div className="font-semibold text-lg">Stake SOL</div>
+        </div>
+      </div>
+      {validatorsIsLoading ? (
+        <UiLoader />
+      ) : validatorsError ? (
+        <UiDebug data={validatorsError} />
+      ) : sortedVoteAccounts.length ? (
+        <div className="grid gap-2">
+          <div className="font-medium text-sm">Validator</div>
+          <ToolsUiStakeCreateValidatorCombobox
+            onSelect={setSelectedVoteAccount}
+            preferredVoteAccount={preferredVoteAccount}
+            selectedVoteAddress={selectedVoteAddress}
+            totalActivatedStake={totalActivatedStake}
+            validators={sortedVoteAccounts}
+          />
+        </div>
+      ) : (
+        <UiEmpty description="No validators found." />
+      )}
+      <div className="grid gap-2">
+        <label className="font-medium text-sm" htmlFor={stakeAmountInputId}>
+          Amount
+        </label>
+        <Input
+          id={stakeAmountInputId}
+          min="0"
+          onChange={(event) => setStakeAmount(event.target.value)}
+          step="0.000000001"
+          type="number"
+          value={stakeAmount}
+        />
+        {stakeAmountValidation ? <div className="text-destructive text-sm">{stakeAmountValidation}</div> : null}
+      </div>
+      <div className="grid gap-3 rounded-md border bg-muted/20 p-3 sm:grid-cols-2">
+        <ToolsUiStakeAccountCardField
+          label="From"
+          value={
+            <ExplorerUiLinkAddress
+              address={account.publicKey}
+              basePath="/explorer"
+              label={ellipsify(account.publicKey, 6, '...')}
+            />
+          }
+        />
+        <ToolsUiStakeAccountCardField
+          label="Balance"
+          value={
+            walletBalanceIsLoading
+              ? 'Loading...'
+              : walletBalance === undefined
+                ? '-'
+                : `${lamportsToSol(walletBalance)} SOL`
+          }
+        />
+      </div>
+      <div className="flex justify-end">
+        <Button disabled={!canSubmitStake} type="submit">
+          Stake
+        </Button>
+      </div>
+      {prerequisiteFailure ? <div className="text-destructive text-sm">{prerequisiteFailure}</div> : null}
+    </form>
+  )
+}

--- a/packages/tools/src/ui/tools-ui-stake-create-validator-card.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-create-validator-card.tsx
@@ -1,0 +1,59 @@
+import { ExplorerUiLinkAddress } from '@workspace/explorer/ui/explorer-ui-link-address'
+import type { VoteAccount } from '@workspace/solana-client-react/use-get-vote-accounts'
+import { Badge } from '@workspace/ui/components/badge'
+import { ellipsify } from '@workspace/ui/lib/ellipsify'
+import { cn } from '@workspace/ui/lib/utils'
+import { ToolsUiStakeAccountCardField } from './tools-ui-stake-account-card-field.tsx'
+import { formatStakePercent, toBigIntLamports } from './tools-ui-stake-utils.ts'
+
+const LAMPORTS_PER_SOL = 1_000_000_000n
+const SOL_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })
+
+export function ToolsUiStakeCreateValidatorCard({
+  className,
+  isPreferred,
+  showAddressActions = false,
+  totalActivatedStake,
+  voteAccount,
+}: {
+  className?: string
+  isPreferred: boolean
+  showAddressActions?: boolean
+  totalActivatedStake: bigint
+  voteAccount: VoteAccount
+}) {
+  return (
+    <div className={cn('rounded-md border bg-muted/20 p-3 text-left hover:bg-muted/30', className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-muted-foreground text-xs">Validator</div>
+          {showAddressActions ? (
+            <ExplorerUiLinkAddress
+              address={voteAccount.votePubkey}
+              basePath="/explorer"
+              className="min-w-0 [&>a]:truncate"
+              label={ellipsify(voteAccount.votePubkey, 6, '...')}
+            />
+          ) : (
+            <div className="truncate font-mono" title={voteAccount.votePubkey}>
+              {ellipsify(voteAccount.votePubkey, 6, '...')}
+            </div>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {isPreferred ? <Badge variant="success">Preferred</Badge> : null}
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <ToolsUiStakeAccountCardField
+          label="Active stake"
+          value={`${SOL_FORMATTER.format(Number(toBigIntLamports(voteAccount.activatedStake) / LAMPORTS_PER_SOL))} SOL`}
+        />
+        <ToolsUiStakeAccountCardField
+          label="Network stake"
+          value={formatStakePercent(toBigIntLamports(voteAccount.activatedStake), totalActivatedStake)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/tools/src/ui/tools-ui-stake-create-validator-combobox.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-create-validator-combobox.tsx
@@ -1,0 +1,109 @@
+import type { Address } from '@solana/kit'
+import type { VoteAccount } from '@workspace/solana-client-react/use-get-vote-accounts'
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+} from '@workspace/ui/components/combobox'
+import { useState } from 'react'
+import { ToolsUiStakeCreateValidatorCard } from './tools-ui-stake-create-validator-card.tsx'
+
+const VALIDATOR_RESULT_LIMIT = 50
+
+export function ToolsUiStakeCreateValidatorCombobox({
+  onSelect,
+  preferredVoteAccount,
+  selectedVoteAddress,
+  totalActivatedStake,
+  validators,
+}: {
+  onSelect: (address: Address) => void
+  preferredVoteAccount: VoteAccount | undefined
+  selectedVoteAddress: Address | undefined
+  totalActivatedStake: bigint
+  validators: readonly VoteAccount[]
+}) {
+  const [search, setSearch] = useState('')
+  const selectedVoteAccount = validators.find((validator) => validator.votePubkey === selectedVoteAddress)
+
+  return (
+    <Combobox
+      autoComplete="list"
+      inputValue={search}
+      isItemEqualToValue={(item, value) => item.votePubkey === value.votePubkey}
+      items={validators}
+      itemToStringLabel={(item) => item.votePubkey}
+      itemToStringValue={(item) => item.votePubkey}
+      limit={VALIDATOR_RESULT_LIMIT}
+      onInputValueChange={setSearch}
+      onOpenChange={(open) => {
+        if (!open) {
+          setSearch('')
+        }
+      }}
+      onValueChange={(value) => {
+        if (!value) {
+          return
+        }
+        onSelect(value.votePubkey)
+        setSearch('')
+      }}
+      value={selectedVoteAccount ?? null}
+    >
+      <ComboboxTrigger
+        aria-label="Validator"
+        className="relative block w-full rounded-md text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [&>[data-slot=combobox-trigger-icon]]:absolute [&>[data-slot=combobox-trigger-icon]]:top-4 [&>[data-slot=combobox-trigger-icon]]:right-4"
+        nativeButton={false}
+        render={<div />}
+      >
+        {selectedVoteAccount ? (
+          <ToolsUiStakeCreateValidatorCard
+            className="pr-12"
+            isPreferred={selectedVoteAccount.votePubkey === preferredVoteAccount?.votePubkey}
+            totalActivatedStake={totalActivatedStake}
+            voteAccount={selectedVoteAccount}
+          />
+        ) : (
+          <div className="rounded-md border bg-muted/20 p-3 pr-12 text-left">
+            <div className="text-muted-foreground text-xs">Validator</div>
+            <div className="font-medium">Select validator</div>
+          </div>
+        )}
+      </ComboboxTrigger>
+      <ComboboxContent className="max-h-[60vh] min-w-0">
+        <ComboboxInput
+          autoFocus
+          className="w-[calc(100%-0.5rem)]"
+          placeholder="Search validator pubkey"
+          showClear={!!search}
+          showTrigger={false}
+        />
+        <ComboboxEmpty>No validators found.</ComboboxEmpty>
+        <ComboboxList className="overflow-x-hidden">
+          <ComboboxCollection>
+            {(validator: VoteAccount, index: number) => (
+              <ComboboxItem
+                className="block h-auto w-full cursor-pointer overflow-hidden p-1 pr-1 data-highlighted:bg-transparent data-highlighted:text-foreground [&>[data-slot=combobox-item-indicator]]:hidden"
+                index={index}
+                key={validator.votePubkey}
+                value={validator}
+              >
+                <ToolsUiStakeCreateValidatorCard
+                  className="pr-12"
+                  isPreferred={validator.votePubkey === preferredVoteAccount?.votePubkey}
+                  totalActivatedStake={totalActivatedStake}
+                  voteAccount={validator}
+                />
+              </ComboboxItem>
+            )}
+          </ComboboxCollection>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  )
+}

--- a/packages/tools/src/ui/tools-ui-stake-utils.ts
+++ b/packages/tools/src/ui/tools-ui-stake-utils.ts
@@ -1,0 +1,138 @@
+import type { Lamports } from '@solana/kit'
+import type { StakeAccount } from '@workspace/solana-client/get-stake-accounts'
+import { lamportsToSol } from '@workspace/solana-client/lamports-to-sol'
+import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
+import type { VoteAccount } from '@workspace/solana-client-react/use-get-vote-accounts'
+
+const DEACTIVATION_EPOCH_INACTIVE = '18446744073709551615'
+const STAKE_PERCENT_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 })
+
+export function canCloseStakeAccount(account: StakeAccount, authority: string) {
+  return (
+    account.data.meta.authorized.withdrawer === authority &&
+    !account.data.stake &&
+    !isStakeLockupInForce(account) &&
+    account.lamports > 0n
+  )
+}
+
+export function canDeactivateStakeAccount(account: StakeAccount, authority: string) {
+  return (
+    account.data.meta.authorized.staker === authority &&
+    !!account.data.stake &&
+    account.data.stake.delegation.deactivationEpoch === DEACTIVATION_EPOCH_INACTIVE
+  )
+}
+
+export function compareVoteAccountsByStake(left: VoteAccount, right: VoteAccount) {
+  const stakeDiff = toBigIntLamports(right.activatedStake) - toBigIntLamports(left.activatedStake)
+
+  if (stakeDiff > 0n) {
+    return 1
+  }
+  if (stakeDiff < 0n) {
+    return -1
+  }
+
+  return left.votePubkey.toString().localeCompare(right.votePubkey.toString())
+}
+
+export function formatDeactivationEpoch(epoch: string | undefined) {
+  return epoch && epoch !== DEACTIVATION_EPOCH_INACTIVE ? epoch : '-'
+}
+
+export function formatStakePercent(stake: bigint, total: bigint) {
+  if (total === 0n) {
+    return '0%'
+  }
+
+  const basisPoints = (stake * 10000n) / total
+  return `${STAKE_PERCENT_FORMATTER.format(Number(basisPoints) / 100)}%`
+}
+
+export function formatStakeSol(account: StakeAccount) {
+  if (!account.data.stake) {
+    return '0'
+  }
+
+  return lamportsToSol(BigInt(account.data.stake.delegation.stake))
+}
+
+export function getPreferredVoteAccount(voteAccounts: readonly VoteAccount[]) {
+  return voteAccounts.toSorted(compareVoteAccountsByStake)[0]
+}
+
+export function getSortedVoteAccounts(voteAccounts: readonly VoteAccount[]) {
+  const preferredVoteAccount = getPreferredVoteAccount(voteAccounts)
+
+  return voteAccounts.toSorted((left, right) => {
+    if (preferredVoteAccount) {
+      if (left.votePubkey === preferredVoteAccount.votePubkey) {
+        return -1
+      }
+      if (right.votePubkey === preferredVoteAccount.votePubkey) {
+        return 1
+      }
+    }
+
+    return compareVoteAccountsByStake(left, right)
+  })
+}
+
+export function getStakeAccountBadgeVariant(account: StakeAccount) {
+  return getStakeAccountStatus(account) === 'Delegated' ? 'success' : 'secondary'
+}
+
+export function getStakeAccountStatus(account: StakeAccount) {
+  if (!account.data.stake) {
+    return 'Inactive'
+  }
+
+  return account.data.stake.delegation.deactivationEpoch === DEACTIVATION_EPOCH_INACTIVE ? 'Delegated' : 'Deactivating'
+}
+
+export function getStakeAmountValidation({
+  amount,
+  rentReserve,
+  walletBalance,
+}: {
+  amount: string
+  rentReserve: Lamports | undefined
+  walletBalance: Lamports | undefined
+}) {
+  if (!amount.trim()) {
+    return 'Enter an amount.'
+  }
+
+  let lamportsAmount: ReturnType<typeof solToLamports>
+  try {
+    lamportsAmount = solToLamports(amount)
+  } catch {
+    return 'Enter a valid stake amount.'
+  }
+
+  if (lamportsAmount <= 0n) {
+    return 'Amount must be greater than 0 SOL.'
+  }
+
+  if (rentReserve !== undefined && lamportsAmount <= rentReserve) {
+    return `Amount must be greater than the ${lamportsToSol(rentReserve)} SOL rent reserve.`
+  }
+
+  if (walletBalance !== undefined && lamportsAmount > walletBalance) {
+    return 'Amount exceeds wallet balance.'
+  }
+
+  return undefined
+}
+
+export function toBigIntLamports(value: VoteAccount['activatedStake']) {
+  return BigInt(value.toString())
+}
+
+function isStakeLockupInForce(account: StakeAccount) {
+  const { epoch, unixTimestamp } = account.data.meta.lockup
+  const now = BigInt(Math.floor(Date.now() / 1000))
+
+  return epoch !== '0' || BigInt(unixTimestamp) > now
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@base-ui/react": "1.4.0",
     "@hookform/resolvers": "catalog:",
     "@nkzw/use-relative-time": "1.2.3",
     "@radix-ui/react-accordion": "1.2.12",

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import { Combobox as ComboboxPrimitive } from '@base-ui/react'
+import { CheckIcon, ChevronDownIcon, XIcon } from 'lucide-react'
+import * as React from 'react'
+import { cn } from '../lib/utils.ts'
+import { Button } from './button.tsx'
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from './input-group.tsx'
+
+const Combobox = ComboboxPrimitive.Root
+
+function ComboboxValue({ ...props }: ComboboxPrimitive.Value.Props) {
+  return <ComboboxPrimitive.Value data-slot="combobox-value" {...props} />
+}
+
+function ComboboxTrigger({ className, children, ...props }: ComboboxPrimitive.Trigger.Props) {
+  return (
+    <ComboboxPrimitive.Trigger
+      className={cn("[&_svg:not([class*='size-'])]:size-4", className)}
+      data-slot="combobox-trigger"
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" data-slot="combobox-trigger-icon" />
+    </ComboboxPrimitive.Trigger>
+  )
+}
+
+function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
+  return (
+    <ComboboxPrimitive.Clear
+      className={cn(className)}
+      render={<InputGroupButton size="icon-xs" variant="ghost" />}
+      {...props}
+    >
+      <XIcon className="pointer-events-none" />
+    </ComboboxPrimitive.Clear>
+  )
+}
+
+function ComboboxInput({
+  className,
+  children,
+  disabled = false,
+  showTrigger = true,
+  showClear = false,
+  ...props
+}: ComboboxPrimitive.Input.Props & {
+  showTrigger?: boolean
+  showClear?: boolean
+}) {
+  return (
+    <InputGroup className={cn('w-auto', className)}>
+      <ComboboxPrimitive.Input render={<InputGroupInput disabled={disabled} />} {...props} />
+      <InputGroupAddon align="inline-end">
+        {showTrigger && (
+          <InputGroupButton
+            asChild
+            className="group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent"
+            data-slot="input-group-button"
+            disabled={disabled}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <ComboboxTrigger />
+          </InputGroupButton>
+        )}
+        {showClear && <ComboboxClear disabled={disabled} />}
+      </InputGroupAddon>
+      {children}
+    </InputGroup>
+  )
+}
+
+function ComboboxContent({
+  className,
+  side = 'bottom',
+  sideOffset = 6,
+  align = 'start',
+  alignOffset = 0,
+  anchor,
+  ...props
+}: ComboboxPrimitive.Popup.Props &
+  Pick<ComboboxPrimitive.Positioner.Props, 'side' | 'align' | 'sideOffset' | 'alignOffset' | 'anchor'>) {
+  return (
+    <ComboboxPrimitive.Portal>
+      <ComboboxPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        className="isolate z-50"
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <ComboboxPrimitive.Popup
+          className={cn(
+            'group/combobox-content data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 relative max-h-96 w-(--anchor-width) min-w-[calc(var(--anchor-width)+--spacing(7))] max-w-(--available-width) origin-(--transform-origin) overflow-hidden rounded-md bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[chips=true]:min-w-(--anchor-width) data-closed:animate-out data-open:animate-in *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:border-input/30 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:shadow-none',
+            className,
+          )}
+          data-chips={!!anchor}
+          data-slot="combobox-content"
+          {...props}
+        />
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  )
+}
+
+function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
+  return (
+    <ComboboxPrimitive.List
+      className={cn(
+        'max-h-[min(calc(--spacing(96)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto p-1 data-empty:p-0',
+        className,
+      )}
+      data-slot="combobox-list"
+      {...props}
+    />
+  )
+}
+
+function ComboboxItem({ className, children, ...props }: ComboboxPrimitive.Item.Props) {
+  return (
+    <ComboboxPrimitive.Item
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden data-[disabled]:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      data-slot="combobox-item"
+      {...props}
+    >
+      {children}
+      <ComboboxPrimitive.ItemIndicator
+        data-slot="combobox-item-indicator"
+        render={<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />}
+      >
+        <CheckIcon className="pointer-events-none pointer-coarse:size-5 size-4" />
+      </ComboboxPrimitive.ItemIndicator>
+    </ComboboxPrimitive.Item>
+  )
+}
+
+function ComboboxGroup({ className, ...props }: ComboboxPrimitive.Group.Props) {
+  return <ComboboxPrimitive.Group className={cn(className)} data-slot="combobox-group" {...props} />
+}
+
+function ComboboxLabel({ className, ...props }: ComboboxPrimitive.GroupLabel.Props) {
+  return (
+    <ComboboxPrimitive.GroupLabel
+      className={cn(
+        'pointer-coarse:px-3 px-2 pointer-coarse:py-2 py-1.5 pointer-coarse:text-sm text-muted-foreground text-xs',
+        className,
+      )}
+      data-slot="combobox-label"
+      {...props}
+    />
+  )
+}
+
+function ComboboxCollection({ ...props }: ComboboxPrimitive.Collection.Props) {
+  return <ComboboxPrimitive.Collection data-slot="combobox-collection" {...props} />
+}
+
+function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
+  return (
+    <ComboboxPrimitive.Empty
+      className={cn(
+        'hidden w-full justify-center py-2 text-center text-muted-foreground text-sm group-data-empty/combobox-content:flex',
+        className,
+      )}
+      data-slot="combobox-empty"
+      {...props}
+    />
+  )
+}
+
+function ComboboxSeparator({ className, ...props }: ComboboxPrimitive.Separator.Props) {
+  return (
+    <ComboboxPrimitive.Separator
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      data-slot="combobox-separator"
+      {...props}
+    />
+  )
+}
+
+function ComboboxChips({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> & ComboboxPrimitive.Chips.Props) {
+  return (
+    <ComboboxPrimitive.Chips
+      className={cn(
+        'flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent bg-clip-padding px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 has-aria-invalid:border-destructive has-data-[slot=combobox-chip]:px-1.5 has-aria-invalid:ring-[3px] has-aria-invalid:ring-destructive/20 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40',
+        className,
+      )}
+      data-slot="combobox-chips"
+      {...props}
+    />
+  )
+}
+
+function ComboboxChip({
+  className,
+  children,
+  showRemove = true,
+  ...props
+}: ComboboxPrimitive.Chip.Props & {
+  showRemove?: boolean
+}) {
+  return (
+    <ComboboxPrimitive.Chip
+      className={cn(
+        'flex h-[calc(--spacing(5.5))] w-fit items-center justify-center gap-1 whitespace-nowrap rounded-sm bg-muted px-1.5 font-medium text-foreground text-xs has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-data-[slot=combobox-chip-remove]:pr-0 has-disabled:opacity-50',
+        className,
+      )}
+      data-slot="combobox-chip"
+      {...props}
+    >
+      {children}
+      {showRemove && (
+        <ComboboxPrimitive.ChipRemove
+          data-slot="combobox-chip-remove"
+          render={<Button className="size-5 rounded-sm p-0" size="icon" variant="ghost" />}
+        >
+          <XIcon className="pointer-events-none" />
+        </ComboboxPrimitive.ChipRemove>
+      )}
+    </ComboboxPrimitive.Chip>
+  )
+}
+
+function ComboboxChipsInput({ className, children, ...props }: ComboboxPrimitive.Input.Props) {
+  return (
+    <ComboboxPrimitive.Input
+      className={cn('min-w-16 flex-1 outline-none', className)}
+      data-slot="combobox-chip-input"
+      {...props}
+    />
+  )
+}
+
+function useComboboxAnchor() {
+  return React.useRef<HTMLDivElement | null>(null)
+}
+
+export {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxSeparator,
+  ComboboxTrigger,
+  ComboboxValue,
+  useComboboxAnchor,
+}


### PR DESCRIPTION
Adds Solana staking transaction support in solana-client and solana-client-react.

Discovers stake accounts, validators, rent reserve, wallet balance, and vote account data.

Builds an accounts-first stake tool with account cards, details, and staking actions.

Adds a searchable validator combobox to the staking flow and removes the Validators tab.
<img width="852" height="1625" alt="image" src="https://github.com/user-attachments/assets/a38c81aa-c600-4da2-a8d6-d50985d545f7" />
<img width="852" height="1625" alt="image" src="https://github.com/user-attachments/assets/1cc19c57-c8cf-46ae-994a-47dfcb38ffaf" />
<img width="852" height="1625" alt="image" src="https://github.com/user-attachments/assets/b61297fb-6e31-469e-84a9-61328486a13a" />
<img width="852" height="1625" alt="image" src="https://github.com/user-attachments/assets/15dc9dff-992a-419e-b3c2-7b35d5755f9a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full “Stake” tool: create stake accounts, browse validators, view stake accounts in grid/detail pages, and close/unstake with confirmations and success/error toasts.
  * Validator selector with search, metrics, preference highlighting, rent/balance validation, and navigation to created stake details.
  * Background fetching of stake, vote, and rent-reserve data for up-to-date balances and status.
  * Improved combobox UI for selecting validators.

* **Chores**
  * Added runtime dependencies for stake support and updated spellchecker to recognize “unstake”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->