### PR TITLE
test(db): add missing function coverage

### DIFF
--- a/packages/db/test/account-create-determine-order.test.ts
+++ b/packages/db/test/account-create-determine-order.test.ts
@@ -1,0 +1,66 @@
+import type { PromiseExtended } from 'dexie'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { accountCreate } from '../src/account/account-create.ts'
+import { accountCreateDetermineOrder } from '../src/account/account-create-determine-order.ts'
+import type { AccountInternal } from '../src/account/account-internal.ts'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('account-create-determine-order', () => {
+  beforeEach(async () => {
+    await db.accounts.clear()
+    await db.settings.clear()
+    await db.wallets.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should determine the next account order for a wallet', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const walletId1 = await walletCreate(db, testWalletCreateInput())
+      const walletId2 = await walletCreate(db, testWalletCreateInput())
+
+      // ACT
+      const result1 = await accountCreateDetermineOrder(db, walletId1)
+      await accountCreate(db, testAccountCreateInput({ walletId: walletId1 }))
+      await accountCreate(db, testAccountCreateInput({ walletId: walletId1 }))
+      await accountCreate(db, testAccountCreateInput({ walletId: walletId2 }))
+      const result2 = await accountCreateDetermineOrder(db, walletId1)
+      const result3 = await accountCreateDetermineOrder(db, walletId2)
+
+      // ASSERT
+      expect(result1).toBe(0)
+      expect(result2).toBe(2)
+      expect(result3).toBe(1)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when finding the last account fails', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      vi.spyOn(db.accounts, 'orderBy').mockImplementation(
+        () =>
+          ({
+            and: () => ({
+              last: () => Promise.reject(new Error('Test error')) as PromiseExtended<AccountInternal | undefined>,
+            }),
+          }) as never,
+      )
+
+      // ACT & ASSERT
+      await expect(accountCreateDetermineOrder(db, 'wallet-id')).rejects.toThrow('Error finding last account')
+    })
+  })
+})

--- a/packages/db/test/account-sanitizer.test.ts
+++ b/packages/db/test/account-sanitizer.test.ts
@@ -1,0 +1,64 @@
+import { address } from '@solana/kit'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AccountInternal } from '../src/account/account-internal.ts'
+import { accountSanitizer } from '../src/account/account-sanitizer.ts'
+
+describe('account-sanitizer', () => {
+  describe('expected behavior', () => {
+    it('should remove the secret key from an account', () => {
+      // ARRANGE
+      expect.assertions(2)
+      const now = new Date()
+      const input = {
+        createdAt: now,
+        derivationIndex: 0,
+        id: 'account-id',
+        name: 'Account',
+        order: 0,
+        publicKey: address('So11111111111111111111111111111111111111112'),
+        secretKey: 'secret-key',
+        type: 'Imported',
+        updatedAt: now,
+        walletId: 'wallet-id',
+      } satisfies AccountInternal
+
+      // ACT
+      const result = accountSanitizer(input)
+
+      // ASSERT
+      expect(result.name).toBe(input.name)
+      expect(result).not.toHaveProperty('secretKey')
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when account data is invalid', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const now = new Date()
+      const input = {
+        createdAt: now,
+        derivationIndex: 0,
+        id: 'account-id',
+        name: ' ',
+        order: 0,
+        publicKey: address('So11111111111111111111111111111111111111112'),
+        secretKey: 'secret-key',
+        type: 'Imported',
+        updatedAt: now,
+        walletId: 'wallet-id',
+      } satisfies AccountInternal
+
+      // ACT & ASSERT
+      expect(() => accountSanitizer(input)).toThrow()
+    })
+  })
+})

--- a/packages/db/test/create-db.test.ts
+++ b/packages/db/test/create-db.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDb } from '../src/create-db.ts'
+import { Database } from '../src/database.ts'
+
+describe('create-db', () => {
+  describe('expected behavior', () => {
+    it('should create a database with the configured name', () => {
+      // ARRANGE
+      expect.assertions(2)
+      const name = 'create-db-test'
+
+      // ACT
+      const result = createDb({ name })
+
+      // ASSERT
+      expect(result).toBeInstanceOf(Database)
+      expect(result.name).toBe(name)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should create a database with an empty name', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const name = ''
+
+      // ACT
+      const result = createDb({ name })
+
+      // ASSERT
+      expect(result.name).toBe(name)
+    })
+  })
+})

