### PR TITLE
refactor(core): add tryCatchOrThrow helper

### DIFF
--- a/packages/core/src/try-catch-or-throw.ts
+++ b/packages/core/src/try-catch-or-throw.ts
@@ -1,0 +1,10 @@
+import { tryCatch } from './try-catch.ts'
+
+export async function tryCatchOrThrow<T>(promise: Promise<T>, message: string): Promise<T> {
+  const { data, error } = await tryCatch(promise)
+  if (error) {
+    console.error(error)
+    throw new Error(message)
+  }
+  return data
+}

--- a/packages/db/src/account/account-create-determine-order.ts
+++ b/packages/db/src/account/account-create-determine-order.ts
@@ -1,20 +1,16 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 
 export async function accountCreateDetermineOrder(db: Database, walletId: string): Promise<number> {
   return db.transaction('r', db.accounts, async () => {
-    const { data, error } = await tryCatch(
+    const data = await tryCatchOrThrow(
       db.accounts
         .orderBy('order')
         .and((x) => x.walletId === walletId)
         .last(),
+      `Error finding last account`,
     )
-
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding last account`)
-    }
 
     if (!data) {
       return 0

--- a/packages/db/src/account/account-create.ts
+++ b/packages/db/src/account/account-create.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { randomId } from '../random-id.ts'
@@ -14,7 +14,7 @@ export async function accountCreate(db: Database, input: AccountCreateInput): Pr
 
   return db.transaction('rw', db.accounts, db.settings, db.wallets, async () => {
     const order = await accountCreateDetermineOrder(db, parsedInput.walletId)
-    const { data, error } = await tryCatch(
+    const data = await tryCatchOrThrow(
       db.accounts.add({
         ...parsedInput,
         createdAt: now,
@@ -24,11 +24,8 @@ export async function accountCreate(db: Database, input: AccountCreateInput): Pr
         secretKey: parsedInput.secretKey,
         updatedAt: now,
       }),
+      `Error creating account`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error creating account`)
-    }
 
     const activeAccountId = (await settingFindUnique(db, 'activeAccountId'))?.value
     if (!activeAccountId) {

--- a/packages/db/src/account/account-delete.ts
+++ b/packages/db/src/account/account-delete.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { settingFindUnique } from '../setting/setting-find-unique.ts'
@@ -10,11 +10,6 @@ export async function accountDelete(db: Database, id: string): Promise<void> {
       throw new Error('You cannot delete the active account. Please change accounts and try again.')
     }
 
-    const { data, error } = await tryCatch(db.accounts.delete(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error deleting account with id ${id}`)
-    }
-    return data
+    return tryCatchOrThrow(db.accounts.delete(id), `Error deleting account with id ${id}`)
   })
 }

--- a/packages/db/src/account/account-find-many.ts
+++ b/packages/db/src/account/account-find-many.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
 import type { AccountFindManyInput } from './account-find-many-input.ts'
@@ -7,7 +7,7 @@ import { accountFindManySchema } from './account-find-many-schema.ts'
 export async function accountFindMany(db: Database, input: AccountFindManyInput = {}): Promise<Account[]> {
   const parsedInput = accountFindManySchema.parse(input)
   return db.transaction('r', db.accounts, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.accounts
         .orderBy('order')
         .filter((item) => {
@@ -20,11 +20,7 @@ export async function accountFindMany(db: Database, input: AccountFindManyInput 
           return matchWalletId && matchId && matchName && matchPublicKey && matchType
         })
         .toArray(),
+      `Error finding accounts for wallet id ${parsedInput.walletId}`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding accounts for wallet id ${parsedInput.walletId}`)
-    }
-    return data
   })
 }

