### PR TITLE
feat: wire db vault runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -203,6 +203,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@workspace/db": "workspace:*",
+        "@workspace/vault": "workspace:*",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -244,6 +245,7 @@
         "@solana/kit": "catalog:",
         "@workspace/core": "workspace:*",
         "@workspace/env": "workspace:*",
+        "@workspace/vault": "workspace:*",
         "dexie": "4.4.2",
         "nanoid": "5.1.9",
         "zod": "catalog:",

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "@workspace/db": "workspace:*"
+    "@workspace/db": "workspace:*",
+    "@workspace/vault": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/context/src/app-context.ts
+++ b/packages/context/src/app-context.ts
@@ -1,5 +1,7 @@
 import type { Database } from '@workspace/db/database'
+import type { Vault } from '@workspace/vault/vault'
 
 export interface AppContext {
   db: Database
+  vault: Vault
 }

--- a/packages/context/src/create-app-context.ts
+++ b/packages/context/src/create-app-context.ts
@@ -1,7 +1,8 @@
 import { createDb } from '@workspace/db/create-db'
+import { createDbVault } from '@workspace/db/create-db-vault'
 import type { Database } from '@workspace/db/database'
 import type { AppContext } from './app-context.ts'
 
 export function createAppContext(db: Database = createDb({ name: 'samui-wallet' })): AppContext {
-  return { db }
+  return { db, vault: createDbVault({ db }) }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,6 +3,7 @@
     "@solana/kit": "catalog:",
     "@workspace/core": "workspace:*",
     "@workspace/env": "workspace:*",
+    "@workspace/vault": "workspace:*",
     "dexie": "4.4.2",
     "nanoid": "5.1.9",
     "zod": "catalog:"

--- a/packages/db/src/create-db-vault.ts
+++ b/packages/db/src/create-db-vault.ts
@@ -1,0 +1,32 @@
+import { createVault, type Vault } from '@workspace/vault/vault'
+import type { Database } from './database.ts'
+import { randomId } from './random-id.ts'
+
+export type { Vault } from '@workspace/vault/vault'
+
+export function createDbVault({ db }: { db: Database }): Vault {
+  return createVault({
+    async getVaultKey() {
+      return (await db.settings.get({ key: 'vaultKey' }))?.value
+    },
+    async getWalletProtection(walletId: string) {
+      const wallet = await db.wallets.where('id').equals(walletId).raw().first()
+      if (!wallet) {
+        throw new Error(`Wallet with id ${walletId} not found`)
+      }
+
+      return wallet.secret
+    },
+    async setVaultKey(value: string) {
+      const now = new Date()
+      await db.transaction('rw', db.settings, async () => {
+        const setting = await db.settings.get({ key: 'vaultKey' })
+        if (setting) {
+          await db.settings.update(setting.id, { updatedAt: now, value })
+          return
+        }
+        await db.settings.add({ createdAt: now, id: randomId(), key: 'vaultKey', updatedAt: now, value })
+      })
+    },
+  })
+}

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -3,6 +3,7 @@ import type { AccountInternal } from './account/account-internal.ts'
 import { accountSanitizer } from './account/account-sanitizer.ts'
 import type { BookmarkAccount } from './bookmark-account/bookmark-account.ts'
 import type { BookmarkTransaction } from './bookmark-transaction/bookmark-transaction.ts'
+import { createDbVault } from './create-db-vault.ts'
 import type { Network } from './network/network.ts'
 import { populate } from './populate.ts'
 import type { Setting } from './setting/setting.ts'
@@ -36,7 +37,7 @@ export class Database extends Dexie {
     this.wallets.hook('reading', walletReadingHook)
 
     this.on('populate', async () => {
-      await populate({ db: this })
+      await populate({ db: this, vault: createDbVault({ db: this }) })
     })
   }
 }

--- a/packages/db/src/db-context.ts
+++ b/packages/db/src/db-context.ts
@@ -1,5 +1,7 @@
+import type { Vault } from '@workspace/vault/vault'
 import type { Database } from './database.ts'
 
 export interface DbContext {
   db: Database
+  vault: Vault
 }

--- a/packages/db/src/setting/setting-key-schema.ts
+++ b/packages/db/src/setting/setting-key-schema.ts
@@ -6,5 +6,6 @@ export const settingKeySchema = z.enum([
   'apiEndpoint',
   'language',
   'theme',
+  'vaultKey',
   'warningAcceptExperimental',
 ])

