### PR TITLE
fix(background): assert sendable transaction before send

### DIFF
--- a/packages/background/src/services/sign.ts
+++ b/packages/background/src/services/sign.ts
@@ -1,4 +1,5 @@
 import {
+  assertIsSendableTransaction,
   createKeyPairFromBytes,
   createSolanaRpc,
   getBase58Encoder,
@@ -53,8 +54,8 @@ function createSignService() {
       for (const input of inputs) {
         const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
         const transaction = await signTransaction([key], decoded)
+        assertIsSendableTransaction(transaction)
         const sendTransaction = sendTransactionWithoutConfirmingFactory({ rpc })
-        // @ts-expect-error TODO: Figure out "Type 'FullySignedTransaction & Readonly<{ messageBytes: TransactionMessageBytes; signatures: SignaturesMap; }> & TransactionWithLifetime' is missing the following properties from type 'Readonly<{ instructions: readonly Instruction<string, readonly (AccountLookupMeta<string, string> | AccountMeta<string>)[]>[]; version: TransactionVersion; }>': instructions, version"
         await sendTransaction(transaction, { commitment: 'confirmed' })
 
         results.push({


### PR DESCRIPTION
Replace the Kit transaction send type suppression with

assertIsSendableTransaction before calling

sendTransactionWithoutConfirmingFactory.

Closes #458
