### PR TITLE
chore: use hoisted bun linker

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,5 @@
 [install]
 exact = true
-linker = "isolated"
+linker = "hoisted"
 minimumReleaseAge = 432000
 minimumReleaseAgeExcludes = ["@beeman/testcontainers"]


### PR DESCRIPTION
Switch Bun installs from the isolated linker to the hoisted linker so root-level tools can resolve workspace packages such as @workspace/config-typescript.

This avoids WebStorm's Tailwind language server failing to load package tsconfig extends from package-local node_modules.
<img width="838" height="466" alt="image" src="https://github.com/user-attachments/assets/2e1671e7-c930-49ba-a17f-152c36419a1c" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency installation configuration to optimize how shared dependencies are managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->