### PR TITLE
fix(db): sanitize wallet find-many accounts

### DIFF
--- a/packages/db/src/wallet/wallet-find-many.ts
+++ b/packages/db/src/wallet/wallet-find-many.ts
@@ -1,5 +1,6 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
+import { accountSanitizer } from '../account/account-sanitizer.ts'
 import type { Database } from '../database.ts'
 import type { Wallet } from './wallet.ts'
 import type { WalletFindManyInput } from './wallet-find-many-input.ts'
@@ -38,7 +39,9 @@ export async function walletFindMany(db: Database, input: WalletFindManyInput = 
       ...dataWallets.map((wallet) => {
         return {
           ...walletSanitizer(wallet),
-          accounts: [...dataAccounts.filter((account) => account.walletId === wallet.id)],
+          accounts: dataAccounts
+            .filter((account) => account.walletId === wallet.id)
+            .map((account) => accountSanitizer(account)),
         }
       }),
     ]

--- a/packages/db/test/wallet-find-many.test.ts
+++ b/packages/db/test/wallet-find-many.test.ts
@@ -90,6 +90,22 @@ describe('wallet-find-many', () => {
       // @ts-expect-error mnemonic does not exist on the type. Here we ensure it's sanitized.
       expect(items[0]?.mnemonic).toEqual(undefined)
     })
+
+    it('should not expose secret keys on nested wallet accounts', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const id = await walletCreate(db, testWalletCreateInput())
+      await accountCreate(db, testAccountCreateInput({ secretKey: 'raw-data-accounts-secret-key', walletId: id }))
+
+      // ACT
+      const result = await walletFindMany(db, { id })
+
+      // ASSERT
+      expect(result).toHaveLength(1)
+      expect(result[0]?.accounts).toHaveLength(1)
+      // @ts-expect-error: Testing invalid input
+      expect(result[0]?.accounts[0]?.secretKey).toBe(undefined)
+    })
   })
 
   describe('unexpected behavior', () => {


### PR DESCRIPTION
Sanitize nested accounts before attaching them to walletFindMany results.

Add a regression test that proves nested account secret keys stay hidden.

Part of #545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account data security in wallet operations. Sensitive account credentials are now properly sanitized and filtered from wallet query results. Confidential information that was previously exposed is no longer returned in results, providing enhanced protection for user account security and preventing unauthorized access to sensitive account credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->