--- a/packages/db/test/db-table-metadata.test.ts
+++ b/packages/db/test/db-table-metadata.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  dbTableMetadata,
+  dbTableNames,
+  getDbTableMetadata,
+  getDbTableRecord,
+  getDbTableRecords,
+} from '../src/db-table-metadata.ts'
+import { networkCreate } from '../src/network/network-create.ts'
+import { createDbTest, testNetworkCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('db-table-metadata', () => {
+  beforeEach(async () => {
+    await Promise.all(db.tables.map((table) => table.clear()))
+  })
+
+  describe('expected behavior', () => {
+    it('should define metadata for every table name', () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT
+      const result = dbTableMetadata.map((metadata) => metadata.name)
+
+      // ASSERT
+      expect(result).toEqual(dbTableNames)
+    })
+
+    it('should get metadata by table name', () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT
+      const result = getDbTableMetadata('networks')
+
+      // ASSERT
+      expect(result?.name).toBe('networks')
+    })
+
+    it('should get a record by table name and id', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const input = testNetworkCreateInput()
+      const id = await networkCreate(db, input)
+
+      // ACT
+      const result = await getDbTableRecord(db, 'networks', id)
+
+      // ASSERT
+      expect(result?.id).toBe(id)
+      expect(result?.['name']).toBe(input.name)
+    })
+
+    it('should get records by table name', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const input1 = testNetworkCreateInput({ name: 'Network 1' })
+      const input2 = testNetworkCreateInput({ name: 'Network 2' })
+      await networkCreate(db, input1)
+      await networkCreate(db, input2)
+
+      // ACT
+      const result = await getDbTableRecords(db, 'networks')
+
+      // ASSERT
+      expect(result).toHaveLength(2)
+      expect(result.map((record) => record['name'])).toEqual(expect.arrayContaining([input1.name, input2.name]))
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return undefined when metadata is not found', () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT
+      const result = getDbTableMetadata('unknown')
+
+      // ASSERT
+      expect(result).toBeUndefined()
+    })
+  })
+})

--- a/packages/db/test/network-get-label.test.ts
+++ b/packages/db/test/network-get-label.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { networkGetLabel } from '../src/network/network-get-label.ts'
+import type { NetworkType } from '../src/network/network-type.ts'
+
+describe('network-get-label', () => {
+  describe('expected behavior', () => {
+    it.each([
+      ['solana:devnet', 'Solana Devnet'],
+      ['solana:localnet', 'Solana Localnet'],
+      ['solana:mainnet', 'Solana Mainnet'],
+      ['solana:testnet', 'Solana Testnet'],
+    ] satisfies [NetworkType, string][])('should get the label for %s', (type, label) => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT
+      const result = networkGetLabel(type)
+
+      // ASSERT
+      expect(result).toBe(label)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return an unknown label for an unsupported network type', () => {
+      // ARRANGE
+      expect.assertions(1)
+      // @ts-expect-error: Testing invalid input
+      const type: NetworkType = 'solana:custom'
+
+      // ACT
+      const result = networkGetLabel(type)
+
+      // ASSERT
+      expect(result).toBe('Unknown network solana:custom')
+    })
+  })
+})

--- a/packages/db/test/parse-strict.test.ts
+++ b/packages/db/test/parse-strict.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { parseStrict } from '../src/parse-strict.ts'
+
+describe('parse-strict', () => {
+  describe('expected behavior', () => {
+    it('should remove undefined values from an object', () => {
+      // ARRANGE
+      expect.assertions(2)
+      const input = {
+        count: 0,
+        enabled: false,
+        missing: undefined,
+        name: '',
+        nested: null,
+      }
+
+      // ACT
+      const result = parseStrict(input)
+
+      // ASSERT
+      expect(result).toEqual({
+        count: 0,
+        enabled: false,
+        name: '',
+        nested: null,
+      })
+      expect(result).not.toHaveProperty('missing')
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return an empty object when all values are undefined', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = {
+        missing1: undefined,
+        missing2: undefined,
+      }
+
+      // ACT
+      const result = parseStrict(input)
+
+      // ASSERT
+      expect(result).toEqual({})
+    })
+  })
+})