--- a/packages/db/src/account/account-find-unique.ts
+++ b/packages/db/src/account/account-find-unique.ts
@@ -1,14 +1,10 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
 
 export async function accountFindUnique(db: Database, id: string): Promise<null | Account> {
   return db.transaction('r', db.accounts, async () => {
-    const { data, error } = await tryCatch(db.accounts.get(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding account with id ${id}`)
-    }
+    const data = await tryCatchOrThrow(db.accounts.get(id), `Error finding account with id ${id}`)
     return data ?? null
   })
 }

--- a/packages/db/src/account/account-read-secret-key.ts
+++ b/packages/db/src/account/account-read-secret-key.ts
@@ -1,13 +1,12 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 
 export function accountReadSecretKey(db: Database, id: string) {
   return db.transaction('r', db.accounts, async () => {
-    const { data: account, error } = await tryCatch(db.accounts.where('id').equals(id).raw().first())
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding account with id ${id}`)
-    }
+    const account = await tryCatchOrThrow(
+      db.accounts.where('id').equals(id).raw().first(),
+      `Error finding account with id ${id}`,
+    )
     if (!account) {
       throw new Error(`Account with id ${id} not found`)
     }

--- a/packages/db/src/account/account-update-order.ts
+++ b/packages/db/src/account/account-update-order.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { Account } from './account.ts'
 import type { AccountUpdateOrderInput } from './account-update-order-input.ts'
@@ -28,24 +28,17 @@ export async function accountUpdateOrder(db: Database, input: AccountUpdateOrder
     const increment = newOrder < oldOrder
     const lower = increment ? newOrder : oldOrder + 1
     const upper = increment ? oldOrder - 1 : newOrder
-    const { error: updateAccountsError } = await tryCatch(
+    await tryCatchOrThrow(
       db.accounts
         .where('order')
         .between(lower, upper, true, true)
         .modify((account: Account) => {
           account.order = increment ? account.order + 1 : account.order - 1
         }),
+      `Error updating account order (${increment ? 'increment' : 'decrement'})`,
     )
-    if (updateAccountsError) {
-      throw new Error(`Error updating account order (${increment ? 'increment' : 'decrement'})`)
-    }
 
     // Finally, update the moved account's order
-    const { error: updateError } = await tryCatch(db.accounts.update(id, { order: newOrder }))
-
-    if (updateError) {
-      console.log(updateError)
-      throw new Error(`Error moving account with id ${id}`)
-    }
+    await tryCatchOrThrow(db.accounts.update(id, { order: newOrder }), `Error moving account with id ${id}`)
   })
 }

--- a/packages/db/src/bookmark-account/bookmark-account-create.ts
+++ b/packages/db/src/bookmark-account/bookmark-account-create.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { randomId } from '../random-id.ts'
@@ -10,19 +10,14 @@ export async function bookmarkAccountCreate(db: Database, input: BookmarkAccount
   const parsedInput = bookmarkAccountCreateSchema.parse(input)
 
   return db.transaction('rw', db.bookmarkAccounts, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.bookmarkAccounts.add({
         ...parsedInput,
         createdAt: now,
         id: randomId(),
         updatedAt: now,
       }),
+      `Error creating bookmark account`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error creating bookmark account`)
-    }
-
-    return data
   })
 }

--- a/packages/db/src/bookmark-account/bookmark-account-delete.ts
+++ b/packages/db/src/bookmark-account/bookmark-account-delete.ts
@@ -1,14 +1,9 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 
 export async function bookmarkAccountDelete(db: Database, id: string): Promise<void> {
   return db.transaction('rw', db.bookmarkAccounts, async () => {
-    const { data, error } = await tryCatch(db.bookmarkAccounts.delete(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error deleting bookmark account with id ${id}`)
-    }
-    return data
+    return tryCatchOrThrow(db.bookmarkAccounts.delete(id), `Error deleting bookmark account with id ${id}`)
   })
 }

