### PR TITLE
chore: prepare typescript 6 config

### DIFF
--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["bun", "node"]
   },
   "extends": ["@workspace/config-typescript/react-library.json", "astro/tsconfigs/strict"]
 }

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -4,7 +4,6 @@
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
-    "baseUrl": ".",
     "composite": true,
     "declaration": true,
     "declarationMap": true,
@@ -16,6 +15,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "libReplacement": false,
     "module": "ESNext",
     "moduleDetection": "force",
     "moduleResolution": "Bundler",
@@ -37,6 +37,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES2022",
+    "types": ["bun", "node", "react", "react-dom"],
     "useDefineForClassFields": true,
     "verbatimModuleSyntax": true
   }

--- a/packages/config-typescript/base.json
+++ b/packages/config-typescript/base.json
@@ -15,6 +15,7 @@
     "incremental": true,
     "isolatedModules": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "libReplacement": false,
     "module": "ESNext",
     "moduleDetection": "force",
     "moduleResolution": "Bundler",
@@ -32,6 +33,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES2022",
+    "types": ["bun", "node"],
     "useDefineForClassFields": true,
     "verbatimModuleSyntax": true
   },

--- a/packages/config-typescript/react-library.json
+++ b/packages/config-typescript/react-library.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["bun", "node", "react", "react-dom"]
   },
   "display": "React Library",
   "extends": "./base.json"

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
Add explicit ambient type package lists for shared configs.

Set libReplacement false and remove deprecated baseUrl entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compiler configurations across the project to standardize type definitions and improve compilation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->