### PR TITLE
fix(web): recover from stale chunk load errors

### DIFF
--- a/apps/web/src/setup.ts
+++ b/apps/web/src/setup.ts
@@ -1,3 +1,19 @@
 import { setup } from '@workspace/wallet-standard'
 
+const preloadErrorReloadKey = 'samui:preload-error-reloaded'
+
+window.addEventListener('load', () => {
+  sessionStorage.removeItem(preloadErrorReloadKey)
+})
+
+window.addEventListener('vite:preloadError', (event) => {
+  if (sessionStorage.getItem(preloadErrorReloadKey)) {
+    return
+  }
+
+  event.preventDefault()
+  sessionStorage.setItem(preloadErrorReloadKey, 'true')
+  window.location.reload()
+})
+
 setup()


### PR DESCRIPTION
Vite emits vite:preloadError when a dynamic import fails after old chunks disappear.

Handle that event in the web setup entrypoint by preventing the route error and reloading once.

The sessionStorage guard avoids refresh loops if the failure repeats after reload.

Docs: https://vite.dev/guide/build#load-error-handling

Fixes #639
