### PR TITLE
refactor: pass addresses to wallet actions

### DIFF
--- a/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
+++ b/packages/portfolio/src/data-access/use-create-and-send-sol-transaction.tsx
@@ -1,6 +1,5 @@
-import type { KeyPairSigner } from '@solana/kit'
+import type { Address, KeyPairSigner } from '@solana/kit'
 import { mutationOptions, type QueryClient, useMutation, useQueryClient } from '@tanstack/react-query'
-import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
 import { createAndSendSolTransaction } from '@workspace/solana-client/create-and-send-sol-transaction'
 import { getBalance } from '@workspace/solana-client/get-balance'
@@ -10,12 +9,17 @@ import { getAccountInfoQueryOptions } from '@workspace/solana-client-react/use-g
 import { getBalanceQueryOptions } from '@workspace/solana-client-react/use-get-balance'
 import { useSolanaClient } from '@workspace/solana-client-react/use-solana-client'
 
-export function createAndSendSolTransactionMutationOptions(
-  client: SolanaClient,
-  queryClient: QueryClient,
-  account: Account,
-  network: Network,
-) {
+function createAndSendSolTransactionMutationOptions({
+  address,
+  client,
+  network,
+  queryClient,
+}: {
+  address: Address
+  client: SolanaClient
+  network: Network
+  queryClient: QueryClient
+}) {
   return mutationOptions({
     mutationFn: async ({
       recipients,
@@ -36,18 +40,18 @@ export function createAndSendSolTransactionMutationOptions(
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: getBalanceQueryOptions({ address: account.publicKey, client, network }).queryKey,
+        queryKey: getBalanceQueryOptions({ address, client, network }).queryKey,
       })
       queryClient.invalidateQueries({
-        queryKey: getAccountInfoQueryOptions({ address: account.publicKey, client, network }).queryKey,
+        queryKey: getAccountInfoQueryOptions({ address, client, network }).queryKey,
       })
     },
   })
 }
 
-export function useCreateAndSendSolTransaction({ account, network }: { account: Account; network: Network }) {
+export function useCreateAndSendSolTransaction({ address, network }: { address: Address; network: Network }) {
   const queryClient = useQueryClient()
   const client = useSolanaClient({ network })
 
-  return useMutation(createAndSendSolTransactionMutationOptions(client, queryClient, account, network))
+  return useMutation(createAndSendSolTransactionMutationOptions({ address, client, network, queryClient }))
 }

--- a/packages/portfolio/src/data-access/use-portfolio-token-mint.tsx
+++ b/packages/portfolio/src/data-access/use-portfolio-token-mint.tsx
@@ -3,9 +3,9 @@ import { useNetworkActive } from '@workspace/db-react/use-network-active'
 import { useGetTokenBalances } from './use-get-token-metadata.ts'
 
 export function usePortfolioTokenMint({ token = '' }: { token?: string | undefined }) {
-  const account = useAccountActive()
+  const { publicKey: address } = useAccountActive()
   const network = useNetworkActive()
-  const balances = useGetTokenBalances({ address: account.publicKey, network })
+  const balances = useGetTokenBalances({ address, network })
 
   return balances.find((item) => item.mint === token)
 }

--- a/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
+++ b/packages/portfolio/src/data-access/use-portfolio-tx-send.tsx
@@ -80,9 +80,9 @@ export function portfolioTxSendMutationOptions({
 }
 
 export function usePortfolioTxSend() {
-  const account = useAccountActive()
+  const { publicKey: address } = useAccountActive()
   const network = useNetworkActive()
-  const sendSolMutation = useCreateAndSendSolTransaction({ account, network })
+  const sendSolMutation = useCreateAndSendSolTransaction({ address, network })
   const sendSplMutation = useCreateAndSendSplTransaction({ network })
 
   return useMutation(

--- a/packages/portfolio/src/portfolio-feature-modal-receive.tsx
+++ b/packages/portfolio/src/portfolio-feature-modal-receive.tsx
@@ -5,11 +5,11 @@ import { PortfolioUiReceive } from './ui/portfolio-ui-receive.tsx'
 
 export function PortfolioFeatureModalReceive() {
   const { t } = useTranslation('portfolio')
-  const account = useAccountActive()
+  const { publicKey: address } = useAccountActive()
 
   return (
     <PortfolioUiModal title={t(($) => $.actionReceive)}>
-      <PortfolioUiReceive account={account} />
+      <PortfolioUiReceive address={address} />
     </PortfolioUiModal>
   )
 }

--- a/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
+++ b/packages/portfolio/src/portfolio-feature-tab-tokens.tsx
@@ -12,11 +12,11 @@ import { PortfolioUiTokenBalances } from './ui/portfolio-ui-token-balances.tsx'
 import { PortfolioUiTokenBalancesSkeleton } from './ui/portfolio-ui-token-balances-skeleton.tsx'
 
 export function PortfolioFeatureTabTokens() {
-  const account = useAccountActive()
+  const { publicKey: address } = useAccountActive()
   const network = useNetworkActive()
-  const balances = useGetTokenBalances({ address: account.publicKey, network })
+  const balances = useGetTokenBalances({ address, network })
   const { data: dataWalletInfo, isLoading: isLoadingWalletInfo } = useGetAccountInfo({
-    address: account.publicKey,
+    address,
     network,
   })
   const totalBalance = useMemo(() => {
@@ -41,7 +41,7 @@ export function PortfolioFeatureTabTokens() {
       <PortfolioUiAccountButtons />
 
       {isLoadingWalletInfo ? null : (
-        <PortfolioUiRequestAirdrop account={account} lamports={dataWalletInfo?.value?.lamports} network={network} />
+        <PortfolioUiRequestAirdrop address={address} lamports={dataWalletInfo?.value?.lamports} network={network} />
       )}
 
       {isLoadingWalletInfo ? (

--- a/packages/portfolio/src/ui/portfolio-ui-receive.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-receive.tsx
@@ -1,22 +1,22 @@
-import type { Account } from '@workspace/db/account/account'
+import type { Address } from '@solana/kit'
 import { useTranslation } from '@workspace/i18n'
 import { UiQrCode } from '@workspace/ui/components/ui-qr-code'
 import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
 
-export function PortfolioUiReceive({ account }: { account: Account }) {
+export function PortfolioUiReceive({ address }: { address: Address }) {
   const { t } = useTranslation('portfolio')
 
   return (
     <div className="space-y-6 p-2 text-center md:pb-10">
       <UiTextCopyButton
         label={t(($) => $.actionCopyPublicKey)}
-        text={account.publicKey}
+        text={address}
         toast={t(($) => $.actionCopyPublicKeySuccess)}
         toastFailed={t(($) => $.actionCopyPublicKeyError)}
       />
       <div className="flex size-85 w-full justify-center">
         <div className="aspect-square">
-          <UiQrCode content={account.publicKey} />
+          <UiQrCode content={address} />
         </div>
       </div>
     </div>

--- a/packages/portfolio/src/ui/portfolio-ui-request-airdrop.tsx
+++ b/packages/portfolio/src/ui/portfolio-ui-request-airdrop.tsx
@@ -1,5 +1,4 @@
-import type { Lamports } from '@solana/kit'
-import type { Account } from '@workspace/db/account/account'
+import type { Address, Lamports } from '@solana/kit'
 import type { Network } from '@workspace/db/network/network'
 import { useTranslation } from '@workspace/i18n'
 import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
@@ -9,11 +8,11 @@ import { UiEmpty } from '@workspace/ui/components/ui-empty'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 
 export function PortfolioUiRequestAirdrop({
-  account,
+  address,
   lamports,
   network,
 }: {
-  account: Account
+  address: Address
   lamports?: Lamports | undefined
   network: Network
 }) {
@@ -28,10 +27,7 @@ export function PortfolioUiRequestAirdrop({
 
   return (
     <UiEmpty description={t(($) => $.requestAirdropDescription)} icon="airdrop" title={t(($) => $.requestAirdropTitle)}>
-      <Button
-        disabled={isPending}
-        onClick={() => mutateAsync({ address: account.publicKey, amount: solToLamports('1') })}
-      >
+      <Button disabled={isPending} onClick={() => mutateAsync({ address, amount: solToLamports('1') })}>
         <UiIcon icon="coins" /> {t(($) => $.actionRequestAirdrop)}
       </Button>
       {isLocalnet ? null : (

--- a/packages/solana-client-react/src/use-create-stake-account.tsx
+++ b/packages/solana-client-react/src/use-create-stake-account.tsx
@@ -44,7 +44,7 @@ export function createStakeAccountMutationOptions({
       toastError('Failed to stake SOL.')
     },
     onSuccess: async ({ signature }) => {
-      await invalidateStakeAccountQueries({ account, client, network, queryClient })
+      await invalidateStakeAccountQueries({ address: account.publicKey, client, network, queryClient })
       toastSuccess(`Stake transaction confirmed: ${ellipsify(signature, 6, '...')}`)
     },
   })
@@ -67,22 +67,22 @@ export function useCreateStakeAccount({ account, network }: { account: Account; 
 }
 
 async function invalidateStakeAccountQueries({
-  account,
+  address,
   client,
   queryClient,
   network,
 }: {
-  account: Account
+  address: Address
   client: SolanaClient
   queryClient: QueryClient
   network: Network
 }) {
   await Promise.all([
     queryClient.invalidateQueries({
-      queryKey: getBalanceQueryOptions({ address: account.publicKey, client, network }).queryKey,
+      queryKey: getBalanceQueryOptions({ address, client, network }).queryKey,
     }),
     queryClient.invalidateQueries({
-      queryKey: getStakeAccountsQueryOptions({ address: account.publicKey, client, network }).queryKey,
+      queryKey: getStakeAccountsQueryOptions({ address, client, network }).queryKey,
     }),
   ])
 }

--- a/packages/tools/src/tools-feature-stake.tsx
+++ b/packages/tools/src/tools-feature-stake.tsx
@@ -1,3 +1,4 @@
+import type { Address } from '@solana/kit'
 import { tryCatch } from '@workspace/core/try-catch'
 import type { Account } from '@workspace/db/account/account'
 import type { Network } from '@workspace/db/network/network'
@@ -62,7 +63,7 @@ export function ToolsFeatureStakeAccounts({ account, network }: { account: Accou
       />
       <Route element={<ToolsFeatureStakeCreate account={account} network={network} />} path="stake" />
       <Route
-        element={<ToolsFeatureStakeAccountDetail account={account} accounts={accounts} actions={actions} />}
+        element={<ToolsFeatureStakeAccountDetail accounts={accounts} actions={actions} authority={account.publicKey} />}
         path=":address"
       />
       <Route element={<Navigate replace to="." />} path="*" />
@@ -73,11 +74,11 @@ export function ToolsFeatureStakeAccounts({ account, network }: { account: Accou
 function ToolsFeatureStakeAccountDetail({
   accounts,
   actions,
-  account,
+  authority,
 }: {
   accounts: StakeAccount[]
   actions: StakeAccountActions
-  account: Account
+  authority: Address
 }) {
   const { address } = useParams<{ address: string }>()
   const navigate = useNavigate()
@@ -91,7 +92,7 @@ function ToolsFeatureStakeAccountDetail({
     <ToolsUiStakeAccountDetail
       account={stakeAccount}
       actions={actions}
-      authority={account.publicKey}
+      authority={authority}
       close={async () => {
         const closed = await actions.close(stakeAccount)
         if (closed) {
@@ -111,7 +112,7 @@ function ToolsFeatureStakeCreate({ account, network }: { account: Account; netwo
 
   return (
     <ToolsUiStakeCreateForm
-      account={account}
+      address={account.publicKey}
       createStake={async (input) => {
         const { data: result, error } = await tryCatch(createStakeAccountMutation.mutateAsync(input))
         if (error) {

--- a/packages/tools/src/ui/tools-ui-stake-create-form.tsx
+++ b/packages/tools/src/ui/tools-ui-stake-create-form.tsx
@@ -1,5 +1,4 @@
 import type { Address, Lamports } from '@solana/kit'
-import type { Account } from '@workspace/db/account/account'
 import { ExplorerUiLinkAddress } from '@workspace/explorer/ui/explorer-ui-link-address'
 import { lamportsToSol } from '@workspace/solana-client/lamports-to-sol'
 import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
@@ -19,7 +18,7 @@ import { ToolsUiStakeCreateValidatorCombobox } from './tools-ui-stake-create-val
 import { getSortedVoteAccounts, getStakeAmountValidation, toBigIntLamports } from './tools-ui-stake-utils.ts'
 
 export function ToolsUiStakeCreateForm({
-  account,
+  address,
   createStake,
   isPending,
   rentReserve,
@@ -30,7 +29,7 @@ export function ToolsUiStakeCreateForm({
   walletBalance,
   walletBalanceIsLoading,
 }: {
-  account: Account
+  address: Address
   createStake: (input: CreateStakeAccountInput) => Promise<void>
   isPending: boolean
   rentReserve: Lamports | undefined
@@ -142,13 +141,7 @@ export function ToolsUiStakeCreateForm({
       <div className="grid gap-3 rounded-md border bg-muted/20 p-3 sm:grid-cols-2">
         <ToolsUiStakeAccountCardField
           label="From"
-          value={
-            <ExplorerUiLinkAddress
-              address={account.publicKey}
-              basePath="/explorer"
-              label={ellipsify(account.publicKey, 6, '...')}
-            />
-          }
+          value={<ExplorerUiLinkAddress address={address} basePath="/explorer" label={ellipsify(address, 6, '...')} />}
         />
         <ToolsUiStakeAccountCardField
           label="Balance"


### PR DESCRIPTION
Use Address props where portfolio receive, airdrop, token, send, and stake UI only need public keys.

Update transaction and stake query invalidation to use explicit addresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and type safety across portfolio and tools modules through architectural enhancements. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->