### PR TITLE
fix(portfolio): pad activity tab on small screens

### DIFF
--- a/packages/portfolio/src/portfolio-feature-tab-activity.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-activity.tsx
@@ -20,7 +20,7 @@ export function PortfolioFeatureTabActivity() {
   })
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 px-2 md:px-0">
       <div className="flex items-center justify-between">
         <h2 className="font-bold text-xl">{t(($) => $.pageTitleActivity)}</h2>
         <div className="space-x-2">


### PR DESCRIPTION
Add horizontal padding to the portfolio activity tab on small viewports.

Keep the existing medium-and-up layout unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing in the portfolio activity section—added horizontal padding on mobile devices and removed it on larger screens for better layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->