--- a/packages/db/test/create-db-vault.test.ts
+++ b/packages/db/test/create-db-vault.test.ts
@@ -1,0 +1,99 @@
+import { createPasswordWalletProtection } from '@workspace/vault/wallet-protection'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDbVault } from '../src/create-db-vault.ts'
+import { randomId } from '../src/random-id.ts'
+import { createDbContextTest, randomName } from './test-helpers.ts'
+
+const ctx = createDbContextTest()
+
+describe('create-db-vault', () => {
+  beforeEach(async () => {
+    await ctx.db.settings.clear()
+    await ctx.db.wallets.clear()
+  })
+
+  describe('expected behavior', () => {
+    it('should create and persist a wrapped vault key', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const vault = createDbVault({ db: ctx.db })
+
+      // ACT
+      await vault.create({ password: 'password-one' })
+      const result = await ctx.db.settings.get({ key: 'vaultKey' })
+
+      // ASSERT
+      expect(result?.value).toBeDefined()
+      expect(result?.value).not.toContain('password-one')
+      await expect(vault.isConfigured()).resolves.toBe(true)
+      expect(vault.isUnlocked()).toBe(true)
+    })
+
+    it('should update the existing vault key setting when the password changes', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const vault = createDbVault({ db: ctx.db })
+      await vault.create({ password: 'password-one' })
+      const result1 = await ctx.db.settings.get({ key: 'vaultKey' })
+
+      // ACT
+      await vault.changePassword({ newPassword: 'password-two', oldPassword: 'password-one' })
+      const result2 = await ctx.db.settings.get({ key: 'vaultKey' })
+
+      // ASSERT
+      expect(result2?.id).toBe(result1?.id)
+      expect(result2?.value).not.toBe(result1?.value)
+      expect(result2?.value).not.toContain('password-two')
+      expect(vault.isUnlocked()).toBe(true)
+    })
+
+    it('should read wallet protection from a wallet row', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const now = new Date()
+      const walletId = randomId()
+      const protection = createPasswordWalletProtection()
+      const vault = createDbVault({ db: ctx.db })
+      await vault.create({ password: 'password-one' })
+      await ctx.db.wallets.add({
+        accounts: [],
+        createdAt: now,
+        derivationPath: 'd',
+        id: walletId,
+        mnemonic: 'plaintext-mnemonic',
+        name: randomName('wallet'),
+        order: 0,
+        secret: protection,
+        updatedAt: now,
+      })
+
+      // ACT
+      const result = await vault.requireWalletKey({ walletId })
+
+      // ASSERT
+      expect(result).toBe(vault.requireDefaultKey())
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw when wallet protection is requested for a missing wallet', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const vault = createDbVault({ db: ctx.db })
+      await vault.create({ password: 'password-one' })
+
+      // ACT & ASSERT
+      await expect(vault.requireWalletKey({ walletId: 'missing-wallet' })).rejects.toThrow(
+        'Wallet with id missing-wallet not found',
+      )
+    })
+  })
+})

--- a/packages/db/test/setting-set-value.test.ts
+++ b/packages/db/test/setting-set-value.test.ts
@@ -26,6 +26,18 @@ describe('setting-set-value', () => {
       expect(item?.value).toBe(value)
     })
 
+    it('should set vault settings', async () => {
+      // ARRANGE
+      expect.assertions(1)
+
+      // ACT
+      await settingSetValue(ctx, 'vaultKey', 'encrypted-vault-key')
+      const result = await settingFindUnique(ctx, 'vaultKey')
+
+      // ASSERT
+      expect(result?.value).toBe('encrypted-vault-key')
+    })
+
     it('should update a setting when it already exists', async () => {
       // ARRANGE
       expect.assertions(3)

--- a/packages/db/test/test-helpers.ts
+++ b/packages/db/test/test-helpers.ts
@@ -4,6 +4,7 @@ import type { AccountCreateInput } from '../src/account/account-create-input.ts'
 import type { BookmarkAccountCreateInput } from '../src/bookmark-account/bookmark-account-create-input.ts'
 import type { BookmarkTransactionCreateInput } from '../src/bookmark-transaction/bookmark-transaction-create-input.ts'
 import { createDb } from '../src/create-db.ts'
+import { createDbVault } from '../src/create-db-vault.ts'
 import type { Database } from '../src/database.ts'
 import type { DbContext } from '../src/db-context.ts'
 import type { NetworkCreateInput } from '../src/network/network-create-input.ts'
@@ -16,7 +17,8 @@ export function createDbTest(name: string = randomName('test')): Database {
 }
 
 export function createDbContextTest(): DbContext {
-  return { db: createDbTest() }
+  const db = createDbTest()
+  return { db, vault: createDbVault({ db }) }
 }
 
 export function randomName(prefix: string): string {


### PR DESCRIPTION
Add a DB-backed vault adapter that stores the wrapped app vault key in settings.vaultKey and reads wallet protection metadata from wallet rows.

Add vault to the DB and app contexts so consumers share the supplied Database instance without changing wallet/account encryption behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vault support across the app, including initialization in app and DB contexts
  * Settings extended to store an encrypted vault key

* **Tests**
  * Added comprehensive tests covering vault creation, key persistence/rotation, and wallet key access behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->