--- a/packages/db/test/populate-networks.test.ts
+++ b/packages/db/test/populate-networks.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { populateNetworks } from '../src/populate-networks.ts'
+
+describe('populate-networks', () => {
+  describe('expected behavior', () => {
+    it('should create networks from configured endpoints', () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      const result = populateNetworks()
+
+      // ASSERT
+      expect(
+        result.map((network) => ({
+          endpoint: network.endpoint,
+          endpointSubscriptions: network.endpointSubscriptions,
+          id: network.id,
+          name: network.name,
+          type: network.type,
+        })),
+      ).toEqual([
+        {
+          endpoint: 'https://api.devnet.solana.com',
+          endpointSubscriptions: '',
+          id: 'networkDevnet',
+          name: 'Devnet',
+          type: 'solana:devnet',
+        },
+        {
+          endpoint: 'http://localhost:8899',
+          endpointSubscriptions: 'ws://127.0.0.1:8900',
+          id: 'networkLocalnet',
+          name: 'Localnet',
+          type: 'solana:localnet',
+        },
+        {
+          endpoint: 'https://api.testnet.solana.com',
+          endpointSubscriptions: '',
+          id: 'networkTestnet',
+          name: 'Testnet',
+          type: 'solana:testnet',
+        },
+      ])
+      expect(result.every((network) => network.createdAt instanceof Date && network.updatedAt instanceof Date)).toBe(
+        true,
+      )
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should not include networks without configured endpoints', () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT
+      const result = populateNetworks()
+
+      // ASSERT
+      expect(result.map((network) => network.id)).not.toContain('networkMainnet')
+    })
+  })
+})

--- a/packages/db/test/populate.test.ts
+++ b/packages/db/test/populate.test.ts
@@ -1,0 +1,50 @@
+import { env } from '@workspace/env/env'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { populate } from '../src/populate.ts'
+import { createDbTest } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('populate', () => {
+  beforeEach(async () => {
+    await Promise.all(db.tables.map((table) => table.clear()))
+  })
+
+  describe('expected behavior', () => {
+    it('should populate networks and settings', async () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      await populate(db)
+      const result1 = await db.networks.orderBy('id').toArray()
+      const result2 = await db.settings.orderBy('key').toArray()
+
+      // ASSERT
+      expect(result1.map((network) => network.id)).toEqual(['networkDevnet', 'networkLocalnet', 'networkTestnet'])
+      expect(result2.map((setting) => [setting.key, setting.value])).toEqual([
+        ['activeNetworkId', env('activeNetworkId')],
+        ['apiEndpoint', env('apiEndpoint')],
+      ])
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when populating duplicate default records', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      await populate(db)
+
+      // ACT & ASSERT
+      await expect(populate(db)).rejects.toThrow()
+    })
+  })
+})

--- a/packages/db/test/random-id.test.ts
+++ b/packages/db/test/random-id.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { randomId } from '../src/random-id.ts'
+
+describe('random-id', () => {
+  describe('expected behavior', () => {
+    it('should create a default id', () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      const result = randomId()
+
+      // ASSERT
+      expect(result).toHaveLength(25)
+      expect(result).toMatch(/^[A-Z0-9]+$/)
+    })
+
+    it('should create an id with a custom size', () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      const result = randomId(8)
+
+      // ASSERT
+      expect(result).toHaveLength(8)
+      expect(result).toMatch(/^[A-Z0-9]+$/)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should create an empty id with a size of zero', () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT
+      const result = randomId(0)
+
+      // ASSERT
+      expect(result).toBe('')
+    })
+  })
+})

--- a/packages/db/test/reset.test.ts
+++ b/packages/db/test/reset.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { accountCreate } from '../src/account/account-create.ts'
+import { reset } from '../src/reset.ts'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import { createDbTest, testAccountCreateInput, testWalletCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('reset', () => {
+  beforeEach(async () => {
+    await Promise.all(db.tables.map((table) => table.clear()))
+  })
+
+  describe('expected behavior', () => {
+    it('should clear tables and populate default records', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletId = await walletCreate(db, testWalletCreateInput())
+      await accountCreate(db, testAccountCreateInput({ walletId }))
+
+      // ACT
+      await reset(db)
+      const result = {
+        accounts: await db.accounts.count(),
+        bookmarkAccounts: await db.bookmarkAccounts.count(),
+        bookmarkTransactions: await db.bookmarkTransactions.count(),
+        networks: await db.networks.count(),
+        settings: await db.settings.count(),
+        wallets: await db.wallets.count(),
+      }
+
+      // ASSERT
+      expect(result).toEqual({
+        accounts: 0,
+        bookmarkAccounts: 0,
+        bookmarkTransactions: 0,
+        networks: 3,
+        settings: 2,
+        wallets: 0,
+      })
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should populate default records when tables are already empty', async () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      await reset(db)
+      const result1 = await db.networks.count()
+      const result2 = await db.settings.count()
+
+      // ASSERT
+      expect(result1).toBe(3)
+      expect(result2).toBe(2)
+    })
+  })
+})