--- a/packages/db/src/bookmark-account/bookmark-account-find-by-address.ts
+++ b/packages/db/src/bookmark-account/bookmark-account-find-by-address.ts
@@ -1,15 +1,14 @@
 import type { Address } from '@solana/kit'
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { BookmarkAccount } from './bookmark-account.ts'
 
 export async function bookmarkAccountFindByAddress(db: Database, address: Address): Promise<null | BookmarkAccount> {
   return db.transaction('r', db.bookmarkAccounts, async () => {
-    const { data, error } = await tryCatch(db.bookmarkAccounts.get({ address }))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding bookmark account with address ${address}`)
-    }
+    const data = await tryCatchOrThrow(
+      db.bookmarkAccounts.get({ address }),
+      `Error finding bookmark account with address ${address}`,
+    )
     return data ? data : null
   })
 }

--- a/packages/db/src/bookmark-account/bookmark-account-find-many.ts
+++ b/packages/db/src/bookmark-account/bookmark-account-find-many.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { BookmarkAccount } from './bookmark-account.ts'
 import type { BookmarkAccountFindManyInput } from './bookmark-account-find-many-input.ts'
@@ -10,7 +10,7 @@ export async function bookmarkAccountFindMany(
 ): Promise<BookmarkAccount[]> {
   const parsedInput = bookmarkAccountFindManySchema.parse(input)
   return db.transaction('r', db.bookmarkAccounts, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.bookmarkAccounts
         .orderBy('updatedAt')
         .filter((item) => {
@@ -22,11 +22,7 @@ export async function bookmarkAccountFindMany(
         })
         .reverse()
         .toArray(),
+      `Error finding bookmark accounts`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding bookmark accounts`)
-    }
-    return data
   })
 }

--- a/packages/db/src/bookmark-account/bookmark-account-update.ts
+++ b/packages/db/src/bookmark-account/bookmark-account-update.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import { parseStrict } from '../parse-strict.ts'
 import type { BookmarkAccountUpdateInput } from './bookmark-account-update-input.ts'
@@ -11,16 +11,12 @@ export async function bookmarkAccountUpdate(
 ): Promise<number> {
   const parsedInput = parseStrict(bookmarkAccountUpdateSchema.parse(input))
   return db.transaction('rw', db.bookmarkAccounts, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.bookmarkAccounts.update(id, {
         ...parsedInput,
         updatedAt: new Date(),
       }),
+      `Error updating bookmark account with id ${id}`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error updating bookmark account with id ${id}`)
-    }
-    return data
   })
 }

--- a/packages/db/src/bookmark-transaction/bookmark-transaction-create.ts
+++ b/packages/db/src/bookmark-transaction/bookmark-transaction-create.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { randomId } from '../random-id.ts'
@@ -10,19 +10,14 @@ export async function bookmarkTransactionCreate(db: Database, input: BookmarkTra
   const parsedInput = bookmarkTransactionCreateSchema.parse(input)
 
   return db.transaction('rw', db.bookmarkTransactions, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.bookmarkTransactions.add({
         ...parsedInput,
         createdAt: now,
         id: randomId(),
         updatedAt: now,
       }),
+      `Error creating bookmark transaction`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error creating bookmark transaction`)
-    }
-
-    return data
   })
 }

--- a/packages/db/src/bookmark-transaction/bookmark-transaction-delete.ts
+++ b/packages/db/src/bookmark-transaction/bookmark-transaction-delete.ts
@@ -1,14 +1,9 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 
 export async function bookmarkTransactionDelete(db: Database, id: string): Promise<void> {
   return db.transaction('rw', db.bookmarkTransactions, async () => {
-    const { data, error } = await tryCatch(db.bookmarkTransactions.delete(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error deleting bookmark transaction with id ${id}`)
-    }
-    return data
+    return tryCatchOrThrow(db.bookmarkTransactions.delete(id), `Error deleting bookmark transaction with id ${id}`)
   })
 }

--- a/packages/db/src/bookmark-transaction/bookmark-transaction-find-by-signature.ts
+++ b/packages/db/src/bookmark-transaction/bookmark-transaction-find-by-signature.ts
@@ -1,5 +1,5 @@
 import type { Signature } from '@solana/kit'
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { BookmarkTransaction } from './bookmark-transaction.ts'
 
@@ -8,11 +8,10 @@ export async function bookmarkTransactionFindBySignature(
   signature: Signature,
 ): Promise<null | BookmarkTransaction> {
   return db.transaction('r', db.bookmarkTransactions, async () => {
-    const { data, error } = await tryCatch(db.bookmarkTransactions.get({ signature }))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding bookmark transaction with signature ${signature}`)
-    }
+    const data = await tryCatchOrThrow(
+      db.bookmarkTransactions.get({ signature }),
+      `Error finding bookmark transaction with signature ${signature}`,
+    )
     return data ? data : null
   })
 }

