### PR TITLE
fix(db): sanitize sensitive table reads by default

### DIFF
--- a/packages/db/src/account/account-find-many.ts
+++ b/packages/db/src/account/account-find-many.ts
@@ -3,7 +3,6 @@ import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
 import type { AccountFindManyInput } from './account-find-many-input.ts'
 import { accountFindManySchema } from './account-find-many-schema.ts'
-import { accountSanitizer } from './account-sanitizer.ts'
 
 export async function accountFindMany(db: Database, input: AccountFindManyInput = {}): Promise<Account[]> {
   const parsedInput = accountFindManySchema.parse(input)
@@ -26,6 +25,6 @@ export async function accountFindMany(db: Database, input: AccountFindManyInput 
       console.log(error)
       throw new Error(`Error finding accounts for wallet id ${parsedInput.walletId}`)
     }
-    return data?.map((item) => accountSanitizer(item))
+    return data
   })
 }

--- a/packages/db/src/account/account-find-unique.ts
+++ b/packages/db/src/account/account-find-unique.ts
@@ -1,7 +1,6 @@
 import { tryCatch } from '@workspace/core/try-catch'
 import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
-import { accountSanitizer } from './account-sanitizer.ts'
 
 export async function accountFindUnique(db: Database, id: string): Promise<null | Account> {
   return db.transaction('r', db.accounts, async () => {
@@ -10,6 +9,6 @@ export async function accountFindUnique(db: Database, id: string): Promise<null 
       console.log(error)
       throw new Error(`Error finding account with id ${id}`)
     }
-    return data ? accountSanitizer(data) : null
+    return data ?? null
   })
 }