--- a/packages/db/test/setting-find-many.test.ts
+++ b/packages/db/test/setting-find-many.test.ts
@@ -1,0 +1,88 @@
+import type { PromiseExtended } from 'dexie'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Setting } from '../src/setting/setting.ts'
+import { settingFindMany } from '../src/setting/setting-find-many.ts'
+import { settingSetValue } from '../src/setting/setting-set-value.ts'
+import { createDbTest, testSettingSetInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('setting-find-many', () => {
+  beforeEach(async () => {
+    await db.settings.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should find many settings by key', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const [key, value] = testSettingSetInput()
+      await settingSetValue(db, key, value)
+      await settingSetValue(db, 'apiEndpoint', 'https://api.samui.build')
+
+      // ACT
+      const result = await settingFindMany(db, { key })
+
+      // ASSERT
+      expect(result).toHaveLength(1)
+      expect(result[0]?.value).toBe(value)
+    })
+
+    it('should find many settings by value', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const [key, value] = testSettingSetInput()
+      await settingSetValue(db, key, value)
+      await settingSetValue(db, 'apiEndpoint', 'https://api.samui.build')
+
+      // ACT
+      const result = await settingFindMany(db, { value })
+
+      // ASSERT
+      expect(result).toHaveLength(1)
+      expect(result[0]?.key).toBe(key)
+    })
+
+    it('should find many settings by value and key', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const [key, value] = testSettingSetInput()
+      await settingSetValue(db, key, value)
+      await settingSetValue(db, 'apiEndpoint', 'https://api.samui.build')
+
+      // ACT
+      const result = await settingFindMany(db, { key, value })
+
+      // ASSERT
+      expect(result).toHaveLength(1)
+      expect(result[0]?.key).toBe(key)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when finding settings fails', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      vi.spyOn(db.settings, 'orderBy').mockImplementation(
+        () =>
+          ({
+            filter: () => ({
+              toArray: () => Promise.reject(new Error('Test error')) as PromiseExtended<Setting[]>,
+            }),
+          }) as never,
+      )
+
+      // ACT & ASSERT
+      await expect(settingFindMany(db)).rejects.toThrow('Error finding settings')
+    })
+  })
+})

--- a/packages/db/test/solana-signature-schema.test.ts
+++ b/packages/db/test/solana-signature-schema.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { solanaSignatureSchema } from '../src/solana/solana-signature-schema.ts'
+
+describe('solanaSignatureSchema', () => {
+  describe('expected behavior', () => {
+    it('should parse a valid Solana signature', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const signature = '2RHM8HGK1NaHrWPnfLMDeBsANJAUh1NWefpYctp4v9ZCgLWVjczA8bsjubm4hDEdrdB5XQLKfkHYUoghZftfo1mZ'
+
+      // ACT
+      const result = solanaSignatureSchema.safeParse(signature)
+
+      // ASSERT
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should not parse a null value', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const signature = null
+
+      // ACT
+      const result = solanaSignatureSchema.safeParse(signature)
+
+      // ASSERT
+      expect(result.success).toBe(false)
+    })
+
+    it('should not parse an empty string', () => {
+      // ARRANGE
+      expect.assertions(2)
+      const signature = ''
+
+      // ACT
+      const result = solanaSignatureSchema.safeParse(signature)
+
+      // ASSERT
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe('Invalid Solana signature')
+      }
+    })
+
+    it('should not parse an invalid Solana signature', () => {
+      // ARRANGE
+      expect.assertions(2)
+      const signature = 'invalid-signature'
+
+      // ACT
+      const result = solanaSignatureSchema.safeParse(signature)
+
+      // ASSERT
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe('Invalid Solana signature')
+      }
+    })
+
+    it('should not parse an undefined value', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const signature = undefined
+
+      // ACT
+      const result = solanaSignatureSchema.safeParse(signature)
+
+      // ASSERT
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/packages/db/test/wallet-create-determine-order.test.ts
+++ b/packages/db/test/wallet-create-determine-order.test.ts
@@ -1,0 +1,56 @@
+import type { PromiseExtended } from 'dexie'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import { walletCreateDetermineOrder } from '../src/wallet/wallet-create-determine-order.ts'
+import type { WalletInternal } from '../src/wallet/wallet-internal.ts'
+import { createDbTest, testWalletCreateInput } from './test-helpers.ts'
+
+const db = createDbTest()
+
+describe('wallet-create-determine-order', () => {
+  beforeEach(async () => {
+    await db.wallets.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should determine the next wallet order', async () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      const result1 = await walletCreateDetermineOrder(db)
+      await walletCreate(db, testWalletCreateInput())
+      await walletCreate(db, testWalletCreateInput())
+      const result2 = await walletCreateDetermineOrder(db)
+
+      // ASSERT
+      expect(result1).toBe(0)
+      expect(result2).toBe(2)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when finding the last wallet fails', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      vi.spyOn(db.wallets, 'orderBy').mockImplementation(
+        () =>
+          ({
+            last: () => Promise.reject(new Error('Test error')) as PromiseExtended<WalletInternal | undefined>,
+          }) as never,
+      )
+
+      // ACT & ASSERT
+      await expect(walletCreateDetermineOrder(db)).rejects.toThrow('Error finding last wallet')
+    })
+  })
+})

