### PR TITLE
fix(commitlint): disable header max length

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -2,6 +2,9 @@ import type { UserConfig } from '@commitlint/types'
 
 const Configuration: UserConfig = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [0],
+  },
 }
 
 export default Configuration


### PR DESCRIPTION
Disable only the commit header max-length rule in commitlint.

Keep body line-length validation enabled to preserve commit message body constraints.