--- a/packages/db/src/account/account-read-secret-key.ts
+++ b/packages/db/src/account/account-read-secret-key.ts
@@ -3,7 +3,7 @@ import type { Database } from '../database.ts'
 
 export function accountReadSecretKey(db: Database, id: string) {
   return db.transaction('r', db.accounts, async () => {
-    const { data: account, error } = await tryCatch(db.accounts.get(id))
+    const { data: account, error } = await tryCatch(db.accounts.where('id').equals(id).raw().first())
     if (error) {
       console.log(error)
       throw new Error(`Error finding account with id ${id}`)

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -1,11 +1,13 @@
 import { Dexie, type Table } from 'dexie'
 import type { AccountInternal } from './account/account-internal.ts'
+import { accountSanitizer } from './account/account-sanitizer.ts'
 import type { BookmarkAccount } from './bookmark-account/bookmark-account.ts'
 import type { BookmarkTransaction } from './bookmark-transaction/bookmark-transaction.ts'
 import type { Network } from './network/network.ts'
 import { populate } from './populate.ts'
 import type { Setting } from './setting/setting.ts'
 import type { WalletInternal } from './wallet/wallet-internal.ts'
+import { walletSanitizer } from './wallet/wallet-sanitizer.ts'
 
 export interface DatabaseConfig {
   name: string
@@ -30,8 +32,19 @@ export class Database extends Dexie {
       wallets: 'id, name, order',
     })
 
+    this.accounts.hook('reading', accountReadingHook)
+    this.wallets.hook('reading', walletReadingHook)
+
     this.on('populate', async () => {
       await populate(this)
     })
   }
+}
+
+function accountReadingHook(account: AccountInternal | undefined) {
+  return account ? accountSanitizer(account) : account
+}
+
+function walletReadingHook(wallet: WalletInternal | undefined) {
+  return wallet ? walletSanitizer(wallet) : wallet
 }

--- a/packages/db/src/wallet/wallet-find-many.ts
+++ b/packages/db/src/wallet/wallet-find-many.ts
@@ -1,12 +1,10 @@
 import { tryCatch } from '@workspace/core/try-catch'
 
-import { accountSanitizer } from '../account/account-sanitizer.ts'
 import type { Database } from '../database.ts'
 import type { Wallet } from './wallet.ts'
 import type { WalletFindManyInput } from './wallet-find-many-input.ts'
 
 import { walletFindManySchema } from './wallet-find-many-schema.ts'
-import { walletSanitizer } from './wallet-sanitizer.ts'
 
 export async function walletFindMany(db: Database, input: WalletFindManyInput = {}): Promise<Wallet[]> {
   const parsedInput = walletFindManySchema.parse(input)
@@ -38,10 +36,8 @@ export async function walletFindMany(db: Database, input: WalletFindManyInput = 
     return [
       ...dataWallets.map((wallet) => {
         return {
-          ...walletSanitizer(wallet),
-          accounts: dataAccounts
-            .filter((account) => account.walletId === wallet.id)
-            .map((account) => accountSanitizer(account)),
+          ...wallet,
+          accounts: dataAccounts.filter((account) => account.walletId === wallet.id),
         }
       }),
     ]

--- a/packages/db/src/wallet/wallet-find-unique.ts
+++ b/packages/db/src/wallet/wallet-find-unique.ts
@@ -2,7 +2,6 @@ import { tryCatch } from '@workspace/core/try-catch'
 
 import type { Database } from '../database.ts'
 import type { Wallet } from './wallet.ts'
-import { walletSanitizer } from './wallet-sanitizer.ts'
 
 export async function walletFindUnique(db: Database, id: string): Promise<Wallet | null> {
   return db.transaction('r', db.wallets, async () => {
@@ -11,6 +10,6 @@ export async function walletFindUnique(db: Database, id: string): Promise<Wallet
       console.log(error)
       throw new Error(`Error finding wallet with id ${id}`)
     }
-    return data ? walletSanitizer(data) : null
+    return data ?? null
   })
 }

--- a/packages/db/src/wallet/wallet-read-mnemonic.ts
+++ b/packages/db/src/wallet/wallet-read-mnemonic.ts
@@ -3,7 +3,7 @@ import type { Database } from '../database.ts'
 
 export function walletReadMnemonic(db: Database, id: string) {
   return db.transaction('r', db.wallets, async () => {
-    const { data: wallet, error } = await tryCatch(db.wallets.get(id))
+    const { data: wallet, error } = await tryCatch(db.wallets.where('id').equals(id).raw().first())
     if (error) {
       console.log(error)
       throw new Error(`Error finding wallet with id ${id}`)

--- a/packages/db/test/account-read-secret-key.test.ts
+++ b/packages/db/test/account-read-secret-key.test.ts
@@ -1,7 +1,7 @@
 import type { PromiseExtended } from 'dexie'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Account } from '../src/account/account.ts'
 import { accountCreate } from '../src/account/account-create.ts'
+import type { AccountInternal } from '../src/account/account-internal.ts'
 import { accountReadSecretKey } from '../src/account/account-read-secret-key.ts'
 import { walletCreate } from '../src/wallet/wallet-create.ts'
 import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
@@ -51,6 +51,7 @@ describe('account-read-secret-key', () => {
 
     it('should throw an error if the account is of type Watched', async () => {
       // ARRANGE
+      expect.assertions(1)
       const walletInput = testWalletCreateInput()
       const walletId = await walletCreate(db, walletInput)
       const accountInput = testAccountCreateInput({ type: 'Watched', walletId })
@@ -64,8 +65,15 @@ describe('account-read-secret-key', () => {
       // ARRANGE
       expect.assertions(1)
       const id = 'test-id'
-      vi.spyOn(db.accounts, 'get').mockImplementationOnce(
-        () => Promise.reject(new Error('Test error')) as PromiseExtended<Account | undefined>,
+      vi.spyOn(db.accounts, 'where').mockImplementationOnce(
+        () =>
+          ({
+            equals: () => ({
+              raw: () => ({
+                first: () => Promise.reject(new Error('Test error')) as PromiseExtended<AccountInternal | undefined>,
+              }),
+            }),
+          }) as never,
       )
 
       // ACT & ASSERT

--- a/packages/db/test/database-reading-hook.test.ts
+++ b/packages/db/test/database-reading-hook.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { accountCreate } from '../src/account/account-create.ts'
+import type { AccountInternal } from '../src/account/account-internal.ts'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import type { WalletInternal } from '../src/wallet/wallet-internal.ts'
+import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('database-reading-hook', () => {
+  beforeEach(async () => {
+    await db.accounts.clear()
+    await db.settings.clear()
+    await db.wallets.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should read account secret keys from raw account queries', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletId = await walletCreate(db, testWalletCreateInput())
+      const input = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const id = await accountCreate(db, input)
+
+      // ACT
+      const result = (await db.accounts.where('id').equals(id).raw().first()) as AccountInternal | undefined
+
+      // ASSERT
+      expect(result?.secretKey).toBe(input.secretKey)
+    })
+
+    it('should read wallet mnemonics from raw wallet queries', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput({ mnemonic: 'test mnemonic' })
+      const id = await walletCreate(db, input)
+
+      // ACT
+      const result = (await db.wallets.where('id').equals(id).raw().first()) as WalletInternal | undefined
+
+      // ASSERT
+      expect(result?.mnemonic).toBe(input.mnemonic)
+    })
+
+    it('should sanitize account secret keys from default reads', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const walletId = await walletCreate(db, testWalletCreateInput())
+      const input = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const id = await accountCreate(db, input)
+
+      // ACT
+      const result = await db.accounts.get(id)
+
+      // ASSERT
+      expect(result).toBeDefined()
+      expect(result).not.toHaveProperty('secretKey')
+    })
+
+    it('should sanitize wallet mnemonics from default reads', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const input = testWalletCreateInput({ mnemonic: 'test mnemonic' })
+      const id = await walletCreate(db, input)
+
+      // ACT
+      const result = await db.wallets.get(id)
+
+      // ASSERT
+      expect(result).toBeDefined()
+      expect(result).not.toHaveProperty('mnemonic')
+    })
+
+    it('should sanitize wallet and account secrets from collection reads', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const walletId = await walletCreate(db, testWalletCreateInput({ mnemonic: 'test mnemonic' }))
+      await walletCreate(db, testWalletCreateInput({ mnemonic: 'other mnemonic' }))
+      await accountCreate(db, testAccountCreateInput({ secretKey: 'test-secret-key-1', walletId }))
+      await accountCreate(db, testAccountCreateInput({ secretKey: 'test-secret-key-2', walletId }))
+
+      // ACT
+      const dataWallets = await db.wallets
+        .orderBy('order')
+        .filter((wallet) => wallet.id === walletId)
+        .toArray()
+      const dataAccounts = await db.accounts
+        .orderBy('order')
+        .filter((account) => account.walletId === walletId)
+        .toArray()
+      const result = dataWallets.map((wallet) => ({
+        ...wallet,
+        accounts: dataAccounts.filter((account) => account.walletId === wallet.id),
+      }))
+
+      // ASSERT
+      expect(result).toHaveLength(1)
+      expect(result[0]).not.toHaveProperty('mnemonic')
+      expect(result[0]?.accounts).toHaveLength(2)
+      expect(result[0]?.accounts.every((account) => !('secretKey' in account))).toBe(true)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return undefined when reading a missing account', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = 'missing-account-id'
+
+      // ACT
+      const result = await db.accounts.get(id)
+
+      // ASSERT
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when reading a missing wallet', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = 'missing-wallet-id'
+
+      // ACT
+      const result = await db.wallets.get(id)
+
+      // ASSERT
+      expect(result).toBeUndefined()
+    })
+  })
+})

--- a/packages/db/test/wallet-read-mnemonic.test.ts
+++ b/packages/db/test/wallet-read-mnemonic.test.ts
@@ -1,7 +1,7 @@
 import type { PromiseExtended } from 'dexie'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Wallet } from '../src/wallet/wallet.ts'
 import { walletCreate } from '../src/wallet/wallet-create.ts'
+import type { WalletInternal } from '../src/wallet/wallet-internal.ts'
 import { walletReadMnemonic } from '../src/wallet/wallet-read-mnemonic.ts'
 import { createDbTest, testWalletCreateInput } from './test-helpers.ts'
 
@@ -49,8 +49,15 @@ describe('wallet-read-mnemonic', () => {
       // ARRANGE
       expect.assertions(1)
       const id = 'test-id'
-      vi.spyOn(db.wallets, 'get').mockImplementationOnce(
-        () => Promise.reject(new Error('Test error')) as PromiseExtended<Wallet | undefined>,
+      vi.spyOn(db.wallets, 'where').mockImplementationOnce(
+        () =>
+          ({
+            equals: () => ({
+              raw: () => ({
+                first: () => Promise.reject(new Error('Test error')) as PromiseExtended<WalletInternal | undefined>,
+              }),
+            }),
+          }) as never,
       )
 
       // ACT & ASSERT


### PR DESCRIPTION
Add Dexie reading hooks for account and wallet tables so default reads strip sensitive fields.

Use raw table queries for internal secret key and mnemonic readers that need access to stored sensitive values.

Remove redundant manual sanitizer calls from account and wallet finder queries now that default reads are sanitized by Dexie.

Closes #616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal database read behavior for accounts and wallets to streamline data handling and sanitization.

* **Bug Fixes**
  * Consistent retrieval of secret fields via query paths to fix inconsistent read outcomes.

* **Tests**
  * Added and updated tests covering reading hooks, secret-field handling, and query-path error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->