### PR TITLE
fix(web): increase e2e web server timeout

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     env: { VITE_ACTIVE_NETWORK_ID: 'networkLocalnet' },
     gracefulShutdown: { signal: 'SIGTERM', timeout: 10_000 },
     reuseExistingServer: false,
+    timeout: 180_000,
     url: 'http://localhost:4173',
   },
   workers: isCi ? 1 : 3,


### PR DESCRIPTION
Allow Playwright more time for e2e webServer startup.

That startup includes Surfpool, the web build, and Vite preview readiness.

Verification:

- bun lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test reliability by adjusting web server timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->