### PR TITLE
fix: raise toasts above bottom navigation

### DIFF
--- a/packages/feature-dev/src/dev-feature-ui-toasts.tsx
+++ b/packages/feature-dev/src/dev-feature-ui-toasts.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@workspace/ui/components/button'
+import { ButtonGroup } from '@workspace/ui/components/button-group'
+import { UiCard } from '@workspace/ui/components/ui-card'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastLoading } from '@workspace/ui/lib/toast-loading'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+
+const loadingToastDuration = 2000
+
+function showLoadingToast() {
+  const { dismiss } = toastLoading('Loading toast')
+  window.setTimeout(dismiss, loadingToastDuration)
+}
+
+export function DevFeatureUiToasts() {
+  return (
+    <UiCard title="ui toasts">
+      <ButtonGroup className="flex-wrap">
+        <Button onClick={() => toastError('Error toast')} variant="outline">
+          Error
+        </Button>
+        <Button onClick={showLoadingToast} variant="outline">
+          Loading
+        </Button>
+        <Button
+          onClick={() => {
+            toastError('Error toast')
+            showLoadingToast()
+            toastSuccess('Success toast')
+          }}
+          variant="outline"
+        >
+          Stack
+        </Button>
+        <Button onClick={() => toastSuccess('Success toast')} variant="outline">
+          Success
+        </Button>
+      </ButtonGroup>
+    </UiCard>
+  )
+}

--- a/packages/feature-dev/src/dev-feature-ui.tsx
+++ b/packages/feature-dev/src/dev-feature-ui.tsx
@@ -2,10 +2,12 @@ import { DevFeatureUiAvatars } from './dev-feature-ui-avatars.tsx'
 import { DevFeatureUiColors } from './dev-feature-ui-colors.tsx'
 import { DevFeatureUiIcons } from './dev-feature-ui-icons.tsx'
 import { DevFeatureUiInputs } from './dev-feature-ui-inputs.tsx'
+import { DevFeatureUiToasts } from './dev-feature-ui-toasts.tsx'
 
 export default function DevFeatureUi() {
   return (
     <div className="space-y-6">
+      <DevFeatureUiToasts />
       <DevFeatureUiInputs />
       <DevFeatureUiIcons />
       <DevFeatureUiAvatars />

--- a/packages/feature-shell/src/data-access/shell-providers.tsx
+++ b/packages/feature-shell/src/data-access/shell-providers.tsx
@@ -38,7 +38,12 @@ export function ShellProviders({ children }: ShellProviderProps) {
   return (
     <PersistQueryClientProvider client={queryClient} persistOptions={{ persister }}>
       {children}
-      <Toaster closeButton richColors />
+      <Toaster
+        closeButton
+        mobileOffset={{ bottom: 'calc(env(safe-area-inset-bottom) + 5rem)' }}
+        offset={{ bottom: 'calc(env(safe-area-inset-bottom) + 5rem)' }}
+        richColors
+      />
       {getEntrypoint() === 'sidepanel' ? <RequestFeatureDialog /> : null}
     </PersistQueryClientProvider>
   )


### PR DESCRIPTION
Offset shell toasts from the bottom edge so they clear the safe-area-aware footer navigation.

Add dev UI toast controls for quickly exercising success, error, loading, and stacked toast states.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new toast notifications interface with interactive buttons to trigger and display different notification types: Error, Loading, Success, and stacked notifications.
  * Enhanced toast configuration with improved mobile-responsive spacing using safe area insets and customizable visual styling options for better presentation across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->