--- a/packages/db/src/bookmark-transaction/bookmark-transaction-find-many.ts
+++ b/packages/db/src/bookmark-transaction/bookmark-transaction-find-many.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { BookmarkTransaction } from './bookmark-transaction.ts'
 import type { BookmarkTransactionFindManyInput } from './bookmark-transaction-find-many-input.ts'
@@ -10,7 +10,7 @@ export async function bookmarkTransactionFindMany(
 ): Promise<BookmarkTransaction[]> {
   const parsedInput = bookmarkTransactionFindManySchema.parse(input)
   return db.transaction('r', db.bookmarkTransactions, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.bookmarkTransactions
         .orderBy('updatedAt')
         .filter((item) => {
@@ -22,11 +22,7 @@ export async function bookmarkTransactionFindMany(
         })
         .reverse()
         .toArray(),
+      `Error finding bookmark transactions`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding bookmark transactions`)
-    }
-    return data
   })
 }

--- a/packages/db/src/bookmark-transaction/bookmark-transaction-update.ts
+++ b/packages/db/src/bookmark-transaction/bookmark-transaction-update.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import { parseStrict } from '../parse-strict.ts'
 import type { BookmarkTransactionUpdateInput } from './bookmark-transaction-update-input.ts'
@@ -11,16 +11,12 @@ export async function bookmarkTransactionUpdate(
 ): Promise<number> {
   const parsedInput = parseStrict(bookmarkTransactionUpdateSchema.parse(input))
   return db.transaction('rw', db.bookmarkTransactions, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.bookmarkTransactions.update(id, {
         ...parsedInput,
         updatedAt: new Date(),
       }),
+      `Error updating bookmark transaction with id ${id}`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error updating bookmark transaction with id ${id}`)
-    }
-    return data
   })
 }

--- a/packages/db/src/network/network-create.ts
+++ b/packages/db/src/network/network-create.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { randomId } from '../random-id.ts'
@@ -10,18 +10,14 @@ export async function networkCreate(db: Database, input: NetworkCreateInput): Pr
   const parsedInput = networkCreateSchema.parse(input)
 
   return db.transaction('rw', db.networks, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.networks.add({
         ...parsedInput,
         createdAt: now,
         id: randomId(),
         updatedAt: now,
       }),
+      `Error creating network`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error creating network`)
-    }
-    return data
   })
 }

--- a/packages/db/src/network/network-delete.ts
+++ b/packages/db/src/network/network-delete.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { settingFindUnique } from '../setting/setting-find-unique.ts'
@@ -9,11 +9,6 @@ export async function networkDelete(db: Database, id: string): Promise<void> {
     if (id === activeNetworkId) {
       throw new Error('You cannot delete the active network. Please change networks and try again.')
     }
-    const { data, error } = await tryCatch(db.networks.delete(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error deleting network with id ${id}`)
-    }
-    return data
+    return tryCatchOrThrow(db.networks.delete(id), `Error deleting network with id ${id}`)
   })
 }

