### PR TITLE
feat(solana-client): export public API types

### DIFF
--- a/packages/explorer/src/ui/get-program-fields.tsx
+++ b/packages/explorer/src/ui/get-program-fields.tsx
@@ -1,12 +1,57 @@
 import type { Address } from '@solana/kit'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from '@workspace/solana-client/constants'
 import { getInstructionType } from '@workspace/solana-client/get-instruction-type'
-import type { GetTransactionResultInstruction } from '@workspace/solana-client/get-transaction'
+import type {
+  GetTransactionResultInstruction,
+  GetTransactionResultParsedInstruction,
+} from '@workspace/solana-client/get-transaction'
+import { assertGetTransactionResultParsedInstruction } from '@workspace/solana-client/get-transaction'
 import { UiDebug } from '@workspace/ui/components/ui-debug'
 import type { ReactNode } from 'react'
 import { formatBalance } from '../data-access/format-balance.tsx'
 import { ExplorerUiLinkAddress } from './explorer-ui-link-address.tsx'
 import { ExplorerUiProgramLabel } from './explorer-ui-program-label.tsx'
+
+type ExplorerParsedInstruction = GetTransactionResultParsedInstruction & {
+  parsed: GetTransactionResultParsedInstruction['parsed'] & {
+    info: ExplorerParsedInstructionInfo
+  }
+}
+
+type ExplorerParsedInstructionInfo = {
+  account: Address
+  authority: Address
+  destination: Address
+  extensionTypes?: readonly string[]
+  lamports: bigint | number
+  mint: Address
+  mintAuthority: Address
+  newAccount: Address
+  owner: Address
+  source: Address
+  space: number
+  systemProgram: Address
+  tokenAmount: { uiAmount: number | null }
+  tokenProgram: Address
+  wallet: Address
+}
+
+function assertExplorerParsedInstruction(
+  instruction: GetTransactionResultInstruction,
+): asserts instruction is ExplorerParsedInstruction {
+  assertGetTransactionResultParsedInstruction(instruction)
+  const parsed = instruction.parsed as Partial<ExplorerParsedInstruction['parsed']>
+  if (!parsed?.info) {
+    throw new Error('Expected parsed transaction instruction info')
+  }
+}
+
+function parsedField(handler: (info: ExplorerParsedInstructionInfo) => ReactNode) {
+  return (instruction: GetTransactionResultInstruction) => {
+    assertExplorerParsedInstruction(instruction)
+    return handler(instruction.parsed.info)
+  }
+}
 
 function getInstructionFields(
   basePath: string,
@@ -26,51 +71,51 @@ function getInstructionFields(
     case `${TOKEN_2022_PROGRAM_ADDRESS}.getAccountDataSize`:
     case `${TOKEN_PROGRAM_ADDRESS}.getAccountDataSize`:
       return [
-        ['Mint', (instruction) => <ExplorerLink address={instruction.parsed.info.mint} />],
-        ['Extension types', (instruction) => <UiDebug data={instruction.parsed.info?.extensionTypes?.join(', ')} />],
+        ['Mint', parsedField((info) => <ExplorerLink address={info.mint} />)],
+        ['Extension types', parsedField((info) => <UiDebug data={info.extensionTypes?.join(', ')} />)],
       ]
     case `${TOKEN_2022_PROGRAM_ADDRESS}.initializeImmutableOwner`:
     case `${TOKEN_PROGRAM_ADDRESS}.initializeImmutableOwner`:
-      return [['Account', (instruction) => <ExplorerLink address={instruction.parsed.info.account} />]]
+      return [['Account', parsedField((info) => <ExplorerLink address={info.account} />)]]
     case `${TOKEN_2022_PROGRAM_ADDRESS}.initializeAccount3`:
     case `${TOKEN_PROGRAM_ADDRESS}.initializeAccount3`:
       return [
-        ['Account', (instruction) => <ExplorerLink address={instruction.parsed.info.account} />],
-        ['Mint', (instruction) => <ExplorerLink address={instruction.parsed.info.mint} />],
-        ['Owner', (instruction) => <ExplorerLink address={instruction.parsed.info.owner} />],
+        ['Account', parsedField((info) => <ExplorerLink address={info.account} />)],
+        ['Mint', parsedField((info) => <ExplorerLink address={info.mint} />)],
+        ['Owner', parsedField((info) => <ExplorerLink address={info.owner} />)],
       ]
     case `${TOKEN_2022_PROGRAM_ADDRESS}.mintToChecked`:
       return [
-        ['Mint', (instruction) => <ExplorerLink address={instruction.parsed.info.mint} />],
-        ['Account', (instruction) => <ExplorerLink address={instruction.parsed.info.account} />],
-        ['Mint authority', (instruction) => <ExplorerLink address={instruction.parsed.info.mintAuthority} />],
-        ['Amount', (instruction) => instruction.parsed.info.tokenAmount.uiAmount],
+        ['Mint', parsedField((info) => <ExplorerLink address={info.mint} />)],
+        ['Account', parsedField((info) => <ExplorerLink address={info.account} />)],
+        ['Mint authority', parsedField((info) => <ExplorerLink address={info.mintAuthority} />)],
+        ['Amount', parsedField((info) => info.tokenAmount.uiAmount)],
       ]
     case `${TOKEN_PROGRAM_ADDRESS}.transferChecked`:
       return [
-        ['Authority', (instruction) => <ExplorerLink address={instruction.parsed.info.authority} />],
-        ['Destination', (instruction) => <ExplorerLink address={instruction.parsed.info.destination} />],
-        ['Mint', (instruction) => <ExplorerLink address={instruction.parsed.info.mint} />],
-        ['Source', (instruction) => <ExplorerLink address={instruction.parsed.info.source} />],
-        ['Amount', (instruction) => instruction.parsed.info.tokenAmount.uiAmount],
+        ['Authority', parsedField((info) => <ExplorerLink address={info.authority} />)],
+        ['Destination', parsedField((info) => <ExplorerLink address={info.destination} />)],
+        ['Mint', parsedField((info) => <ExplorerLink address={info.mint} />)],
+        ['Source', parsedField((info) => <ExplorerLink address={info.source} />)],
+        ['Amount', parsedField((info) => info.tokenAmount.uiAmount)],
       ]
     case `11111111111111111111111111111111.createAccount`:
       return [
-        ['From Address', (instruction) => <ExplorerLink address={instruction.parsed.info.source} />],
-        ['New Address', (instruction) => <ExplorerLink address={instruction.parsed.info.newAccount} />],
-        ['Transfer amount', (instruction) => formatBalance({ balance: instruction.parsed.info.lamports, decimals: 9 })],
-        ['Allocated Data Size', (instruction) => instruction.parsed.info.space],
-        ['Assigned Program ID', (instruction) => <ExplorerLink address={instruction.parsed.info.owner} />],
+        ['From Address', parsedField((info) => <ExplorerLink address={info.source} />)],
+        ['New Address', parsedField((info) => <ExplorerLink address={info.newAccount} />)],
+        ['Transfer amount', parsedField((info) => formatBalance({ balance: info.lamports, decimals: 9 }))],
+        ['Allocated Data Size', parsedField((info) => info.space)],
+        ['Assigned Program ID', parsedField((info) => <ExplorerLink address={info.owner} />)],
       ]
     case `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.createIdempotent`:
     case `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.create`:
       return [
-        ['Source', (instruction) => <ExplorerLink address={instruction.parsed.info.source} />],
-        ['Account', (instruction) => <ExplorerLink address={instruction.parsed.info.account} />],
-        ['Mint', (instruction) => <ExplorerLink address={instruction.parsed.info.mint} />],
-        ['Wallet', (instruction) => <ExplorerLink address={instruction.parsed.info.wallet} />],
-        ['System Program', (instruction) => <ExplorerLink address={instruction.parsed.info.systemProgram} />],
-        ['Token Program', (instruction) => <ExplorerLink address={instruction.parsed.info.tokenProgram} />],
+        ['Source', parsedField((info) => <ExplorerLink address={info.source} />)],
+        ['Account', parsedField((info) => <ExplorerLink address={info.account} />)],
+        ['Mint', parsedField((info) => <ExplorerLink address={info.mint} />)],
+        ['Wallet', parsedField((info) => <ExplorerLink address={info.wallet} />)],
+        ['System Program', parsedField((info) => <ExplorerLink address={info.systemProgram} />)],
+        ['Token Program', parsedField((info) => <ExplorerLink address={info.tokenProgram} />)],
       ]
     default:
       return []

--- a/packages/solana-client/src/create-get-or-create-ata-instruction.ts
+++ b/packages/solana-client/src/create-get-or-create-ata-instruction.ts
@@ -2,17 +2,21 @@ import type { Address, Instruction, TransactionSigner } from '@solana/kit'
 import { findAssociatedTokenPda } from '@solana-program/token'
 import { getCreateAssociatedTokenIdempotentInstruction } from '@solana-program/token-2022'
 
+export interface CreateGetOrCreateAtaInstructionOptions {
+  mint: Address
+  owner: Address
+  tokenProgram: Address
+  transactionSigner: TransactionSigner
+}
+
+export type CreateGetOrCreateAtaInstructionResult = [Address, Instruction]
+
 export async function createGetOrCreateAtaInstruction({
   mint,
   owner,
   tokenProgram,
   transactionSigner: payer,
-}: {
-  mint: Address
-  owner: Address
-  tokenProgram: Address
-  transactionSigner: TransactionSigner
-}): Promise<[Address, Instruction]> {
+}: CreateGetOrCreateAtaInstructionOptions): Promise<CreateGetOrCreateAtaInstructionResult> {
   const [ata] = await findAssociatedTokenPda({
     mint,
     owner,

--- a/packages/solana-client/src/create-solana-client.ts
+++ b/packages/solana-client/src/create-solana-client.ts
@@ -2,13 +2,15 @@ import type { ClusterUrl } from '@solana/kit'
 import { createSolanaRpc, createSolanaRpcSubscriptions } from '@solana/kit'
 import type { SolanaClient } from './solana-client.ts'
 
+export interface CreateSolanaClientOptions<TClusterUrl extends ClusterUrl> {
+  url: TClusterUrl
+  urlSubscriptions?: TClusterUrl | undefined
+}
+
 export function createSolanaClient<TClusterUrl extends ClusterUrl>({
   url,
   urlSubscriptions,
-}: {
-  url: TClusterUrl
-  urlSubscriptions?: TClusterUrl | undefined
-}): SolanaClient<TClusterUrl> {
+}: CreateSolanaClientOptions<TClusterUrl>): SolanaClient<TClusterUrl> {
   if (!url.startsWith('http')) {
     throw new Error('Invalid url')
   }

--- a/packages/solana-client/src/fetch-account.ts
+++ b/packages/solana-client/src/fetch-account.ts
@@ -1,13 +1,18 @@
 import { type Address, fetchJsonParsedAccount } from '@solana/kit'
 import type { SolanaClient } from './solana-client.ts'
 
-export type FetchedAccount = Awaited<ReturnType<typeof fetchAccount>>
+export interface FetchAccountOptions {
+  address: Address
+  throwOnError?: boolean
+}
+
+export type FetchedAccount = Awaited<ReturnType<typeof fetchJsonParsedAccount>>
 export type ExistingFetchedAccount = Extract<FetchedAccount, { exists: true }>
 
 export async function fetchAccount(
   client: SolanaClient,
-  { address, throwOnError = true }: { address: Address; throwOnError?: boolean },
-) {
+  { address, throwOnError = true }: FetchAccountOptions,
+): Promise<FetchedAccount> {
   const result = await fetchJsonParsedAccount(client.rpc, address)
 
   // Throw an error if the account is not found, ensuring the return type is never null

--- a/packages/solana-client/src/format-simulation-failure.ts
+++ b/packages/solana-client/src/format-simulation-failure.ts
@@ -1,11 +1,11 @@
-export function formatSimulationFailure(error: unknown, logs: string[] = []) {
+export function formatSimulationFailure(error: unknown, logs: string[] = []): string {
   const formattedError = formatUnknownError(error)
   const parts = formattedError ? [formattedError] : []
   parts.push(...logs)
   return parts.join('\n')
 }
 
-function formatUnknownError(error: unknown) {
+function formatUnknownError(error: unknown): string {
   if (!error) {
     return ''
   }

--- a/packages/solana-client/src/get-account-info.ts
+++ b/packages/solana-client/src/get-account-info.ts
@@ -2,8 +2,15 @@ import type { Address, GetAccountInfoApi } from '@solana/kit'
 
 import type { SolanaClient } from './solana-client.ts'
 
+export interface GetAccountInfoOptions {
+  address: Address
+}
+
 export type GetAccountInfoResult = ReturnType<GetAccountInfoApi['getAccountInfo']>
 
-export function getAccountInfo(client: SolanaClient, { address }: { address: Address }): Promise<GetAccountInfoResult> {
+export function getAccountInfo(
+  client: SolanaClient,
+  { address }: GetAccountInfoOptions,
+): Promise<GetAccountInfoResult> {
   return client.rpc.getAccountInfo(address).send()
 }

--- a/packages/solana-client/src/get-account-token-info.ts
+++ b/packages/solana-client/src/get-account-token-info.ts
@@ -33,6 +33,10 @@ export type AccountTokenMintInfo = Readonly<{
 
 export type AccountTokenInfo = AccountTokenAccountInfo | AccountTokenMintInfo
 
+export interface GetAccountTokenInfoOptions {
+  account?: FetchedAccount | undefined
+}
+
 function getExtensionLabels(extensions: readonly unknown[] | undefined) {
   const result = extensions
     ?.map((extension) => {
@@ -56,11 +60,7 @@ function isParsedTokenMintData(data: ExistingFetchedAccountData): data is Parsed
   return !(data instanceof Uint8Array) && data.parsedAccountMeta?.type === 'mint'
 }
 
-export function getAccountTokenInfo({
-  account,
-}: {
-  account?: FetchedAccount | undefined
-}): AccountTokenInfo | undefined {
+export function getAccountTokenInfo({ account }: GetAccountTokenInfoOptions): AccountTokenInfo | undefined {
   if (!account?.exists) {
     return undefined
   }

--- a/packages/solana-client/src/get-account-token-type.ts
+++ b/packages/solana-client/src/get-account-token-type.ts
@@ -2,7 +2,12 @@ import { assertAccountExists } from '@solana/kit'
 import type { FetchedAccount } from './fetch-account.ts'
 
 export type AccountTokenType = 'token-account' | 'token-mint' | 'token-unknown'
-export function getAccountTokenType({ account }: { account: FetchedAccount }): AccountTokenType {
+
+export interface GetAccountTokenTypeOptions {
+  account: FetchedAccount
+}
+
+export function getAccountTokenType({ account }: GetAccountTokenTypeOptions): AccountTokenType {
   assertAccountExists(account)
   if (
     account.data.parsedAccountMeta?.program !== 'spl-token' &&

--- a/packages/solana-client/src/get-account-type.ts
+++ b/packages/solana-client/src/get-account-type.ts
@@ -5,7 +5,11 @@ import { type AccountTokenType, getAccountTokenType } from './get-account-token-
 
 export type AccountType = AccountTokenType | 'not-found' | 'system' | 'system-program' | 'unknown'
 
-export function getAccountType({ account }: { account?: FetchedAccount | undefined }): AccountType {
+export interface GetAccountTypeOptions {
+  account?: FetchedAccount | undefined
+}
+
+export function getAccountType({ account }: GetAccountTypeOptions): AccountType {
   if (!account?.exists) {
     return 'not-found'
   }

--- a/packages/solana-client/src/get-activity.ts
+++ b/packages/solana-client/src/get-activity.ts
@@ -2,6 +2,10 @@ import type { Address, Commitment, Signature, Slot, TransactionError, UnixTimest
 
 import type { SolanaClient } from './solana-client.ts'
 
+export interface GetActivityOptions {
+  address: Address
+}
+
 export type GetActivityItem = Readonly<{
   blockTime: null | UnixTimestamp
   confirmationStatus: Commitment | null
@@ -13,6 +17,6 @@ export type GetActivityItem = Readonly<{
 
 export type GetActivityItems = Readonly<GetActivityItem[]>
 
-export function getActivity(client: SolanaClient, { address }: { address: Address }): Promise<GetActivityItems> {
+export function getActivity(client: SolanaClient, { address }: GetActivityOptions): Promise<GetActivityItems> {
   return client.rpc.getSignaturesForAddress(address).send()
 }

--- a/packages/solana-client/src/get-balance.ts
+++ b/packages/solana-client/src/get-balance.ts
@@ -2,8 +2,12 @@ import type { Address, GetBalanceApi } from '@solana/kit'
 
 import type { SolanaClient } from './solana-client.ts'
 
+export interface GetBalanceOptions {
+  address: Address
+}
+
 export type GetBalanceResult = ReturnType<GetBalanceApi['getBalance']>
 
-export function getBalance(client: SolanaClient, { address }: { address: Address }): Promise<GetBalanceResult> {
+export function getBalance(client: SolanaClient, { address }: GetBalanceOptions): Promise<GetBalanceResult> {
   return client.rpc.getBalance(address).send()
 }

--- a/packages/solana-client/src/get-explorer-url.ts
+++ b/packages/solana-client/src/get-explorer-url.ts
@@ -15,7 +15,7 @@ export interface GetExplorerUrlProps {
   provider: ExplorerProvider
 }
 
-export function getExplorerUrl({ network, path, provider }: GetExplorerUrlProps) {
+export function getExplorerUrl({ network, path, provider }: GetExplorerUrlProps): string {
   if (!(path.startsWith('/address') || path.startsWith('/block') || path.startsWith('/tx'))) {
     throw new Error('Invalid path. Must be /address, /block, or /tx.')
   }
@@ -34,7 +34,7 @@ export function getExplorerUrl({ network, path, provider }: GetExplorerUrlProps)
   return url.toString()
 }
 
-function getExplorerBaseUrl(provider: ExplorerProvider) {
+function getExplorerBaseUrl(provider: ExplorerProvider): string {
   switch (provider) {
     case 'orb':
       return 'https://orb.helius.dev'

--- a/packages/solana-client/src/get-instruction-type.ts
+++ b/packages/solana-client/src/get-instruction-type.ts
@@ -1,5 +1,6 @@
 import type { GetTransactionResultInstruction } from './get-transaction.ts'
 
-export function getInstructionType(instruction: GetTransactionResultInstruction) {
-  return instruction.parsed?.type ?? ''
+export function getInstructionType(instruction: GetTransactionResultInstruction): string {
+  const parsedType = instruction.parsed?.type
+  return typeof parsedType === 'string' ? parsedType : ''
 }

--- a/packages/solana-client/src/get-latest-blockhash.ts
+++ b/packages/solana-client/src/get-latest-blockhash.ts
@@ -1,7 +1,9 @@
+import type { GetLatestBlockhashApi } from '@solana/kit'
 import type { SolanaClient } from './solana-client.ts'
 
-export type LatestBlockhash = Awaited<ReturnType<typeof getLatestBlockhash>>
-export async function getLatestBlockhash(client: SolanaClient) {
+export type LatestBlockhash = ReturnType<GetLatestBlockhashApi['getLatestBlockhash']>['value']
+
+export async function getLatestBlockhash(client: SolanaClient): Promise<LatestBlockhash> {
   return await client.rpc
     .getLatestBlockhash()
     .send()

--- a/packages/solana-client/src/get-program-instruction.ts
+++ b/packages/solana-client/src/get-program-instruction.ts
@@ -16,7 +16,7 @@ const instructionMap = new Map<string, string>()
   .set(`ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.create`, 'Create')
   .set(`ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.createIdempotent`, 'Create idempotent')
 
-export function getProgramInstruction(instruction: GetTransactionResultInstruction) {
+export function getProgramInstruction(instruction: GetTransactionResultInstruction): string {
   return (
     instructionMap.get(`${instruction.programId}.${getInstructionType(instruction)}`) ?? getInstructionType(instruction)
   )

--- a/packages/solana-client/src/get-program.ts
+++ b/packages/solana-client/src/get-program.ts
@@ -1,7 +1,7 @@
 import type { GetTransactionResultInstruction } from './get-transaction.ts'
 import { programMap } from './program-map.ts'
 
-export function getProgram(instruction: GetTransactionResultInstruction) {
+export function getProgram(instruction: GetTransactionResultInstruction): string {
   const found = programMap.get(instruction.programId)
 
   return found ?? instruction.programId

--- a/packages/solana-client/src/get-simulated-sol-balance-changes.ts
+++ b/packages/solana-client/src/get-simulated-sol-balance-changes.ts
@@ -5,19 +5,23 @@ import type {
   SimulatePreparedTransactionSolBalanceChange,
 } from './simulate-prepared-transaction-types.ts'
 
+export interface GetSimulatedSolBalanceChangesOptions {
+  accountAddresses: Address[]
+  postAccounts: readonly (RawParsedAccount | null)[] | undefined
+  postBalances: readonly (bigint | number | string)[] | undefined
+  preAccounts: readonly (RawParsedAccount | null)[]
+  preBalances: readonly (bigint | number | string)[] | undefined
+}
+
+export type GetSimulatedSolBalanceChangesResult = SimulatePreparedTransactionSolBalanceChange[]
+
 export function getSimulatedSolBalanceChanges({
   accountAddresses,
   postAccounts,
   postBalances,
   preAccounts,
   preBalances,
-}: {
-  accountAddresses: Address[]
-  postAccounts: readonly (RawParsedAccount | null)[] | undefined
-  postBalances: readonly (bigint | number | string)[] | undefined
-  preAccounts: readonly (RawParsedAccount | null)[]
-  preBalances: readonly (bigint | number | string)[] | undefined
-}) {
+}: GetSimulatedSolBalanceChangesOptions): GetSimulatedSolBalanceChangesResult {
   return (
     getSolBalanceChanges({
       accountAddresses,

--- a/packages/solana-client/src/get-simulated-token-balance-changes.ts
+++ b/packages/solana-client/src/get-simulated-token-balance-changes.ts
@@ -17,19 +17,23 @@ interface ParsedTokenAccountBalance {
   programId?: Address | undefined
 }
 
+export interface GetSimulatedTokenBalanceChangesOptions {
+  accountAddresses: Address[]
+  postAccounts: readonly (RawParsedAccount | null)[] | undefined
+  postTokenBalances: readonly RawSimulateTransactionTokenBalance[] | undefined
+  preAccounts: readonly (RawParsedAccount | null)[]
+  preTokenBalances: readonly RawSimulateTransactionTokenBalance[] | undefined
+}
+
+export type GetSimulatedTokenBalanceChangesResult = SimulatePreparedTransactionTokenBalanceChange[]
+
 export function getSimulatedTokenBalanceChanges({
   accountAddresses,
   postAccounts,
   postTokenBalances,
   preAccounts,
   preTokenBalances,
-}: {
-  accountAddresses: Address[]
-  postAccounts: readonly (RawParsedAccount | null)[] | undefined
-  postTokenBalances: readonly RawSimulateTransactionTokenBalance[] | undefined
-  preAccounts: readonly (RawParsedAccount | null)[]
-  preTokenBalances: readonly RawSimulateTransactionTokenBalance[] | undefined
-}) {
+}: GetSimulatedTokenBalanceChangesOptions): GetSimulatedTokenBalanceChangesResult {
   return (
     getTokenBalanceChanges({
       accountAddresses,

--- a/packages/solana-client/src/get-simulated-transaction-change-rows.ts
+++ b/packages/solana-client/src/get-simulated-transaction-change-rows.ts
@@ -1,6 +1,6 @@
 import type { Address } from '@solana/kit'
 import { NATIVE_MINT } from './constants.ts'
-import type { SimulatePreparedTransactionResult } from './simulate-prepared-transaction.ts'
+import type { SimulatePreparedTransactionSuccessResult } from './simulate-prepared-transaction.ts'
 
 export interface SimulatedTransactionChangeRow {
   address: Address
@@ -10,11 +10,20 @@ export interface SimulatedTransactionChangeRow {
   type: 'sol' | 'token'
 }
 
+export interface FormatSimulatedTransactionChangeOptions {
+  change: bigint
+  decimals: number
+}
+
+export interface GetSimulatedTransactionChangeRowsOptions {
+  simulation: SimulatePreparedTransactionSuccessResult
+}
+
+export type GetSimulatedTransactionChangeRowsResult = SimulatedTransactionChangeRow[]
+
 export function getSimulatedTransactionChangeRows({
   simulation,
-}: {
-  simulation: Extract<SimulatePreparedTransactionResult, { status: 'success' }>
-}) {
+}: GetSimulatedTransactionChangeRowsOptions): GetSimulatedTransactionChangeRowsResult {
   const solRows = simulation.solBalanceChanges.map(
     ({ address, change }): SimulatedTransactionChangeRow => ({
       address,
@@ -44,7 +53,10 @@ export function getSimulatedTransactionChangeRows({
   })
 }
 
-export function formatSimulatedTransactionChange({ change, decimals }: { change: bigint; decimals: number }) {
+export function formatSimulatedTransactionChange({
+  change,
+  decimals,
+}: FormatSimulatedTransactionChangeOptions): string {
   const formattedChange = formatBigIntAmount({ amount: change, decimals })
 
   return `${change > 0n ? '+' : ''}${formattedChange}`

--- a/packages/solana-client/src/get-stake-accounts.ts
+++ b/packages/solana-client/src/get-stake-accounts.ts
@@ -33,6 +33,10 @@ export interface StakeAccountData {
   } | null
 }
 
+export interface GetStakeAccountsOptions {
+  address: Address
+}
+
 interface ParsedStakeAccountData {
   parsed: {
     info: StakeAccountData
@@ -41,7 +45,7 @@ interface ParsedStakeAccountData {
 
 export async function getStakeAccounts(
   client: SolanaClient,
-  { address }: { address: Address },
+  { address }: GetStakeAccountsOptions,
 ): Promise<StakeAccount[]> {
   const accounts = await client.rpc
     .getProgramAccounts(STAKE_PROGRAM_ADDRESS, {

--- a/packages/solana-client/src/get-token-account-info.ts
+++ b/packages/solana-client/src/get-token-account-info.ts
@@ -1,5 +1,6 @@
 import { type Address, fetchJsonParsedAccount, type JsonParsedTokenAccount } from '@solana/kit'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from './constants.ts'
+import type { ExistingFetchedAccount } from './fetch-account.ts'
 import type { SolanaClient } from './solana-client.ts'
 import type { SplTokenBurnTokenProgram } from './spl-token-burn.ts'
 
@@ -9,7 +10,15 @@ export type ParsedTokenAccountData = JsonParsedTokenAccount & {
   }
 }
 
-export type TokenAccountInfo = Awaited<ReturnType<typeof getTokenAccountInfo>>
+export interface GetTokenAccountInfoOptions {
+  address: Address
+}
+
+export interface GetTokenAccountProgramAddressOptions {
+  account: TokenAccountInfo
+}
+
+export type TokenAccountInfo = ExistingFetchedAccount
 export type TokenAccountInfoWithTokenProgram = TokenAccountInfo & {
   tokenProgram: SplTokenBurnTokenProgram | undefined
 }
@@ -20,9 +29,7 @@ export function isParsedTokenAccountData(data: unknown): data is ParsedTokenAcco
 
 export function getTokenAccountProgramAddress({
   account,
-}: {
-  account: TokenAccountInfo
-}): SplTokenBurnTokenProgram | undefined {
+}: GetTokenAccountProgramAddressOptions): SplTokenBurnTokenProgram | undefined {
   if (!account.exists || account.data instanceof Uint8Array) {
     return undefined
   }
@@ -37,7 +44,10 @@ export function getTokenAccountProgramAddress({
   }
 }
 
-export async function getTokenAccountInfo(client: SolanaClient, { address }: { address: Address }) {
+export async function getTokenAccountInfo(
+  client: SolanaClient,
+  { address }: GetTokenAccountInfoOptions,
+): Promise<TokenAccountInfo> {
   const parsed = await fetchJsonParsedAccount(client.rpc, address, { commitment: 'confirmed' })
 
   if (!parsed?.exists) {

--- a/packages/solana-client/src/get-token-accounts-for-mint.ts
+++ b/packages/solana-client/src/get-token-accounts-for-mint.ts
@@ -1,11 +1,19 @@
 import type { Address } from '@solana/kit'
 
+import type { GetTokenAccountsByOwnerResult } from './get-token-accounts-for-program-id.ts'
 import type { SolanaClient } from './solana-client.ts'
+
+export interface GetTokenAccountsForMintOptions {
+  address: Address
+  mint: Address
+}
+
+export type GetTokenAccountsForMintResult = GetTokenAccountsByOwnerResult
 
 export async function getTokenAccountsForMint(
   client: SolanaClient,
-  { address, mint }: { address: Address; mint: Address },
-) {
+  { address, mint }: GetTokenAccountsForMintOptions,
+): Promise<GetTokenAccountsForMintResult> {
   return await client.rpc
     .getTokenAccountsByOwner(address, { mint }, { commitment: 'confirmed', encoding: 'jsonParsed' })
     .send()

--- a/packages/solana-client/src/get-token-accounts-for-program-id.ts
+++ b/packages/solana-client/src/get-token-accounts-for-program-id.ts
@@ -1,11 +1,43 @@
-import type { Address } from '@solana/kit'
+import type { Address, JsonParsedTokenAccount, Lamports, Slot } from '@solana/kit'
 
 import type { SolanaClient } from './solana-client.ts'
 
+export interface GetTokenAccountsForProgramIdOptions {
+  address: Address
+  programId: Address
+}
+
+export type GetTokenAccountsByOwnerResult = Readonly<{
+  context: Readonly<{
+    slot: Slot
+  }>
+  value: readonly TokenAccountsByOwnerAccount[]
+}>
+
+export interface TokenAccountsByOwnerAccount {
+  account: Readonly<{
+    data: Readonly<{
+      parsed: {
+        info: JsonParsedTokenAccount
+        type: 'account'
+      }
+      program: Address
+      space: bigint
+    }>
+    executable: boolean
+    lamports: Lamports
+    owner: Address
+    space: bigint
+  }>
+  pubkey: Address
+}
+
+export type GetTokenAccountsForProgramIdResult = GetTokenAccountsByOwnerResult
+
 export async function getTokenAccountsForProgramId(
   client: SolanaClient,
-  { address, programId }: { address: Address; programId: Address },
-) {
+  { address, programId }: GetTokenAccountsForProgramIdOptions,
+): Promise<GetTokenAccountsForProgramIdResult> {
   return await client.rpc
     .getTokenAccountsByOwner(address, { programId }, { commitment: 'confirmed', encoding: 'jsonParsed' })
     .send()

--- a/packages/solana-client/src/get-token-accounts.ts
+++ b/packages/solana-client/src/get-token-accounts.ts
@@ -1,12 +1,22 @@
 import type { Address } from '@solana/kit'
 import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token'
 import { TOKEN_2022_PROGRAM_ADDRESS } from '@solana-program/token-2022'
-import { getTokenAccountsForProgramId } from './get-token-accounts-for-program-id.ts'
+import {
+  type GetTokenAccountsForProgramIdResult,
+  getTokenAccountsForProgramId,
+} from './get-token-accounts-for-program-id.ts'
 import type { SolanaClient } from './solana-client.ts'
 
-export type GetTokenAccountsResult = Awaited<ReturnType<typeof getTokenAccounts>>
+export interface GetTokenAccountsOptions {
+  address: Address
+}
 
-export async function getTokenAccounts(client: SolanaClient, { address }: { address: Address }) {
+export type GetTokenAccountsResult = GetTokenAccountsForProgramIdResult['value']
+
+export async function getTokenAccounts(
+  client: SolanaClient,
+  { address }: GetTokenAccountsOptions,
+): Promise<GetTokenAccountsResult> {
   return Promise.all([
     getTokenAccountsForProgramId(client, { address, programId: TOKEN_PROGRAM_ADDRESS }),
     getTokenAccountsForProgramId(client, { address, programId: TOKEN_2022_PROGRAM_ADDRESS }),

--- a/packages/solana-client/src/get-transaction-base64.ts
+++ b/packages/solana-client/src/get-transaction-base64.ts
@@ -2,7 +2,16 @@ import type { Signature } from '@solana/kit'
 
 import type { SolanaClient } from './solana-client.ts'
 
-export async function getTransactionBase64(client: SolanaClient, { signature }: { signature: Signature }) {
+export interface GetTransactionBase64Options {
+  signature: Signature
+}
+
+export type GetTransactionBase64Result = string | null
+
+export async function getTransactionBase64(
+  client: SolanaClient,
+  { signature }: GetTransactionBase64Options,
+): Promise<GetTransactionBase64Result> {
   const tx = await client.rpc
     .getTransaction(signature, {
       encoding: 'base64',

--- a/packages/solana-client/src/get-transaction.ts
+++ b/packages/solana-client/src/get-transaction.ts
@@ -2,7 +2,11 @@ import type { Signature } from '@solana/kit'
 
 import type { SolanaClient } from './solana-client.ts'
 
-export async function getTransaction(client: SolanaClient, { signature }: { signature: Signature }) {
+export interface GetTransactionOptions {
+  signature: Signature
+}
+
+export async function getTransaction(client: SolanaClient, { signature }: GetTransactionOptions) {
   return client.rpc
     .getTransaction(signature, {
       encoding: 'jsonParsed',
@@ -11,7 +15,18 @@ export async function getTransaction(client: SolanaClient, { signature }: { sign
     .send()
 }
 
-export type GetTransactionResult = NonNullable<Awaited<ReturnType<typeof getTransaction>>>
-export type GetTransactionResultInstruction =
-  // biome-ignore lint/suspicious/noExplicitAny: ongoing type confusion
-  GetTransactionResult['transaction']['message']['instructions'][number] & { parsed?: any }
+export type GetTransactionResponse = Awaited<ReturnType<typeof getTransaction>>
+export type GetTransactionResult = NonNullable<GetTransactionResponse>
+type GetTransactionResultInstructionUnion = GetTransactionResult['transaction']['message']['instructions'][number]
+export type GetTransactionResultParsedInstruction = Extract<GetTransactionResultInstructionUnion, { parsed: unknown }>
+export type GetTransactionResultInstruction = GetTransactionResultInstructionUnion & {
+  parsed?: GetTransactionResultParsedInstruction['parsed']
+}
+
+export function assertGetTransactionResultParsedInstruction(
+  instruction: GetTransactionResultInstruction,
+): asserts instruction is GetTransactionResultParsedInstruction {
+  if (!('parsed' in instruction)) {
+    throw new Error('Expected parsed transaction instruction')
+  }
+}

--- a/packages/solana-client/src/get-vote-accounts.ts
+++ b/packages/solana-client/src/get-vote-accounts.ts
@@ -1,7 +1,10 @@
+import type { GetVoteAccountsApi } from '@solana/kit'
 import { tryCatch } from '@workspace/core/try-catch'
 import type { SolanaClient } from './solana-client.ts'
 
-export async function getVoteAccounts(client: SolanaClient) {
+export type GetCurrentVoteAccountsResult = ReturnType<GetVoteAccountsApi['getVoteAccounts']>['current']
+
+export async function getVoteAccounts(client: SolanaClient): Promise<GetCurrentVoteAccountsResult> {
   const { data: accounts, error } = await tryCatch(client.rpc.getVoteAccounts().send())
   if (error) {
     console.log(error)

--- a/packages/solana-client/src/parse-transaction-inspector-input.ts
+++ b/packages/solana-client/src/parse-transaction-inspector-input.ts
@@ -66,6 +66,11 @@ export interface TransactionInspectorAddressTableLookup {
   writableIndexes: readonly number[]
 }
 
+export interface TransactionInspectorAccountReferencesOptions {
+  addressTableLookups: TransactionInspectorAddressTableLookup[]
+  staticAccounts: Address[]
+}
+
 interface ParsedTransactionBytes {
   rawMessage: ReadonlyUint8Array
   signatures: TransactionInspectorSignature[]
@@ -172,10 +177,7 @@ function getAddressTableLookups(message: CompiledTransactionMessage): Transactio
 export function getTransactionInspectorAccountReferences({
   addressTableLookups,
   staticAccounts,
-}: {
-  addressTableLookups: TransactionInspectorAddressTableLookup[]
-  staticAccounts: Address[]
-}): TransactionInspectorAccountReference[] {
+}: TransactionInspectorAccountReferencesOptions): TransactionInspectorAccountReference[] {
   return [
     ...staticAccounts.map((address, index) => ({
       address,

--- a/packages/solana-client/src/prepared-transaction-message.ts
+++ b/packages/solana-client/src/prepared-transaction-message.ts
@@ -5,6 +5,9 @@ import {
   pipe,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
+  type TransactionMessage,
+  type TransactionMessageWithBlockhashLifetime,
+  type TransactionMessageWithFeePayerSigner,
   type TransactionSigner,
 } from '@solana/kit'
 import { getLatestBlockhash, type LatestBlockhash } from './get-latest-blockhash.ts'
@@ -18,10 +21,17 @@ export interface PreparedTransactionOptions {
 
 export type PreparedTransaction = Omit<PreparedTransactionOptions, 'latestBlockhash'>
 
+export interface PreparedTransactionMessage {
+  latestBlockhash: LatestBlockhash
+  transactionMessage: TransactionMessage &
+    TransactionMessageWithBlockhashLifetime &
+    TransactionMessageWithFeePayerSigner
+}
+
 export async function createPreparedTransactionMessage(
   client: SolanaClient,
   { instructions, latestBlockhash, transactionSigner }: PreparedTransactionOptions,
-) {
+): Promise<PreparedTransactionMessage> {
   const transactionLatestBlockhash = latestBlockhash ?? (await getLatestBlockhash(client))
   const transactionMessage = pipe(
     createTransactionMessage({ version: 0 }),

--- a/packages/solana-client/src/request-airdrop.ts
+++ b/packages/solana-client/src/request-airdrop.ts
@@ -1,13 +1,18 @@
-import { type Address, airdropFactory, type Lamports } from '@solana/kit'
+import { type Address, airdropFactory, type Lamports, type Signature } from '@solana/kit'
 
 import type { SolanaClient } from './solana-client.ts'
 
-export interface RequestAirdropOption {
+export interface RequestAirdropOptions {
   address: Address
   amount: Lamports
 }
 
-export async function requestAirdrop(client: SolanaClient, { address, amount }: RequestAirdropOption) {
+export type RequestAirdropOption = RequestAirdropOptions
+
+export async function requestAirdrop(
+  client: SolanaClient,
+  { address, amount }: RequestAirdropOptions,
+): Promise<Signature> {
   return await airdropFactory(client)({
     commitment: 'confirmed',
     lamports: amount,

--- a/packages/solana-client/src/simulate-prepared-transaction-types.ts
+++ b/packages/solana-client/src/simulate-prepared-transaction-types.ts
@@ -50,15 +50,19 @@ export interface SimulatePreparedTransactionBaseResult {
   unitsConsumed: bigint | undefined
 }
 
+export type SimulatePreparedTransactionFailureResult = SimulatePreparedTransactionBaseResult & {
+  error: unknown
+  status: 'failure'
+}
+
 export type SimulatePreparedTransactionResult =
-  | (SimulatePreparedTransactionBaseResult & {
-      error: null
-      status: 'success'
-    })
-  | (SimulatePreparedTransactionBaseResult & {
-      error: unknown
-      status: 'failure'
-    })
+  | SimulatePreparedTransactionFailureResult
+  | SimulatePreparedTransactionSuccessResult
+
+export type SimulatePreparedTransactionSuccessResult = SimulatePreparedTransactionBaseResult & {
+  error: null
+  status: 'success'
+}
 
 export interface SimulatePreparedTransactionSolBalanceChange {
   address: Address

--- a/packages/solana-client/src/simulate-prepared-transaction.ts
+++ b/packages/solana-client/src/simulate-prepared-transaction.ts
@@ -23,8 +23,10 @@ export type SimulatePreparedTransactionOptions = PreparedTransactionOptions
 
 export type {
   SimulatePreparedTransactionBaseResult,
+  SimulatePreparedTransactionFailureResult,
   SimulatePreparedTransactionResult,
   SimulatePreparedTransactionSolBalanceChange,
+  SimulatePreparedTransactionSuccessResult,
   SimulatePreparedTransactionTokenBalanceChange,
 } from './simulate-prepared-transaction-types.ts'
 

--- a/packages/solana-client/src/spl-token-create-token-account.ts
+++ b/packages/solana-client/src/spl-token-create-token-account.ts
@@ -6,7 +6,10 @@ export interface SplTokenCreateTokenAccountOptions {
   mint: Address
 }
 
-export async function splTokenCreateTokenAccount(client: SolanaClient, options: SplTokenCreateTokenAccountOptions) {
+export async function splTokenCreateTokenAccount(
+  client: SolanaClient,
+  options: SplTokenCreateTokenAccountOptions,
+): Promise<void> {
   //
   console.log({
     client,

--- a/packages/solana-client/src/unix-timestamp-to-date.ts
+++ b/packages/solana-client/src/unix-timestamp-to-date.ts
@@ -1,6 +1,6 @@
 import type { UnixTimestamp } from '@solana/kit'
 
-export function unixTimestampToDate(time: null | UnixTimestamp) {
+export function unixTimestampToDate(time: null | UnixTimestamp): Date | null {
   if (!time) {
     return null
   }

--- a/packages/solana-client/src/unix-timestamp-to-iso-date-string.ts
+++ b/packages/solana-client/src/unix-timestamp-to-iso-date-string.ts
@@ -1,7 +1,7 @@
 import type { UnixTimestamp } from '@solana/kit'
 import { unixTimestampToDate } from './unix-timestamp-to-date.ts'
 
-export function unixTimestampToIsoDateString(time: null | UnixTimestamp) {
+export function unixTimestampToIsoDateString(time: null | UnixTimestamp): string {
   const timestamp = unixTimestampToDate(time) ?? new Date()
   const year = timestamp.getFullYear()
   const month = (timestamp.getMonth() + 1).toString().padStart(2, '0')


### PR DESCRIPTION
Add named option and result types to exported Solana client helpers.

Derive getTransaction response and instruction types from the RPC return type.

Expose a parsed-instruction assertion helper for consumers that require parsed payloads.

Narrow parsed explorer instruction fields at the UI boundary.

Handle review feedback for parsed instruction type narrowing and current vote-account result naming.

Keep the cleanup free of explicit any and copied Solana internal types.

Part of #416.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated many inline parameter objects into named option types for a more consistent public API.
  * Added explicit return/result types and clearer exported type variants for improved IDE experience and type safety.
  * Introduced a runtime assertion to surface parsing errors earlier when inspecting transaction instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->