--- a/packages/db/test/wallet-determine-name.test.ts
+++ b/packages/db/test/wallet-determine-name.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Wallet } from '../src/wallet/wallet.ts'
+import { walletDetermineName } from '../src/wallet/wallet-determine-name.ts'
+
+function createWallet(input: Pick<Wallet, 'name' | 'order'>): Wallet {
+  const now = new Date()
+  return {
+    accounts: [],
+    createdAt: now,
+    derivationPath: 'd',
+    id: input.name,
+    name: input.name,
+    order: input.order,
+    secret: 'secret',
+    updatedAt: now,
+  }
+}
+
+describe('wallet-determine-name', () => {
+  describe('expected behavior', () => {
+    it('should return the first wallet name when no numbered wallet exists', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const items = [createWallet({ name: 'Primary', order: 0 })]
+
+      // ACT
+      const result = walletDetermineName(items)
+
+      // ASSERT
+      expect(result).toBe('Wallet 1')
+    })
+
+    it('should return the next highest numbered wallet name', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const items = [
+        createWallet({ name: 'Primary', order: 0 }),
+        createWallet({ name: 'Wallet 1', order: 1 }),
+        createWallet({ name: 'Wallet 3', order: 2 }),
+      ]
+
+      // ACT
+      const result = walletDetermineName(items)
+
+      // ASSERT
+      expect(result).toBe('Wallet 4')
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should ignore wallet names that are not exact numbered matches', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const items = [
+        createWallet({ name: 'Wallet 1 Backup', order: 0 }),
+        createWallet({ name: 'Wallet 2', order: 1 }),
+        createWallet({ name: 'Wallet Two', order: 2 }),
+      ]
+
+      // ACT
+      const result = walletDetermineName(items)
+
+      // ASSERT
+      expect(result).toBe('Wallet 3')
+    })
+  })
+})

--- a/packages/db/test/wallet-sanitizer.test.ts
+++ b/packages/db/test/wallet-sanitizer.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WalletInternal } from '../src/wallet/wallet-internal.ts'
+import { walletSanitizer } from '../src/wallet/wallet-sanitizer.ts'
+
+describe('wallet-sanitizer', () => {
+  describe('expected behavior', () => {
+    it('should remove the mnemonic from a wallet', () => {
+      // ARRANGE
+      expect.assertions(3)
+      const now = new Date()
+      const input = {
+        accounts: [],
+        createdAt: now,
+        derivationPath: 'd',
+        id: 'wallet-id',
+        mnemonic: 'mnemonic',
+        name: 'Wallet',
+        order: 0,
+        secret: 'secret',
+        updatedAt: now,
+      } satisfies WalletInternal
+
+      // ACT
+      const result = walletSanitizer(input)
+
+      // ASSERT
+      expect(result.name).toBe(input.name)
+      expect(result.secret).toBe(input.secret)
+      expect(result).not.toHaveProperty('mnemonic')
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when wallet data is invalid', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const now = new Date()
+      const input = {
+        accounts: [],
+        createdAt: now,
+        derivationPath: 'd',
+        id: 'wallet-id',
+        mnemonic: 'mnemonic',
+        name: ' ',
+        order: 0,
+        secret: 'secret',
+        updatedAt: now,
+      } satisfies WalletInternal
+
+      // ACT & ASSERT
+      expect(() => walletSanitizer(input)).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Add focused tests for previously untested db helpers, metadata accessors, population utilities, sanitizers, schema parsing, and order calculators.

Cover setting list queries and supporting pure utilities in line with the surrounding Vitest structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for database account and wallet operations including creation order determination, network and settings management, data sanitization and validation, transaction signature schema verification, random identifier generation, and database reset functionality. New utility functions provide database table metadata discovery, individual and bulk record retrieval, and table management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->