--- a/packages/db/src/network/network-find-many.ts
+++ b/packages/db/src/network/network-find-many.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import type { Network } from './network.ts'
@@ -9,7 +9,7 @@ import { networkFindManySchema } from './network-find-many-schema.ts'
 export async function networkFindMany(db: Database, input: NetworkFindManyInput = {}): Promise<Network[]> {
   const parsedInput = networkFindManySchema.parse(input)
   return db.transaction('r', db.networks, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.networks
         .orderBy('name')
         .filter((item) => {
@@ -21,11 +21,7 @@ export async function networkFindMany(db: Database, input: NetworkFindManyInput 
           return matchName && matchType && matchEndpoint && matchId
         })
         .toArray(),
+      `Error finding networks`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding networks`)
-    }
-    return data
   })
 }

--- a/packages/db/src/network/network-find-unique.ts
+++ b/packages/db/src/network/network-find-unique.ts
@@ -1,15 +1,11 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import type { Network } from './network.ts'
 
 export async function networkFindUnique(db: Database, id: string): Promise<Network | null> {
   return db.transaction('r', db.networks, async () => {
-    const { data, error } = await tryCatch(db.networks.get(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding network with id ${id}`)
-    }
+    const data = await tryCatchOrThrow(db.networks.get(id), `Error finding network with id ${id}`)
     return data ? data : null
   })
 }

--- a/packages/db/src/network/network-update.ts
+++ b/packages/db/src/network/network-update.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { parseStrict } from '../parse-strict.ts'
@@ -9,17 +9,13 @@ export async function networkUpdate(db: Database, id: string, input: NetworkUpda
   const parsedInput = networkUpdateSchema.parse(input)
   const parsedStrictInput = parseStrict(parsedInput)
   return db.transaction('rw', db.networks, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.networks.update(id, {
         ...parsedStrictInput,
         ...('color' in input && input.color === undefined ? { color: undefined } : {}),
         updatedAt: new Date(),
       }),
+      `Error updating network with id ${id}`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error updating network with id ${id}`)
-    }
-    return data
   })
 }

--- a/packages/db/src/setting/setting-find-many.ts
+++ b/packages/db/src/setting/setting-find-many.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { Setting } from './setting.ts'
 import type { SettingFindManyInput } from './setting-find-many-input.ts'
@@ -7,7 +7,7 @@ import { settingFindManySchema } from './setting-find-many-schema.ts'
 export async function settingFindMany(db: Database, input: SettingFindManyInput = {}): Promise<Setting[]> {
   const parsedInput = settingFindManySchema.parse(input)
   return db.transaction('r', db.settings, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.settings
         .orderBy('key')
         .filter((item) => {
@@ -17,11 +17,7 @@ export async function settingFindMany(db: Database, input: SettingFindManyInput 
           return matchKey && matchValue
         })
         .toArray(),
+      `Error finding settings`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding settings`)
-    }
-    return data
   })
 }

