### PR TITLE
ci: cache playwright and update surfpool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,11 +150,19 @@ jobs:
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package.json') }}
+          path: ~/.cache/ms-playwright
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright Browsers
         run: bunx playwright install --with-deps
 
       - name: Pull Surfpool
-        run: docker pull surfpool/surfpool:1.0
+        run: docker pull surfpool/surfpool:latest
 
       - name: Run Playwright tests
         run: bun run test:e2e
@@ -177,7 +185,7 @@ jobs:
 
       - name: Start Surfpool
         run: |
-          docker run -d --name surfpool -p 8899:8899 -p 8900:8900 surfpool/surfpool:main start --offline --no-tui
+          docker run -d --name surfpool -e SURFPOOL_NETWORK_HOST=0.0.0.0 -p 8899:8899 -p 8900:8900 surfpool/surfpool:latest start --offline --no-tui
           bunx wait-on tcp:localhost:8899 --verbose --timeout 10000
           bunx wait-on tcp:localhost:8900 --verbose --timeout 10000
 

--- a/bun.lock
+++ b/bun.lock
@@ -713,7 +713,7 @@
     "editorconfig-checker",
   ],
   "catalog": {
-    "@beeman/testcontainers": "1.2.0",
+    "@beeman/testcontainers": "1.2.1",
     "@eslint/js": "9.38.0",
     "@hookform/resolvers": "5.2.2",
     "@playwright/test": "1.57.0",
@@ -857,7 +857,7 @@
 
     "@base-ui/utils": ["@base-ui/utils@0.2.7", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA=="],
 
-    "@beeman/testcontainers": ["@beeman/testcontainers@1.2.0", "", { "peerDependencies": { "@solana/kit": "^6", "@solana/kit-plugins": "^0.3", "testcontainers": "^11", "typescript": "^5 || ^6" } }, "sha512-UY6smhT+mywpOmxVJ4NvATMBzlwmtdYcO1yDn61aL4QrynioPlIZLeCfLtk+/PkmIMl94SYdZ4FhLKxMmqMx3g=="],
+    "@beeman/testcontainers": ["@beeman/testcontainers@1.2.1", "", { "peerDependencies": { "@solana/kit": "^6", "@solana/kit-plugins": "^0.3", "testcontainers": "^11", "typescript": "^5 || ^6" } }, "sha512-8NUvI1UCuMEfbLpTL8rWYHXOo9gL5LPTbHtvxm2AjX9xSqLZPDxIgk+FWHWcqkPxTuRtQkN4VVjGYkxzEEKzBg=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.13", "@biomejs/cli-darwin-x64": "2.4.13", "@biomejs/cli-linux-arm64": "2.4.13", "@biomejs/cli-linux-arm64-musl": "2.4.13", "@biomejs/cli-linux-x64": "2.4.13", "@biomejs/cli-linux-x64-musl": "2.4.13", "@biomejs/cli-win32-arm64": "2.4.13", "@biomejs/cli-win32-x64": "2.4.13" }, "bin": { "biome": "bin/biome" } }, "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "catalog": {
-    "@beeman/testcontainers": "1.2.0",
+    "@beeman/testcontainers": "1.2.1",
     "@eslint/js": "9.38.0",
     "@hookform/resolvers": "5.2.2",
     "@playwright/test": "1.57.0",

--- a/packages/solana-client/src/constants.ts
+++ b/packages/solana-client/src/constants.ts
@@ -4,6 +4,8 @@ export const NATIVE_MINT = address('So11111111111111111111111111111111111111112'
 export const SYSTEM_ACCOUNT = address('11111111111111111111111111111111')
 export const NATIVE_LOADER = address('NativeLoader1111111111111111111111111111111')
 export const BPF_LOADER = address('BPFLoader2111111111111111111111111111111111')
+// cspell:ignore Upgradeab
+export const BPF_LOADER_UPGRADEABLE = address('BPFLoaderUpgradeab1e11111111111111111111111')
 export const TRANSACTION_FEE_LAMPORTS = BigInt(5000)
 
 export { STAKE_PROGRAM_ADDRESS } from '@solana-program/stake'

--- a/packages/solana-client/src/get-account-type.ts
+++ b/packages/solana-client/src/get-account-type.ts
@@ -1,5 +1,5 @@
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from '@workspace/solana-client/constants'
-import { BPF_LOADER, NATIVE_LOADER, SYSTEM_ACCOUNT } from './constants.ts'
+import { BPF_LOADER, BPF_LOADER_UPGRADEABLE, NATIVE_LOADER, SYSTEM_ACCOUNT } from './constants.ts'
 import type { FetchedAccount } from './fetch-account.ts'
 import { type AccountTokenType, getAccountTokenType } from './get-account-token-type.ts'
 
@@ -14,6 +14,7 @@ export function getAccountType({ account }: { account?: FetchedAccount | undefin
     case TOKEN_PROGRAM_ADDRESS:
       return getAccountTokenType({ account })
     case BPF_LOADER:
+    case BPF_LOADER_UPGRADEABLE:
       return 'system-program'
     case SYSTEM_ACCOUNT:
     case NATIVE_LOADER:

--- a/packages/solana-client/test/create-and-send-transaction-sol.integration.test.ts
+++ b/packages/solana-client/test/create-and-send-transaction-sol.integration.test.ts
@@ -5,6 +5,7 @@ import {
   createAndSendTransactionSol,
 } from '../src/create-and-send-transaction-sol.ts'
 import { getBalance } from '../src/get-balance.ts'
+import { solToLamports } from '../src/sol-to-lamports.ts'
 import { setupIntegrationTestContext } from './test-helpers.ts'
 
 describe('create-and-send-transaction-sol', async () => {
@@ -16,12 +17,13 @@ describe('create-and-send-transaction-sol', async () => {
       expect.assertions(2)
       const destinationKeypair = await generateKeyPairSigner()
       const destination = destinationKeypair.address
+      const amount = solToLamports('0.01')
       const senderBalance = await getBalance(client, { address: transactionSigner.address }).then((res) => res.value)
       const input: CreateAndSendTransactionSolOptions = {
         latestBlockhash,
         recipients: [
           {
-            amount: 100n,
+            amount,
             destination,
           },
         ],
@@ -45,16 +47,18 @@ describe('create-and-send-transaction-sol', async () => {
       const destinationAlice = destinationAliceKeypair.address
       const destinationBobKeypair = await generateKeyPairSigner()
       const destinationBob = destinationBobKeypair.address
+      const amountAlice = solToLamports('0.01')
+      const amountBob = solToLamports('0.02')
       const senderBalance = await getBalance(client, { address: transactionSigner.address }).then((res) => res.value)
       const input: CreateAndSendTransactionSolOptions = {
         latestBlockhash,
         recipients: [
           {
-            amount: 100n,
+            amount: amountAlice,
             destination: destinationAlice,
           },
           {
-            amount: 42n,
+            amount: amountBob,
             destination: destinationBob,
           },
         ],

--- a/packages/solana-client/test/simulate-prepared-transaction.integration.test.ts
+++ b/packages/solana-client/test/simulate-prepared-transaction.integration.test.ts
@@ -27,7 +27,7 @@ describe('simulate-prepared-transaction', () => {
       expect.assertions(5)
       const { client, latestBlockhash, transactionSigner } = context
       const destination = (await generateKeyPairSigner()).address
-      const amount = 100n
+      const amount = solToLamports('0.01')
       const senderBalance = await getBalance(client, { address: transactionSigner.address }).then((res) => res.value)
       const preparedTransaction = prepareTransactionSol({
         recipients: [{ amount, destination }],


### PR DESCRIPTION
Summary: cache Playwright browsers in CI; bump @beeman/testcontainers to 1.2.1; run surfpool/surfpool:latest with SURFPOOL_NETWORK_HOST=0.0.0.0; adjust integration coverage for latest Surfpool rent checks and upgradeable loader program accounts. Verification: bun run test:integration; bun lint; bun check-types.