### PR TITLE
fix(background): decode transport bytes at boundary

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -692,7 +692,6 @@
         "@solana/wallet-standard-features": "catalog:",
         "@wallet-standard/core": "catalog:",
         "@workspace/background": "workspace:*",
-        "@workspace/keypair": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "catalog:",

--- a/packages/background/src/services/sign.ts
+++ b/packages/background/src/services/sign.ts
@@ -22,8 +22,8 @@ import type {
 import { createSignInMessage } from '@solana/wallet-standard-util'
 import type { ProxyService, ProxyServiceKey } from '@webext-core/proxy-service'
 import { createProxyService, registerService } from '@webext-core/proxy-service'
-import { ensureUint8Array } from '@workspace/keypair/ensure-uint8array'
 
+import { decodeTransportBytes } from '../transport-bytes.ts'
 import { getDbService } from './db.ts'
 
 const rpc = createSolanaRpc('https://api.devnet.solana.com')
@@ -51,7 +51,7 @@ function createSignService() {
       const key = await createKeyPairFromBytes(bytes)
 
       for (const input of inputs) {
-        const decoded = getTransactionDecoder().decode(ensureUint8Array(input.transaction))
+        const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
         const transaction = await signTransaction([key], decoded)
         const sendTransaction = sendTransactionWithoutConfirmingFactory({ rpc })
         // @ts-expect-error TODO: Figure out "Type 'FullySignedTransaction & Readonly<{ messageBytes: TransactionMessageBytes; signatures: SignaturesMap; }> & TransactionWithLifetime' is missing the following properties from type 'Readonly<{ instructions: readonly Instruction<string, readonly (AccountLookupMeta<string, string> | AccountMeta<string>)[]>[]; version: TransactionVersion; }>': instructions, version"
@@ -109,7 +109,7 @@ function createSignService() {
       const { privateKey } = await createKeyPairFromBytes(bytes)
 
       for (const input of inputs) {
-        const signedMessage = ensureUint8Array(input.message)
+        const signedMessage = decodeTransportBytes(input.message)
         const signature = await signBytes(privateKey, signedMessage)
 
         results.push({
@@ -132,7 +132,7 @@ function createSignService() {
       const key = await createKeyPairFromBytes(bytes)
 
       for (const input of inputs) {
-        const decoded = getTransactionDecoder().decode(ensureUint8Array(input.transaction))
+        const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
         const signed = await signTransaction([key], decoded)
         results.push({
           signedTransaction: new Uint8Array(getTransactionEncoder().encode(signed)),

--- a/packages/background/src/transport-bytes.ts
+++ b/packages/background/src/transport-bytes.ts
@@ -4,6 +4,6 @@ import type { ReadonlyUint8Array } from '@solana/kit'
  * @link https://github.com/mozilla/webextension-polyfill/issues/643
  * @link https://issues.chromium.org/issues/40321352
  */
-export function ensureUint8Array(value: Record<string, number> | Uint8Array | ReadonlyUint8Array): Uint8Array {
+export function decodeTransportBytes(value: Record<string, number> | Uint8Array | ReadonlyUint8Array): Uint8Array {
   return value instanceof Uint8Array ? value : new Uint8Array(Object.values(value))
 }

--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -3,8 +3,7 @@
     "@solana/wallet-standard-chains": "catalog:",
     "@solana/wallet-standard-features": "catalog:",
     "@wallet-standard/core": "catalog:",
-    "@workspace/background": "workspace:*",
-    "@workspace/keypair": "workspace:*"
+    "@workspace/background": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/wallet-standard/src/features/sign-and-send-transaction.ts
+++ b/packages/wallet-standard/src/features/sign-and-send-transaction.ts
@@ -3,8 +3,8 @@ import type {
   SolanaSignAndSendTransactionOutput,
 } from '@solana/wallet-standard-features'
 
+import { decodeTransportBytes } from '@workspace/background/transport-bytes'
 import { sendMessage } from '@workspace/background/window'
-import { ensureUint8Array } from '@workspace/keypair/ensure-uint8array'
 
 export async function signAndSendTransaction(
   ...inputs: SolanaSignAndSendTransactionInput[]
@@ -13,6 +13,6 @@ export async function signAndSendTransaction(
 
   return response.map((output) => ({
     ...output,
-    signature: ensureUint8Array(output.signature),
+    signature: decodeTransportBytes(output.signature),
   }))
 }

--- a/packages/wallet-standard/src/features/sign-in.ts
+++ b/packages/wallet-standard/src/features/sign-in.ts
@@ -1,14 +1,14 @@
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features'
 
+import { decodeTransportBytes } from '@workspace/background/transport-bytes'
 import { sendMessage } from '@workspace/background/window'
-import { ensureUint8Array } from '@workspace/keypair/ensure-uint8array'
 
 export async function signIn(...inputs: SolanaSignInInput[]): Promise<SolanaSignInOutput[]> {
   const outputs = await sendMessage('signIn', inputs)
 
   return outputs.map((output) => ({
     ...output,
-    signature: ensureUint8Array(output.signature),
-    signedMessage: ensureUint8Array(output.signedMessage),
+    signature: decodeTransportBytes(output.signature),
+    signedMessage: decodeTransportBytes(output.signedMessage),
   }))
 }

--- a/packages/wallet-standard/src/features/sign-message.ts
+++ b/packages/wallet-standard/src/features/sign-message.ts
@@ -1,14 +1,14 @@
 import type { SolanaSignMessageInput, SolanaSignMessageOutput } from '@solana/wallet-standard-features'
 
+import { decodeTransportBytes } from '@workspace/background/transport-bytes'
 import { sendMessage } from '@workspace/background/window'
-import { ensureUint8Array } from '@workspace/keypair/ensure-uint8array'
 
 export async function signMessage(...inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> {
   const outputs = await sendMessage('signMessage', inputs)
 
   return outputs.map((output) => ({
     ...output,
-    signature: ensureUint8Array(output.signature),
-    signedMessage: ensureUint8Array(output.signedMessage),
+    signature: decodeTransportBytes(output.signature),
+    signedMessage: decodeTransportBytes(output.signedMessage),
   }))
 }

--- a/packages/wallet-standard/src/features/sign-transaction.ts
+++ b/packages/wallet-standard/src/features/sign-transaction.ts
@@ -1,13 +1,13 @@
 import type { SolanaSignTransactionInput, SolanaSignTransactionOutput } from '@solana/wallet-standard-features'
 
+import { decodeTransportBytes } from '@workspace/background/transport-bytes'
 import { sendMessage } from '@workspace/background/window'
-import { ensureUint8Array } from '@workspace/keypair/ensure-uint8array'
 
 export async function signTransaction(...inputs: SolanaSignTransactionInput[]): Promise<SolanaSignTransactionOutput[]> {
   const response = await sendMessage('signTransaction', inputs)
 
   return response.map((output) => ({
     ...output,
-    signedTransaction: ensureUint8Array(output.signedTransaction),
+    signedTransaction: decodeTransportBytes(output.signedTransaction),
   }))
 }

--- a/packages/wallet-standard/src/wallet.ts
+++ b/packages/wallet-standard/src/wallet.ts
@@ -28,8 +28,8 @@ import {
   type WalletIcon,
   type WalletVersion,
 } from '@wallet-standard/core'
+import { decodeTransportBytes } from '@workspace/background/transport-bytes'
 import { sendMessage } from '@workspace/background/window'
-import { ensureUint8Array } from '@workspace/keypair/ensure-uint8array'
 import { signAndSendTransaction } from './features/sign-and-send-transaction.ts'
 import { signIn } from './features/sign-in.ts'
 import { signMessage } from './features/sign-message.ts'
@@ -78,7 +78,7 @@ export class SamuiWallet implements Wallet {
           const response = await sendMessage('connect', input)
           const accounts = response.accounts.map((account) => ({
             ...account,
-            publicKey: ensureUint8Array(account.publicKey),
+            publicKey: decodeTransportBytes(account.publicKey),
           }))
 
           this.#accounts = accounts


### PR DESCRIPTION
Move Chrome extension byte normalization from @workspace/keypair into @workspace/background.

This keeps the workaround beside the message transport boundary that requires it.

Update background signing and wallet-standard response handling to use the background helper.

Remove the now-unused wallet-standard dependency on @workspace/keypair.

SuperJSON did not improve the implementation because the message schema stays unchanged.

The only required behavior is rebuilding Uint8Array values from Chrome transport records.

A serializer refactor would still leave this boundary needing explicit transport-byte decoding.

Fixes #696