--- a/packages/db/src/setting/setting-find-unique.ts
+++ b/packages/db/src/setting/setting-find-unique.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import type { Setting } from './setting.ts'
@@ -6,11 +6,7 @@ import type { SettingKey } from './setting-key.ts'
 
 export async function settingFindUnique(db: Database, key: SettingKey): Promise<null | Setting> {
   return db.transaction('r', db.settings, async () => {
-    const { data, error } = await tryCatch(db.settings.get({ key }))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding setting with key ${key}`)
-    }
+    const data = await tryCatchOrThrow(db.settings.get({ key }), `Error finding setting with key ${key}`)
     return data ?? null
   })
 }

--- a/packages/db/src/setting/setting-set-value.ts
+++ b/packages/db/src/setting/setting-set-value.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { randomId } from '../random-id.ts'
@@ -19,17 +19,14 @@ export async function settingSetValue(db: Database, key: SettingKey, value: stri
     const setting = await settingFindUnique(db, key)
     // Update the setting if it's already set
     if (setting) {
-      const { error } = await tryCatch(db.settings.update(setting.id, { updatedAt: now, value }))
-      if (error) {
-        throw new Error(`Error updating setting`)
-      }
+      await tryCatchOrThrow(db.settings.update(setting.id, { updatedAt: now, value }), `Error updating setting`)
       return
     }
     // Create the setting if it's not set
-    const { error } = await tryCatch(db.settings.add({ createdAt: now, id: randomId(), key, updatedAt: now, value }))
-    if (error) {
-      throw new Error(`Error creating setting`)
-    }
+    await tryCatchOrThrow(
+      db.settings.add({ createdAt: now, id: randomId(), key, updatedAt: now, value }),
+      `Error creating setting`,
+    )
     return
   })
 }

--- a/packages/db/src/wallet/wallet-create-determine-order.ts
+++ b/packages/db/src/wallet/wallet-create-determine-order.ts
@@ -1,15 +1,10 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 
 export async function walletCreateDetermineOrder(db: Database): Promise<number> {
   return db.transaction('r', db.wallets, async () => {
-    const { data, error } = await tryCatch(db.wallets.orderBy('order').last())
-
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding last wallet`)
-    }
+    const data = await tryCatchOrThrow(db.wallets.orderBy('order').last(), `Error finding last wallet`)
 
     if (!data) {
       return 0

--- a/packages/db/src/wallet/wallet-create.ts
+++ b/packages/db/src/wallet/wallet-create.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { randomId } from '../random-id.ts'
@@ -13,7 +13,7 @@ export async function walletCreate(db: Database, input: WalletCreateInput): Prom
   return db.transaction('rw', db.wallets, db.settings, db.accounts, async () => {
     const order = await walletCreateDetermineOrder(db)
 
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.wallets.add({
         ...parsedInput,
         accounts: [],
@@ -22,12 +22,7 @@ export async function walletCreate(db: Database, input: WalletCreateInput): Prom
         order,
         updatedAt: now,
       }),
+      `Error creating wallet`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error creating wallet`)
-    }
-
-    return data
   })
 }

--- a/packages/db/src/wallet/wallet-delete.ts
+++ b/packages/db/src/wallet/wallet-delete.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import { accountFindMany } from '../account/account-find-many.ts'
 import { accountFindUnique } from '../account/account-find-unique.ts'
 import type { Database } from '../database.ts'
@@ -15,16 +15,10 @@ export async function walletDelete(db: Database, id: string): Promise<void> {
       throw new Error('You cannot delete the active wallet. Please change wallets and try again.')
     }
     const accounts = await accountFindMany(db, { walletId: id })
-    const { error: errorAccounts } = await tryCatch(db.accounts.bulkDelete(accounts.map((account) => account.id)))
-    if (errorAccounts) {
-      console.log(errorAccounts)
-      throw new Error(`Error deleting accounts for wallet with id ${id}`)
-    }
-    const { data, error } = await tryCatch(db.wallets.delete(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error deleting wallet with id ${id}`)
-    }
-    return data
+    await tryCatchOrThrow(
+      db.accounts.bulkDelete(accounts.map((account) => account.id)),
+      `Error deleting accounts for wallet with id ${id}`,
+    )
+    return tryCatchOrThrow(db.wallets.delete(id), `Error deleting wallet with id ${id}`)
   })
 }

