### PR TITLE
chore(deps): group TanStack Query updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     cooldown:
       default-days: 5
     directory: /
+    groups:
+      tanstack-query:
+        patterns:
+          - "@tanstack/query-*"
+          - "@tanstack/react-query*"
     schedule:
       day: sunday
       interval: weekly


### PR DESCRIPTION
Configure Dependabot to update TanStack Query packages in one grouped Bun dependency PR.

Closes #990


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation to group TanStack Query-related packages for coordinated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->