### PR TITLE
refactor(background): centralize active key pair retrieval

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -170,7 +170,9 @@
       "devDependencies": {
         "@types/bun": "catalog:",
         "@workspace/config-typescript": "workspace:*",
+        "@workspace/config-vitest": "workspace:*",
         "typescript": "catalog:",
+        "vitest": "catalog:",
       },
     },
     "packages/config-typescript": {

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -16,7 +16,9 @@
   "devDependencies": {
     "@types/bun": "catalog:",
     "@workspace/config-typescript": "workspace:*",
-    "typescript": "catalog:"
+    "@workspace/config-vitest": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "exports": {
     ".": "./src/index.ts",
@@ -26,7 +28,9 @@
   "name": "@workspace/background",
   "private": false,
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
   },
   "type": "module",
   "version": "0.0.0"

--- a/packages/background/src/services/db.ts
+++ b/packages/background/src/services/db.ts
@@ -1,4 +1,4 @@
-import { address, getAddressEncoder } from '@solana/kit'
+import { address, createKeyPairFromBytes, getAddressEncoder } from '@solana/kit'
 import { SOLANA_CHAINS } from '@solana/wallet-standard-chains'
 import {
   SolanaSignAndSendTransaction,
@@ -36,6 +36,11 @@ function createDbService() {
         }
 
         return account
+      },
+      keyPair: async (): Promise<CryptoKeyPair> => {
+        const secretKey = await getDbService().account.secretKey()
+
+        return await createKeyPairFromBytes(new Uint8Array(JSON.parse(secretKey)))
       },
       secretKey: async (): Promise<string> => {
         const accountId = (await settingFindUnique(db, 'activeAccountId'))?.value

--- a/packages/background/src/services/sign.ts
+++ b/packages/background/src/services/sign.ts
@@ -1,6 +1,5 @@
 import {
   assertIsSendableTransaction,
-  createKeyPairFromBytes,
   createSolanaRpc,
   getBase58Encoder,
   getSignatureFromTransaction,
@@ -43,13 +42,7 @@ function createSignService() {
       inputs: SolanaSignAndSendTransactionInput[],
     ): Promise<SolanaSignAndSendTransactionOutput[]> => {
       const results: SolanaSignAndSendTransactionOutput[] = []
-      const activeSecretKey = await getDbService().account.secretKey()
-      if (!activeSecretKey) {
-        throw new Error('Active account has no secret key')
-      }
-
-      const bytes = new Uint8Array(JSON.parse(activeSecretKey))
-      const key = await createKeyPairFromBytes(bytes)
+      const key = await getDbService().account.keyPair()
 
       for (const input of inputs) {
         const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
@@ -68,18 +61,13 @@ function createSignService() {
     signIn: async (inputs: SolanaSignInInput[]): Promise<SolanaSignInOutput[]> => {
       const results: SolanaSignInOutput[] = []
       const active = await getDbService().account.active()
-      const activeSecretKey = await getDbService().account.secretKey()
       const accounts = await getDbService().account.walletAccounts()
-      if (!activeSecretKey) {
-        throw new Error('Active account has no secret key')
-      }
 
       if (accounts.accounts[0] === undefined) {
         throw new Error('No wallet account found')
       }
 
-      const bytes = new Uint8Array(JSON.parse(activeSecretKey))
-      const { privateKey } = await createKeyPairFromBytes(bytes)
+      const { privateKey } = await getDbService().account.keyPair()
 
       for (const input of inputs) {
         const signedMessage = createSignInMessage({
@@ -101,13 +89,7 @@ function createSignService() {
     },
     signMessage: async (inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> => {
       const results: SolanaSignMessageOutput[] = []
-      const activeSecretKey = await getDbService().account.secretKey()
-      if (!activeSecretKey) {
-        throw new Error('Active account has no secret key')
-      }
-
-      const bytes = new Uint8Array(JSON.parse(activeSecretKey))
-      const { privateKey } = await createKeyPairFromBytes(bytes)
+      const { privateKey } = await getDbService().account.keyPair()
 
       for (const input of inputs) {
         const signedMessage = decodeTransportBytes(input.message)
@@ -124,13 +106,7 @@ function createSignService() {
     },
     signTransaction: async (inputs: SolanaSignTransactionInput[]): Promise<SolanaSignTransactionOutput[]> => {
       const results: SolanaSignTransactionOutput[] = []
-      const activeSecretKey = await getDbService().account.secretKey()
-      if (!activeSecretKey) {
-        throw new Error('Active account has no secret key')
-      }
-
-      const bytes = new Uint8Array(JSON.parse(activeSecretKey))
-      const key = await createKeyPairFromBytes(bytes)
+      const key = await getDbService().account.keyPair()
 
       for (const input of inputs) {
         const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))

--- a/packages/background/test/db-service.test.ts
+++ b/packages/background/test/db-service.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registerDbService } from '../src/services/db.ts'
+
+const mocks = vi.hoisted(() => ({
+  accountCreate: vi.fn(),
+  accountFindUnique: vi.fn(),
+  accountReadSecretKey: vi.fn(),
+  address: vi.fn(),
+  createKeyPairFromBytes: vi.fn(),
+  createProxyService: vi.fn(),
+  db: { id: 'db' },
+  deriveFromMnemonicAtIndex: vi.fn(),
+  ellipsify: vi.fn(),
+  getAddressEncoder: vi.fn(),
+  registerService: vi.fn(),
+  settingFindUnique: vi.fn(),
+  walletCreate: vi.fn(),
+}))
+
+vi.mock('@solana/kit', () => ({
+  address: mocks.address,
+  createKeyPairFromBytes: mocks.createKeyPairFromBytes,
+  getAddressEncoder: mocks.getAddressEncoder,
+}))
+
+vi.mock('@solana/wallet-standard-chains', () => ({
+  SOLANA_CHAINS: [],
+}))
+
+vi.mock('@solana/wallet-standard-features', () => ({
+  SolanaSignAndSendTransaction: 'solana:signAndSendTransaction',
+  SolanaSignIn: 'solana:signIn',
+  SolanaSignMessage: 'solana:signMessage',
+  SolanaSignTransaction: 'solana:signTransaction',
+}))
+
+vi.mock('@webext-core/proxy-service', () => ({
+  createProxyService: mocks.createProxyService,
+  registerService: mocks.registerService,
+}))
+
+vi.mock('@workspace/db/account/account-create', () => ({
+  accountCreate: mocks.accountCreate,
+}))
+
+vi.mock('@workspace/db/account/account-find-unique', () => ({
+  accountFindUnique: mocks.accountFindUnique,
+}))
+
+vi.mock('@workspace/db/account/account-read-secret-key', () => ({
+  accountReadSecretKey: mocks.accountReadSecretKey,
+}))
+
+vi.mock('@workspace/db/db', () => ({
+  db: mocks.db,
+}))
+
+vi.mock('@workspace/db/setting/setting-find-unique', () => ({
+  settingFindUnique: mocks.settingFindUnique,
+}))
+
+vi.mock('@workspace/db/wallet/wallet-create', () => ({
+  walletCreate: mocks.walletCreate,
+}))
+
+vi.mock('@workspace/keypair/derive-from-mnemonic-at-index', () => ({
+  deriveFromMnemonicAtIndex: mocks.deriveFromMnemonicAtIndex,
+}))
+
+vi.mock('@workspace/ui/lib/ellipsify', () => ({
+  ellipsify: mocks.ellipsify,
+}))
+
+const accountId = 'active-account-id'
+const keyPair = {
+  privateKey: { id: 'private-key' } as unknown as CryptoKey,
+  publicKey: { id: 'public-key' } as unknown as CryptoKey,
+}
+const secretKey = JSON.stringify([1, 2, 3, 4])
+const secretKeyBytes = new Uint8Array([1, 2, 3, 4])
+
+describe('db-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.accountReadSecretKey.mockResolvedValue(secretKey)
+    mocks.createKeyPairFromBytes.mockResolvedValue(keyPair)
+    mocks.settingFindUnique.mockResolvedValue({ value: accountId })
+  })
+
+  describe('expected behavior', () => {
+    it('should create the active account key pair from the active secret key', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const service = registerDbService()
+
+      // ACT
+      const result = await service.account.keyPair()
+
+      // ASSERT
+      expect(mocks.accountReadSecretKey).toHaveBeenCalledWith(mocks.db, accountId)
+      expect(mocks.createKeyPairFromBytes).toHaveBeenCalledWith(secretKeyBytes)
+      expect(mocks.settingFindUnique).toHaveBeenCalledWith(mocks.db, 'activeAccountId')
+      expect(result).toBe(keyPair)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should throw an error when the active secret key is not found', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      mocks.accountReadSecretKey.mockResolvedValue(undefined)
+      const service = registerDbService()
+
+      // ACT & ASSERT
+      await expect(service.account.keyPair()).rejects.toThrow('Active account secretKey not found')
+      expect(mocks.createKeyPairFromBytes).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/background/test/sign-service.test.ts
+++ b/packages/background/test/sign-service.test.ts
@@ -1,0 +1,209 @@
+import type {
+  SolanaSignAndSendTransactionInput,
+  SolanaSignInInput,
+  SolanaSignMessageInput,
+  SolanaSignTransactionInput,
+} from '@solana/wallet-standard-features'
+import type { StandardConnectOutput } from '@wallet-standard/core'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registerSignService } from '../src/services/sign.ts'
+
+const mocks = vi.hoisted(() => ({
+  accountActive: vi.fn(),
+  accountKeyPair: vi.fn(),
+  accountWalletAccounts: vi.fn(),
+  assertIsSendableTransaction: vi.fn(),
+  base58Encode: vi.fn(),
+  createProxyService: vi.fn(),
+  createSignInMessage: vi.fn(),
+  createSolanaRpc: vi.fn(() => ({ url: 'https://api.devnet.solana.com' })),
+  getBase58Encoder: vi.fn(),
+  getDbService: vi.fn(),
+  getSignatureFromTransaction: vi.fn(),
+  getTransactionDecoder: vi.fn(),
+  getTransactionEncoder: vi.fn(),
+  registerService: vi.fn(),
+  sendTransaction: vi.fn(),
+  sendTransactionWithoutConfirmingFactory: vi.fn(),
+  signBytes: vi.fn(),
+  signTransaction: vi.fn(),
+  transactionDecode: vi.fn(),
+  transactionEncode: vi.fn(),
+}))
+
+vi.mock('@solana/kit', () => ({
+  assertIsSendableTransaction: mocks.assertIsSendableTransaction,
+  createSolanaRpc: mocks.createSolanaRpc,
+  getBase58Encoder: mocks.getBase58Encoder,
+  getSignatureFromTransaction: mocks.getSignatureFromTransaction,
+  getTransactionDecoder: mocks.getTransactionDecoder,
+  getTransactionEncoder: mocks.getTransactionEncoder,
+  sendTransactionWithoutConfirmingFactory: mocks.sendTransactionWithoutConfirmingFactory,
+  signBytes: mocks.signBytes,
+  signTransaction: mocks.signTransaction,
+}))
+
+vi.mock('@solana/wallet-standard-util', () => ({
+  createSignInMessage: mocks.createSignInMessage,
+}))
+
+vi.mock('@webext-core/proxy-service', () => ({
+  createProxyService: mocks.createProxyService,
+  registerService: mocks.registerService,
+}))
+
+vi.mock('../src/services/db.ts', () => ({
+  getDbService: mocks.getDbService,
+}))
+
+const activeAccount = { publicKey: 'active-public-key' }
+const decodedTransaction = { id: 'decoded-transaction' }
+const encodedTransactionBytes = new Uint8Array([14, 15])
+const privateKey = { id: 'private-key' } as unknown as CryptoKey
+const signature = new Uint8Array([10, 11])
+const signatureBytes = new Uint8Array([12, 13])
+const signatureValue = 'transaction-signature'
+const signedMessage = new Uint8Array([8, 9])
+const signedTransaction = { id: 'signed-transaction' }
+const transactionBytes = new Uint8Array([5, 6])
+const keyPair = { privateKey } as CryptoKeyPair
+const walletAccount = {
+  address: activeAccount.publicKey,
+  chains: [],
+  features: [],
+  publicKey: new Uint8Array([7]),
+}
+const walletAccounts = { accounts: [walletAccount] } as unknown as StandardConnectOutput
+
+describe('sign-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.accountActive.mockResolvedValue(activeAccount)
+    mocks.accountKeyPair.mockResolvedValue(keyPair)
+    mocks.accountWalletAccounts.mockResolvedValue(walletAccounts)
+    mocks.base58Encode.mockReturnValue(signatureBytes)
+    mocks.createSignInMessage.mockReturnValue(signedMessage)
+    mocks.getBase58Encoder.mockReturnValue({ encode: mocks.base58Encode })
+    mocks.getDbService.mockReturnValue({
+      account: {
+        active: mocks.accountActive,
+        keyPair: mocks.accountKeyPair,
+        walletAccounts: mocks.accountWalletAccounts,
+      },
+    })
+    mocks.getSignatureFromTransaction.mockReturnValue(signatureValue)
+    mocks.getTransactionDecoder.mockReturnValue({ decode: mocks.transactionDecode })
+    mocks.getTransactionEncoder.mockReturnValue({ encode: mocks.transactionEncode })
+    mocks.sendTransaction.mockResolvedValue(undefined)
+    mocks.sendTransactionWithoutConfirmingFactory.mockReturnValue(mocks.sendTransaction)
+    mocks.signBytes.mockResolvedValue(signature)
+    mocks.signTransaction.mockResolvedValue(signedTransaction)
+    mocks.transactionDecode.mockReturnValue(decodedTransaction)
+    mocks.transactionEncode.mockReturnValue(encodedTransactionBytes)
+  })
+
+  describe('expected behavior', () => {
+    it('should sign and send a transaction with the active secret key', async () => {
+      // ARRANGE
+      expect.assertions(6)
+      const service = registerSignService()
+      const input = { transaction: transactionBytes } as SolanaSignAndSendTransactionInput
+
+      // ACT
+      const result = await service.signAndSendTransaction([input])
+
+      // ASSERT
+      expect(mocks.accountKeyPair).toHaveBeenCalledTimes(1)
+      expect(mocks.assertIsSendableTransaction).toHaveBeenCalledWith(signedTransaction)
+      expect(mocks.base58Encode).toHaveBeenCalledWith(signatureValue)
+      expect(mocks.sendTransaction).toHaveBeenCalledWith(signedTransaction, { commitment: 'confirmed' })
+      expect(mocks.signTransaction).toHaveBeenCalledWith([keyPair], decodedTransaction)
+      expect(result).toEqual([{ signature: signatureBytes }])
+    })
+
+    it('should sign in with the active secret key', async () => {
+      // ARRANGE
+      expect.assertions(5)
+      const service = registerSignService()
+      const input = {} as SolanaSignInInput
+
+      // ACT
+      const result = await service.signIn([input])
+
+      // ASSERT
+      expect(mocks.accountActive).toHaveBeenCalledTimes(1)
+      expect(mocks.accountKeyPair).toHaveBeenCalledTimes(1)
+      expect(mocks.createSignInMessage).toHaveBeenCalledWith({
+        address: activeAccount.publicKey,
+        domain: 'localhost',
+      })
+      expect(mocks.signBytes).toHaveBeenCalledWith(privateKey, signedMessage)
+      expect(result).toEqual([
+        {
+          account: walletAccount,
+          signature,
+          signatureType: 'ed25519',
+          signedMessage,
+        },
+      ])
+    })
+
+    it('should sign a message with the active secret key', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const service = registerSignService()
+      const input = { message: transactionBytes } as SolanaSignMessageInput
+
+      // ACT
+      const result = await service.signMessage([input])
+
+      // ASSERT
+      expect(mocks.accountKeyPair).toHaveBeenCalledTimes(1)
+      expect(mocks.signBytes).toHaveBeenCalledWith(privateKey, transactionBytes)
+      expect(result).toEqual([{ signature, signatureType: 'ed25519', signedMessage: transactionBytes }])
+    })
+
+    it('should sign a transaction with the active secret key', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const service = registerSignService()
+      const input = { transaction: transactionBytes } as SolanaSignTransactionInput
+
+      // ACT
+      const result = await service.signTransaction([input])
+
+      // ASSERT
+      expect(mocks.accountKeyPair).toHaveBeenCalledTimes(1)
+      expect(mocks.signTransaction).toHaveBeenCalledWith([keyPair], decodedTransaction)
+      expect(mocks.transactionEncode).toHaveBeenCalledWith(signedTransaction)
+      expect(result).toEqual([{ signedTransaction: encodedTransactionBytes }])
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should throw an error when the active account key pair is not available', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      mocks.accountKeyPair.mockRejectedValue(new Error('Active account secretKey not found'))
+      const service = registerSignService()
+      const input = { message: transactionBytes } as SolanaSignMessageInput
+
+      // ACT & ASSERT
+      await expect(service.signMessage([input])).rejects.toThrow('Active account secretKey not found')
+      expect(mocks.signBytes).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/background/vitest.config.ts
+++ b/packages/background/vitest.config.ts
@@ -1,0 +1,4 @@
+import { sharedConfig } from '@workspace/config-vitest'
+import { defineProject, mergeConfig } from 'vitest/config'
+
+export default mergeConfig(sharedConfig, defineProject({}))


### PR DESCRIPTION
Add an account.keyPair() DB service helper that converts the active secret key into a CryptoKeyPair.

Update signing methods to use the helper and add background service tests for key pair creation and signing behavior.

Closes #615


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for signing and key management operations.
  * Integrated Vitest testing framework with test runner configuration.

* **New Features**
  * Added improved account key pair derivation and management.

* **Refactor**
  * Streamlined internal key management architecture for cryptographic signing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->