--- a/packages/db/src/wallet/wallet-find-many.ts
+++ b/packages/db/src/wallet/wallet-find-many.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import type { Wallet } from './wallet.ts'
@@ -9,30 +9,21 @@ import { walletFindManySchema } from './wallet-find-many-schema.ts'
 export async function walletFindMany(db: Database, input: WalletFindManyInput = {}): Promise<Wallet[]> {
   const parsedInput = walletFindManySchema.parse(input)
   return db.transaction('r', db.wallets, db.accounts, async () => {
-    const [{ data: dataWallets, error: walletsError }, { data: dataAccounts, error: errorAccounts }] =
-      await Promise.all([
-        tryCatch(
-          db.wallets
-            .orderBy('order')
-            .filter((item) => {
-              const matchId = !parsedInput.id || item.id === parsedInput.id
-              const matchName = !parsedInput.name || item.name.includes(parsedInput.name)
+    const [dataWallets, dataAccounts] = await Promise.all([
+      tryCatchOrThrow(
+        db.wallets
+          .orderBy('order')
+          .filter((item) => {
+            const matchId = !parsedInput.id || item.id === parsedInput.id
+            const matchName = !parsedInput.name || item.name.includes(parsedInput.name)
 
-              return matchId && matchName
-            })
-            .toArray(),
-        ),
-        tryCatch(db.accounts.orderBy('order').toArray()),
-      ])
-
-    if (walletsError) {
-      console.log(walletsError)
-      throw new Error(`Error finding wallets`)
-    }
-    if (errorAccounts) {
-      console.log(errorAccounts)
-      throw new Error(`Error finding accounts`)
-    }
+            return matchId && matchName
+          })
+          .toArray(),
+        `Error finding wallets`,
+      ),
+      tryCatchOrThrow(db.accounts.orderBy('order').toArray(), `Error finding accounts`),
+    ])
     return [
       ...dataWallets.map((wallet) => {
         return {

--- a/packages/db/src/wallet/wallet-find-unique.ts
+++ b/packages/db/src/wallet/wallet-find-unique.ts
@@ -1,15 +1,11 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import type { Wallet } from './wallet.ts'
 
 export async function walletFindUnique(db: Database, id: string): Promise<Wallet | null> {
   return db.transaction('r', db.wallets, async () => {
-    const { data, error } = await tryCatch(db.wallets.get(id))
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding wallet with id ${id}`)
-    }
+    const data = await tryCatchOrThrow(db.wallets.get(id), `Error finding wallet with id ${id}`)
     return data ?? null
   })
 }

--- a/packages/db/src/wallet/wallet-read-mnemonic.ts
+++ b/packages/db/src/wallet/wallet-read-mnemonic.ts
@@ -1,13 +1,12 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 
 export function walletReadMnemonic(db: Database, id: string) {
   return db.transaction('r', db.wallets, async () => {
-    const { data: wallet, error } = await tryCatch(db.wallets.where('id').equals(id).raw().first())
-    if (error) {
-      console.log(error)
-      throw new Error(`Error finding wallet with id ${id}`)
-    }
+    const wallet = await tryCatchOrThrow(
+      db.wallets.where('id').equals(id).raw().first(),
+      `Error finding wallet with id ${id}`,
+    )
     if (!wallet) {
       throw new Error(`Wallet with id ${id} not found`)
     }

--- a/packages/db/src/wallet/wallet-update-order.ts
+++ b/packages/db/src/wallet/wallet-update-order.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { Database } from '../database.ts'
 import type { Wallet } from './wallet.ts'
 import type { WalletUpdateOrderInput } from './wallet-update-order-input.ts'
@@ -28,24 +28,17 @@ export async function walletUpdateOrder(db: Database, input: WalletUpdateOrderIn
     const increment = newOrder < oldOrder
     const lower = increment ? newOrder : oldOrder + 1
     const upper = increment ? oldOrder - 1 : newOrder
-    const { error: updateWalletsError } = await tryCatch(
+    await tryCatchOrThrow(
       db.wallets
         .where('order')
         .between(lower, upper, true, true)
         .modify((wallet: Wallet) => {
           wallet.order = increment ? wallet.order + 1 : wallet.order - 1
         }),
+      `Error updating wallet order (${increment ? 'increment' : 'decrement'})`,
     )
-    if (updateWalletsError) {
-      throw new Error(`Error updating wallet order (${increment ? 'increment' : 'decrement'})`)
-    }
 
     // Finally, update the moved wallet's order
-    const { error: updateError } = await tryCatch(db.wallets.update(id, { order: newOrder }))
-
-    if (updateError) {
-      console.log(updateError)
-      throw new Error(`Error moving wallet with id ${id}`)
-    }
+    await tryCatchOrThrow(db.wallets.update(id, { order: newOrder }), `Error moving wallet with id ${id}`)
   })
 }

--- a/packages/db/src/wallet/wallet-update.ts
+++ b/packages/db/src/wallet/wallet-update.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { Database } from '../database.ts'
 import { parseStrict } from '../parse-strict.ts'
@@ -8,16 +8,12 @@ import { walletUpdateSchema } from './wallet-update-schema.ts'
 export async function walletUpdate(db: Database, id: string, input: WalletUpdateInput): Promise<number> {
   const parsedInput = parseStrict(walletUpdateSchema.parse(input))
   return db.transaction('rw', db.wallets, async () => {
-    const { data, error } = await tryCatch(
+    return tryCatchOrThrow(
       db.wallets.update(id, {
         ...parsedInput,
         updatedAt: new Date(),
       }),
+      `Error updating wallet with id ${id}`,
     )
-    if (error) {
-      console.log(error)
-      throw new Error(`Error updating wallet with id ${id}`)
-    }
-    return data
   })
 }

--- a/packages/solana-client/src/close-stake-account.ts
+++ b/packages/solana-client/src/close-stake-account.ts
@@ -1,6 +1,6 @@
 import type { Address, Lamports, Signature, TransactionSigner } from '@solana/kit'
 import { getWithdrawInstruction } from '@solana-program/stake'
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { LatestBlockhash } from './get-latest-blockhash.ts'
 import { sendPreparedTransaction } from './send-prepared-transaction.ts'
 import type { SolanaClient } from './solana-client.ts'
@@ -17,7 +17,7 @@ export async function closeStakeAccount(
   client: SolanaClient,
   { amount, latestBlockhash, recipient, stake, transactionSigner }: CloseStakeAccountOptions,
 ): Promise<Signature> {
-  const { data: signature, error } = await tryCatch(
+  return tryCatchOrThrow(
     sendPreparedTransaction(client, {
       instructions: [
         getWithdrawInstruction({
@@ -30,9 +30,6 @@ export async function closeStakeAccount(
       latestBlockhash,
       transactionSigner,
     }),
+    'Error closing stake account',
   )
-  if (error) {
-    throw error
-  }
-  return signature
 }

--- a/packages/solana-client/src/deactivate-stake-account.ts
+++ b/packages/solana-client/src/deactivate-stake-account.ts
@@ -1,6 +1,6 @@
 import type { Address, Signature, TransactionSigner } from '@solana/kit'
 import { getDeactivateInstruction } from '@solana-program/stake'
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { LatestBlockhash } from './get-latest-blockhash.ts'
 import { sendPreparedTransaction } from './send-prepared-transaction.ts'
 import type { SolanaClient } from './solana-client.ts'
@@ -15,7 +15,7 @@ export async function deactivateStakeAccount(
   client: SolanaClient,
   { latestBlockhash, stake, transactionSigner }: DeactivateStakeAccountOptions,
 ): Promise<Signature> {
-  const { data: signature, error } = await tryCatch(
+  return tryCatchOrThrow(
     sendPreparedTransaction(client, {
       instructions: [
         getDeactivateInstruction({
@@ -26,9 +26,6 @@ export async function deactivateStakeAccount(
       latestBlockhash,
       transactionSigner,
     }),
+    'Error deactivating stake account',
   )
-  if (error) {
-    throw error
-  }
-  return signature
 }

--- a/packages/solana-client/src/get-vote-accounts.ts
+++ b/packages/solana-client/src/get-vote-accounts.ts
@@ -1,15 +1,11 @@
 import type { GetVoteAccountsApi } from '@solana/kit'
-import { tryCatch } from '@workspace/core/try-catch'
+import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { SolanaClient } from './solana-client.ts'
 
 export type GetCurrentVoteAccountsResult = ReturnType<GetVoteAccountsApi['getVoteAccounts']>['current']
 
 export async function getVoteAccounts(client: SolanaClient): Promise<GetCurrentVoteAccountsResult> {
-  const { data: accounts, error } = await tryCatch(client.rpc.getVoteAccounts().send())
-  if (error) {
-    console.log(error)
-    throw new Error('Error fetching vote accounts')
-  }
+  const accounts = await tryCatchOrThrow(client.rpc.getVoteAccounts().send(), 'Error fetching vote accounts')
 
   return accounts.current ?? []
 }


### PR DESCRIPTION
Add a shared helper that logs caught errors with console.error before throwing an operation-specific error.

Use the helper across db operations and selected solana-client RPC helpers to remove repeated tryCatch error handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across the application by introducing a centralized error utility and refactoring multiple modules to use it consistently. This streamlines error management, reduces code duplication, and improves overall codebase maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->