### PR TITLE
feat: add vault unlock dialog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -316,6 +316,7 @@
         "@workspace/i18n": "workspace:*",
         "@workspace/solana-client-react": "workspace:*",
         "@workspace/ui": "workspace:*",
+        "@workspace/vault-react": "workspace:*",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",
         "zod": "catalog:",
@@ -495,6 +496,7 @@
         "@workspace/flags": "workspace:*",
         "@workspace/i18n": "workspace:*",
         "@workspace/ui": "workspace:*",
+        "@workspace/vault-react": "workspace:*",
         "@wxt-dev/browser": "catalog:",
         "react-router": "catalog:",
       },
@@ -712,6 +714,31 @@
         "@workspace/config-vitest": "workspace:*",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+    },
+    "packages/vault-react": {
+      "name": "@workspace/vault-react",
+      "version": "0.0.0",
+      "dependencies": {
+        "@tanstack/react-query": "catalog:",
+        "@workspace/context": "workspace:*",
+        "@workspace/context-react": "workspace:*",
+        "@workspace/i18n": "workspace:*",
+        "@workspace/ui": "workspace:*",
+        "@workspace/vault": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
+        "@workspace/config-typescript": "workspace:*",
+        "@workspace/config-vitest": "workspace:*",
+        "typescript": "catalog:",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "react": "catalog:",
+        "react-dom": "catalog:",
       },
     },
     "packages/wallet-standard": {
@@ -2007,6 +2034,8 @@
     "@workspace/ui": ["@workspace/ui@workspace:packages/ui"],
 
     "@workspace/vault": ["@workspace/vault@workspace:packages/vault"],
+
+    "@workspace/vault-react": ["@workspace/vault-react@workspace:packages/vault-react"],
 
     "@workspace/wallet-standard": ["@workspace/wallet-standard@workspace:packages/wallet-standard"],
 

--- a/packages/feature-dev/src/dev-feature-scratch-pad.tsx
+++ b/packages/feature-dev/src/dev-feature-scratch-pad.tsx
@@ -18,7 +18,7 @@ export default function DevFeatureScratchPad() {
       description="Your place to quickly test some UI components"
       title="Scratch Pad"
     >
-      <div className="space-y-6">Start here</div>
+      <div>Start here</div>
     </UiCard>
   )
 }

--- a/packages/feature-dev/src/dev-feature-vault.tsx
+++ b/packages/feature-dev/src/dev-feature-vault.tsx
@@ -1,0 +1,64 @@
+import { useMutation } from '@tanstack/react-query'
+import { Button } from '@workspace/ui/components/button'
+import { UiCard } from '@workspace/ui/components/ui-card'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { useVaultLock, useVaultStatus, useVaultUnlockDialog } from '@workspace/vault-react/vault-unlock-provider'
+
+function formatVaultStatus(value: boolean | undefined) {
+  if (value === undefined) {
+    return 'Unknown'
+  }
+  return value ? 'Yes' : 'No'
+}
+
+export default function DevFeatureVault() {
+  const { requestUnlock } = useVaultUnlockDialog()
+  const status = useVaultStatus()
+  const lockVault = useVaultLock({
+    onSuccess: () => {
+      toastSuccess('Vault locked')
+    },
+  })
+  const unlockVault = useMutation({
+    mutationFn: () => requestUnlock(),
+    onError: (error) => toastError(error instanceof Error ? error.message : 'Unable to request vault unlock'),
+    onSuccess: (result) => {
+      if (result) {
+        toastSuccess('Vault unlocked successfully')
+      } else {
+        toastError('Vault unlock was cancelled or failed')
+      }
+    },
+  })
+  const isPending = lockVault.isPending || status.isPending || unlockVault.isPending
+  const isConfigured = status.data?.isConfigured
+  const isUnlocked = status.data?.isUnlocked
+  const canLockVault = isUnlocked === true
+  const canRequestUnlock = isUnlocked === false
+
+  return (
+    <UiCard description="Open the shared vault unlock/setup dialog from the dev surface." title="Vault unlock dialog">
+      <div className="space-y-4">
+        <dl className="grid gap-2 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-muted-foreground">Configured</dt>
+            <dd>{formatVaultStatus(isConfigured)}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Unlocked</dt>
+            <dd>{formatVaultStatus(isUnlocked)}</dd>
+          </div>
+        </dl>
+        <div className="flex flex-wrap gap-2">
+          <Button disabled={isPending || !canRequestUnlock} onClick={() => unlockVault.mutate()} variant="outline">
+            Request Unlock
+          </Button>
+          <Button disabled={isPending || !canLockVault} onClick={() => lockVault.mutate()} variant="outline">
+            Lock Vault
+          </Button>
+        </div>
+      </div>
+    </UiCard>
+  )
+}

--- a/packages/feature-dev/src/dev-features.tsx
+++ b/packages/feature-dev/src/dev-features.tsx
@@ -7,9 +7,11 @@ const DevFeatureError = lazy(() => import('./dev-feature-error.tsx'))
 const DevFeatureScratchPad = lazy(() => import('./dev-feature-scratch-pad.tsx'))
 const DevFeatureSolana = lazy(() => import('./dev-feature-solana.tsx'))
 const DevFeatureUi = lazy(() => import('./dev-feature-ui.tsx'))
+const DevFeatureVault = lazy(() => import('./dev-feature-vault.tsx'))
 
 export const devFeatures: UiTabRoute[] = [
   { element: <DevFeatureScratchPad />, label: 'Scratch Pad', path: 'scratch-pad' },
+  { element: <DevFeatureVault />, label: 'Vault', path: 'vault' },
   { element: <DevFeatureDb />, label: 'DB', path: 'db' },
   { element: <DevFeatureError />, label: 'Error', path: 'error' },
   { element: <DevFeatureSolana />, label: 'Solana', path: 'solana' },

--- a/packages/feature-shell/package.json
+++ b/packages/feature-shell/package.json
@@ -19,6 +19,7 @@
     "@workspace/flags": "workspace:*",
     "@workspace/i18n": "workspace:*",
     "@workspace/ui": "workspace:*",
+    "@workspace/vault-react": "workspace:*",
     "@wxt-dev/browser": "catalog:",
     "react-router": "catalog:"
   },

--- a/packages/feature-shell/src/data-access/shell-providers.tsx
+++ b/packages/feature-shell/src/data-access/shell-providers.tsx
@@ -5,6 +5,7 @@ import { AppContextProvider } from '@workspace/context-react/app-context-provide
 import { queryClient } from '@workspace/db-react/query-client'
 import { getEntrypoint } from '@workspace/env/get-entrypoint'
 import { Toaster } from '@workspace/ui/components/sonner'
+import { VaultUnlockProvider } from '@workspace/vault-react/vault-unlock-provider'
 import { browser } from '@wxt-dev/browser'
 import type { ReactNode } from 'react'
 import { lazy } from 'react'
@@ -41,14 +42,16 @@ export function ShellProviders({ children, ctx }: ShellProviderProps) {
   return (
     <PersistQueryClientProvider client={queryClient} persistOptions={{ persister }}>
       <AppContextProvider ctx={ctx}>
-        {children}
-        <Toaster
-          closeButton
-          mobileOffset={{ bottom: 'calc(env(safe-area-inset-bottom) + 5rem)' }}
-          offset={{ bottom: 'calc(env(safe-area-inset-bottom) + 5rem)' }}
-          richColors
-        />
-        {getEntrypoint() === 'sidepanel' ? <RequestFeatureDialog /> : null}
+        <VaultUnlockProvider>
+          {children}
+          <Toaster
+            closeButton
+            mobileOffset={{ bottom: 'calc(env(safe-area-inset-bottom) + 5rem)' }}
+            offset={{ bottom: 'calc(env(safe-area-inset-bottom) + 5rem)' }}
+            richColors
+          />
+          {getEntrypoint() === 'sidepanel' ? <RequestFeatureDialog /> : null}
+        </VaultUnlockProvider>
       </AppContextProvider>
     </PersistQueryClientProvider>
   )

--- a/packages/i18n/locales/en/vault-react.json
+++ b/packages/i18n/locales/en/vault-react.json
@@ -1,0 +1,14 @@
+{
+  "unlockDialogActionCancel": "Cancel",
+  "unlockDialogActionContinue": "Continue",
+  "unlockDialogConfirmPasswordLabel": "Confirm password",
+  "unlockDialogDefaultDescription": "Unlock to continue with this sensitive action.",
+  "unlockDialogDefaultTitle": "Unlock wallet",
+  "unlockDialogPasswordLabel": "Password",
+  "unlockDialogPasswordMaxLengthMessage": "Password must be at most {{passwordMaxLength, number}} characters",
+  "unlockDialogPasswordMinLengthMessage": "Password must be at least {{passwordMinLength, number}} characters",
+  "unlockDialogPasswordMismatchMessage": "Passwords do not match",
+  "unlockDialogPinLabel": "PIN",
+  "unlockDialogSetupDescription": "Create an app password once. You can add wallets later without repeating setup.",
+  "unlockDialogSetupTitle": "Create app password"
+}

--- a/packages/i18n/locales/es/vault-react.json
+++ b/packages/i18n/locales/es/vault-react.json
@@ -1,0 +1,14 @@
+{
+  "unlockDialogActionCancel": "Cancelar",
+  "unlockDialogActionContinue": "Continuar",
+  "unlockDialogConfirmPasswordLabel": "Confirmar contraseña",
+  "unlockDialogDefaultDescription": "Desbloquea para continuar con esta acción confidencial.",
+  "unlockDialogDefaultTitle": "Desbloquear billetera",
+  "unlockDialogPasswordLabel": "Contraseña",
+  "unlockDialogPasswordMaxLengthMessage": "La contraseña debe tener como máximo {{passwordMaxLength, number}} caracteres",
+  "unlockDialogPasswordMinLengthMessage": "La contraseña debe tener al menos {{passwordMinLength, number}} caracteres",
+  "unlockDialogPasswordMismatchMessage": "Las contraseñas no coinciden",
+  "unlockDialogPinLabel": "PIN",
+  "unlockDialogSetupDescription": "Crea una contraseña de app una vez. Puedes agregar billeteras más tarde sin repetir la configuración.",
+  "unlockDialogSetupTitle": "Crear contraseña de app"
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -11,6 +11,7 @@ import enSettings from '../locales/en/settings.json' with { type: 'json' }
 import enShell from '../locales/en/shell.json' with { type: 'json' }
 import enTranslation from '../locales/en/translation.json' with { type: 'json' }
 import enUi from '../locales/en/ui.json' with { type: 'json' }
+import enVaultReact from '../locales/en/vault-react.json' with { type: 'json' }
 import esDbReact from '../locales/es/db-react.json' with { type: 'json' }
 import esExplorer from '../locales/es/explorer.json' with { type: 'json' }
 import esOnboarding from '../locales/es/onboarding.json' with { type: 'json' }
@@ -19,6 +20,7 @@ import esSettings from '../locales/es/settings.json' with { type: 'json' }
 import esShell from '../locales/es/shell.json' with { type: 'json' }
 import esTranslation from '../locales/es/translation.json' with { type: 'json' }
 import esUi from '../locales/es/ui.json' with { type: 'json' }
+import esVaultReact from '../locales/es/vault-react.json' with { type: 'json' }
 
 i18n.use(initReactI18next).init({
   defaultNS: 'translation',
@@ -37,6 +39,7 @@ i18n.use(initReactI18next).init({
       shell: enShell,
       translation: enTranslation,
       ui: enUi,
+      'vault-react': enVaultReact,
     },
     es: {
       'db-react': esDbReact,
@@ -47,6 +50,7 @@ i18n.use(initReactI18next).init({
       shell: esShell,
       translation: esTranslation,
       ui: esUi,
+      'vault-react': esVaultReact,
     },
   },
 })

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -305,6 +305,20 @@ interface Resources {
     relativeDateYesterday: 'Yesterday'
     textCopyFailed: 'Failed to copy text'
   }
+  'vault-react': {
+    unlockDialogActionCancel: 'Cancel'
+    unlockDialogActionContinue: 'Continue'
+    unlockDialogConfirmPasswordLabel: 'Confirm password'
+    unlockDialogDefaultDescription: 'Unlock to continue with this sensitive action.'
+    unlockDialogDefaultTitle: 'Unlock wallet'
+    unlockDialogPasswordLabel: 'Password'
+    unlockDialogPasswordMaxLengthMessage: 'Password must be at most {{passwordMaxLength, number}} characters'
+    unlockDialogPasswordMinLengthMessage: 'Password must be at least {{passwordMinLength, number}} characters'
+    unlockDialogPasswordMismatchMessage: 'Passwords do not match'
+    unlockDialogPinLabel: 'PIN'
+    unlockDialogSetupDescription: 'Create an app password once. You can add wallets later without repeating setup.'
+    unlockDialogSetupTitle: 'Create app password'
+  }
 }
 
 export default Resources

--- a/packages/vault-react/package.json
+++ b/packages/vault-react/package.json
@@ -1,39 +1,35 @@
 {
   "dependencies": {
-    "@hookform/resolvers": "catalog:",
-    "@solana/kit": "catalog:",
     "@tanstack/react-query": "catalog:",
+    "@workspace/context": "workspace:*",
     "@workspace/context-react": "workspace:*",
-    "@workspace/db": "workspace:*",
-    "@workspace/db-react": "workspace:*",
-    "@workspace/feature-explorer": "workspace:*",
     "@workspace/i18n": "workspace:*",
-    "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
-    "@workspace/vault-react": "workspace:*",
-    "react-hook-form": "catalog:",
-    "react-router": "catalog:",
-    "zod": "catalog:"
+    "@workspace/vault": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@workspace/config-typescript": "workspace:*",
-    "typescript": "catalog:"
+    "@workspace/config-vitest": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "exports": {
     "./*": "./src/*.tsx"
   },
   "license": "MIT",
-  "name": "@workspace/feature-dev",
+  "name": "@workspace/vault-react",
   "peerDependencies": {
     "react": "catalog:",
     "react-dom": "catalog:"
   },
   "private": false,
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
   },
   "type": "module",
   "version": "0.0.0"

--- a/packages/vault-react/src/data-access/options-vault.ts
+++ b/packages/vault-react/src/data-access/options-vault.ts
@@ -1,0 +1,25 @@
+import { type MutateOptions, mutationOptions, queryOptions } from '@tanstack/react-query'
+import type { AppContext } from '@workspace/context/app-context'
+
+export type VaultLockMutateOptions = MutateOptions<void, Error, void>
+export type VaultStatus = { isConfigured: boolean; isUnlocked: boolean }
+
+export const vaultStatusQueryKey = ['vaultStatus'] as const
+
+export const optionsVault = {
+  lock: (context: AppContext, props: VaultLockMutateOptions = {}) =>
+    mutationOptions({
+      ...props,
+      mutationFn: async () => {
+        context.vault.lock()
+      },
+    }),
+  status: (context: AppContext) =>
+    queryOptions({
+      queryFn: async (): Promise<VaultStatus> => ({
+        isConfigured: await context.vault.isConfigured(),
+        isUnlocked: context.vault.isUnlocked(),
+      }),
+      queryKey: vaultStatusQueryKey,
+    }),
+}

--- a/packages/vault-react/src/data-access/use-vault-lock.ts
+++ b/packages/vault-react/src/data-access/use-vault-lock.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAppContext } from '@workspace/context-react/use-app-context'
+import { optionsVault, type VaultLockMutateOptions, vaultStatusQueryKey } from './options-vault.ts'
+
+export function useVaultLock(props: VaultLockMutateOptions = {}) {
+  const context = useAppContext()
+  const queryClient = useQueryClient()
+
+  return useMutation(
+    optionsVault.lock(context, {
+      ...props,
+      onSuccess: async (data, variables, onMutateResult, mutationContext) => {
+        await queryClient.invalidateQueries({ queryKey: vaultStatusQueryKey })
+        await props.onSuccess?.(data, variables, onMutateResult, mutationContext)
+      },
+    }),
+  )
+}

--- a/packages/vault-react/src/data-access/use-vault-status.ts
+++ b/packages/vault-react/src/data-access/use-vault-status.ts
@@ -1,0 +1,8 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAppContext } from '@workspace/context-react/use-app-context'
+import { optionsVault } from './options-vault.ts'
+
+export function useVaultStatus() {
+  const context = useAppContext()
+  return useQuery(optionsVault.status(context))
+}

--- a/packages/vault-react/src/data-access/use-vault-unlock-dialog-copy.ts
+++ b/packages/vault-react/src/data-access/use-vault-unlock-dialog-copy.ts
@@ -1,0 +1,17 @@
+import { useTranslation } from '@workspace/i18n'
+
+export function useVaultUnlockDialogCopy() {
+  const { t } = useTranslation('vault-react')
+
+  return {
+    actionCancel: t(($) => $.unlockDialogActionCancel),
+    actionContinue: t(($) => $.unlockDialogActionContinue),
+    confirmPasswordLabel: t(($) => $.unlockDialogConfirmPasswordLabel),
+    defaultDescription: t(($) => $.unlockDialogDefaultDescription),
+    defaultTitle: t(($) => $.unlockDialogDefaultTitle),
+    passwordLabel: t(($) => $.unlockDialogPasswordLabel),
+    pinLabel: t(($) => $.unlockDialogPinLabel),
+    setupDescription: t(($) => $.unlockDialogSetupDescription),
+    setupTitle: t(($) => $.unlockDialogSetupTitle),
+  }
+}

--- a/packages/vault-react/src/data-access/use-vault-unlock-dialog.ts
+++ b/packages/vault-react/src/data-access/use-vault-unlock-dialog.ts
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react'
+
+export type VaultUnlockMode = 'password' | 'pin' | 'unsecured'
+
+export type VaultUnlockReason =
+  | 'createWallet'
+  | 'exportAccountSecretKey'
+  | 'exportWalletMnemonic'
+  | 'generic'
+  | 'signRequest'
+  | 'walletProtection'
+
+export type VaultUnlockRequest = {
+  description?: string | undefined
+  mode?: VaultUnlockMode | undefined
+  reason?: VaultUnlockReason | undefined
+  title?: string | undefined
+  walletId?: string | undefined
+}
+
+export type VaultUnlockDialogContext = {
+  requestUnlock(input?: VaultUnlockRequest): Promise<boolean>
+}
+
+export const VaultUnlockDialogReact = createContext<VaultUnlockDialogContext | null>(null)
+
+export function useVaultUnlockDialog(): VaultUnlockDialogContext {
+  const value = useContext(VaultUnlockDialogReact)
+  if (!value) {
+    throw new Error('VaultUnlockProvider is missing')
+  }
+  return value
+}

--- a/packages/vault-react/src/data-access/use-vault-unlock-provider.ts
+++ b/packages/vault-react/src/data-access/use-vault-unlock-provider.ts
@@ -1,0 +1,232 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useAppContext } from '@workspace/context-react/use-app-context'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { optionsVault, vaultStatusQueryKey } from './options-vault.ts'
+import type { VaultUnlockDialogContext, VaultUnlockRequest } from './use-vault-unlock-dialog.ts'
+import { useVaultUnlockDialogCopy } from './use-vault-unlock-dialog-copy.ts'
+import { submitVaultPassword } from './vault-password-submit.ts'
+
+export interface VaultUnlockDialogActions {
+  cancel(): void
+  changeConfirmPassword(value: string): void
+  changeCredential(value: string): void
+  changeOpen(open: boolean): void
+  submit(): void
+}
+
+export interface VaultUnlockDialogState {
+  cancelLabel: string
+  confirmPassword: string
+  confirmPasswordLabel: string
+  credential: string
+  credentialInputType: 'password' | 'text'
+  credentialLabel: string
+  description: string
+  error: string | null
+  isOpen: boolean
+  isSetupMode: boolean
+  isSubmitting: boolean
+  submitLabel: string
+  title: string
+}
+
+export interface VaultUnlockProviderValue {
+  actions: VaultUnlockDialogActions
+  contextValue: VaultUnlockDialogContext
+  state: VaultUnlockDialogState
+}
+
+type PendingVaultUnlockRequest = Required<Pick<VaultUnlockRequest, 'mode'>> &
+  Omit<VaultUnlockRequest, 'mode'> & {
+    resolve: (value: boolean) => void
+  }
+
+type VaultUnlockSubmitInput = {
+  confirmPassword: string
+  credential: string
+  pending: PendingVaultUnlockRequest
+  setupMode: boolean
+}
+
+export function useVaultUnlockProvider(): VaultUnlockProviderValue {
+  const context = useAppContext()
+  const copy = useVaultUnlockDialogCopy()
+  const pendingRef = useRef<PendingVaultUnlockRequest | null>(null)
+  const queryClient = useQueryClient()
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [credential, setCredential] = useState('')
+  const [pending, setPending] = useState<PendingVaultUnlockRequest | null>(null)
+  const [setupMode, setSetupMode] = useState(false)
+  const {
+    error: unlockError,
+    isPending: isSubmitting,
+    mutate: submitUnlock,
+    reset: resetSubmitUnlock,
+  } = useMutation({
+    mutationFn: async ({ confirmPassword, credential, pending, setupMode }: VaultUnlockSubmitInput) => {
+      if (setupMode || pending.mode === 'password') {
+        await submitVaultPassword(context.vault, {
+          confirmPassword: setupMode ? confirmPassword : undefined,
+          password: credential,
+        })
+      } else {
+        if (!pending.walletId) {
+          throw new Error('Wallet id is required')
+        }
+        await context.vault.unlockWallet({ credential, walletId: pending.walletId })
+      }
+      await queryClient.invalidateQueries({ queryKey: vaultStatusQueryKey })
+    },
+  })
+
+  const resetForm = useCallback(() => {
+    setConfirmPassword('')
+    setCredential('')
+    resetSubmitUnlock()
+    setSetupMode(false)
+  }, [resetSubmitUnlock])
+
+  const close = useCallback(
+    (value: boolean) => {
+      const request = pendingRef.current
+      pendingRef.current = null
+      setPending(null)
+      resetForm()
+      request?.resolve(value)
+    },
+    [resetForm],
+  )
+
+  const resetSubmitError = useCallback(() => {
+    if (!isSubmitting) {
+      resetSubmitUnlock()
+    }
+  }, [isSubmitting, resetSubmitUnlock])
+
+  const changeConfirmPassword = useCallback(
+    (value: string) => {
+      setConfirmPassword(value)
+      resetSubmitError()
+    },
+    [resetSubmitError],
+  )
+
+  const changeCredential = useCallback(
+    (value: string) => {
+      setCredential(value)
+      resetSubmitError()
+    },
+    [resetSubmitError],
+  )
+
+  const changeOpen = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        close(false)
+      }
+    },
+    [close],
+  )
+
+  const requestUnlock = useCallback(
+    async (input: VaultUnlockRequest = {}): Promise<boolean> => {
+      const mode = input.mode ?? 'password'
+
+      if (mode === 'unsecured') {
+        if (!input.walletId) {
+          return true
+        }
+        try {
+          await context.vault.unlockWallet({ credential: '', walletId: input.walletId })
+          return true
+        } catch {
+          return false
+        }
+      }
+
+      if (input.walletId) {
+        try {
+          await context.vault.requireWalletKey({ walletId: input.walletId })
+          return true
+        } catch {
+          // Continue into the dialog.
+        }
+      } else if (mode === 'password' && context.vault.isUnlocked()) {
+        return true
+      }
+
+      // requestUnlock is single-flight: pendingRef.current means another dialog is already open, so
+      // return false to mark this request as ignored rather than queueing subsequent requests.
+      if (pendingRef.current) {
+        return false
+      }
+
+      const request: PendingVaultUnlockRequest = {
+        ...input,
+        mode,
+        resolve: () => undefined,
+      }
+      const promise = new Promise<boolean>((resolve) => {
+        request.resolve = resolve
+      })
+
+      pendingRef.current = request
+
+      try {
+        const status = await queryClient.fetchQuery(optionsVault.status(context))
+        setSetupMode(!status.isConfigured)
+        setPending(request)
+      } catch (error) {
+        pendingRef.current = null
+        setPending(null)
+        request.resolve(false)
+        throw error
+      }
+
+      return promise
+    },
+    [context, queryClient],
+  )
+
+  const submit = useCallback(() => {
+    if (!pending || isSubmitting) {
+      return
+    }
+
+    submitUnlock(
+      { confirmPassword, credential, pending, setupMode },
+      {
+        onSuccess: () => close(true),
+      },
+    )
+  }, [close, confirmPassword, credential, isSubmitting, pending, setupMode, submitUnlock])
+
+  const contextValue = useMemo<VaultUnlockDialogContext>(() => ({ requestUnlock }), [requestUnlock])
+  const error = unlockError ? (unlockError instanceof Error ? unlockError.message : 'Unable to unlock') : null
+
+  return {
+    actions: {
+      cancel: () => close(false),
+      changeConfirmPassword,
+      changeCredential,
+      changeOpen,
+      submit,
+    },
+    contextValue,
+    state: {
+      cancelLabel: copy.actionCancel,
+      confirmPassword,
+      confirmPasswordLabel: copy.confirmPasswordLabel,
+      credential,
+      credentialInputType: pending?.mode === 'pin' ? 'text' : 'password',
+      credentialLabel: pending?.mode === 'pin' ? copy.pinLabel : copy.passwordLabel,
+      description: setupMode ? copy.setupDescription : (pending?.description ?? copy.defaultDescription),
+      error,
+      isOpen: Boolean(pending),
+      isSetupMode: setupMode,
+      isSubmitting,
+      submitLabel: copy.actionContinue,
+      title: setupMode ? copy.setupTitle : (pending?.title ?? copy.defaultTitle),
+    },
+  }
+}

--- a/packages/vault-react/src/data-access/vault-password-submit.ts
+++ b/packages/vault-react/src/data-access/vault-password-submit.ts
@@ -1,0 +1,40 @@
+import { i18n } from '@workspace/i18n'
+import { VAULT_PASSWORD_MAX_LENGTH, VAULT_PASSWORD_MIN_LENGTH } from '@workspace/vault/encrypted-value-schema'
+import type { Vault } from '@workspace/vault/vault'
+
+export type VaultPasswordSubmitInput = {
+  confirmPassword?: string | undefined
+  password: string
+  passwordMaxLength?: number | undefined
+  passwordMinLength?: number | undefined
+}
+
+export type VaultPasswordSubmitResult = 'configured' | 'unlocked'
+
+export async function submitVaultPassword(
+  vault: Vault,
+  {
+    confirmPassword,
+    password,
+    passwordMaxLength = VAULT_PASSWORD_MAX_LENGTH,
+    passwordMinLength = VAULT_PASSWORD_MIN_LENGTH,
+  }: VaultPasswordSubmitInput,
+): Promise<VaultPasswordSubmitResult> {
+  if (await vault.isConfigured()) {
+    await vault.unlock({ password })
+    return 'unlocked'
+  }
+
+  if (password.length < passwordMinLength) {
+    throw new Error(i18n.t(($) => $.unlockDialogPasswordMinLengthMessage, { ns: 'vault-react', passwordMinLength }))
+  }
+  if (password.length > passwordMaxLength) {
+    throw new Error(i18n.t(($) => $.unlockDialogPasswordMaxLengthMessage, { ns: 'vault-react', passwordMaxLength }))
+  }
+  if (confirmPassword !== undefined && password !== confirmPassword) {
+    throw new Error(i18n.t(($) => $.unlockDialogPasswordMismatchMessage, { ns: 'vault-react' }))
+  }
+
+  await vault.create({ password })
+  return 'configured'
+}

--- a/packages/vault-react/src/ui/vault-ui-unlock-dialog.tsx
+++ b/packages/vault-react/src/ui/vault-ui-unlock-dialog.tsx
@@ -1,0 +1,107 @@
+import { Alert, AlertDescription } from '@workspace/ui/components/alert'
+import { Button } from '@workspace/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@workspace/ui/components/dialog'
+import { Input } from '@workspace/ui/components/input'
+import { Label } from '@workspace/ui/components/label'
+import type { ChangeEvent, FormEvent } from 'react'
+import { useId } from 'react'
+import type { VaultUnlockDialogActions, VaultUnlockDialogState } from '../data-access/use-vault-unlock-provider.ts'
+
+export type VaultUiUnlockDialogProps = {
+  actions: VaultUnlockDialogActions
+  state: VaultUnlockDialogState
+}
+
+export function VaultUiUnlockDialog({
+  actions: { cancel, changeConfirmPassword, changeCredential, changeOpen, submit: submitUnlock },
+  state: {
+    cancelLabel,
+    confirmPassword,
+    confirmPasswordLabel,
+    credential,
+    credentialInputType,
+    credentialLabel,
+    description,
+    error,
+    isOpen,
+    isSetupMode,
+    isSubmitting,
+    submitLabel,
+    title,
+  },
+}: VaultUiUnlockDialogProps) {
+  const confirmPasswordId = useId()
+  const credentialId = useId()
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (isSubmitting) {
+      return
+    }
+    submitUnlock()
+  }
+
+  function updateConfirmPassword(event: ChangeEvent<HTMLInputElement>) {
+    changeConfirmPassword(event.target.value)
+  }
+
+  function updateCredential(event: ChangeEvent<HTMLInputElement>) {
+    changeCredential(event.target.value)
+  }
+
+  return (
+    <Dialog onOpenChange={changeOpen} open={isOpen}>
+      <DialogContent>
+        <form className="space-y-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor={credentialId}>{credentialLabel}</Label>
+            <Input
+              autoComplete={isSetupMode ? 'new-password' : 'current-password'}
+              autoFocus
+              id={credentialId}
+              onChange={updateCredential}
+              type={credentialInputType}
+              value={credential}
+            />
+          </div>
+          {isSetupMode ? (
+            <div className="space-y-2">
+              <Label htmlFor={confirmPasswordId}>{confirmPasswordLabel}</Label>
+              <Input
+                autoComplete="new-password"
+                id={confirmPasswordId}
+                onChange={updateConfirmPassword}
+                type="password"
+                value={confirmPassword}
+              />
+            </div>
+          ) : null}
+          {error ? (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+          <DialogFooter>
+            <Button disabled={isSubmitting} onClick={cancel} type="button" variant="outline">
+              {cancelLabel}
+            </Button>
+            <Button disabled={isSubmitting} type="submit">
+              {submitLabel}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/vault-react/src/vault-unlock-provider.tsx
+++ b/packages/vault-react/src/vault-unlock-provider.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+import { VaultUnlockDialogReact } from './data-access/use-vault-unlock-dialog.ts'
+import { useVaultUnlockProvider } from './data-access/use-vault-unlock-provider.ts'
+import { VaultUiUnlockDialog } from './ui/vault-ui-unlock-dialog.tsx'
+
+export { useVaultLock } from './data-access/use-vault-lock.ts'
+export { useVaultStatus } from './data-access/use-vault-status.ts'
+export {
+  useVaultUnlockDialog,
+  type VaultUnlockDialogContext,
+  type VaultUnlockMode,
+  type VaultUnlockReason,
+  type VaultUnlockRequest,
+} from './data-access/use-vault-unlock-dialog.ts'
+
+export function VaultUnlockProvider({ children }: { children: ReactNode }) {
+  const { actions, contextValue, state } = useVaultUnlockProvider()
+
+  return (
+    <VaultUnlockDialogReact.Provider value={contextValue}>
+      {children}
+      <VaultUiUnlockDialog actions={actions} state={state} />
+    </VaultUnlockDialogReact.Provider>
+  )
+}

--- a/packages/vault-react/test/vault-password-submit.test.ts
+++ b/packages/vault-react/test/vault-password-submit.test.ts
@@ -1,0 +1,137 @@
+import { VAULT_PASSWORD_MAX_LENGTH } from '@workspace/vault/encrypted-value-schema'
+import { createVault, type VaultStorage } from '@workspace/vault/vault'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { submitVaultPassword } from '../src/data-access/vault-password-submit.ts'
+
+let vaultKey: string | undefined
+
+const storage: VaultStorage = {
+  async getVaultKey() {
+    return vaultKey
+  },
+  async getWalletProtection() {
+    throw new Error('Wallet protection is not configured')
+  },
+  async setVaultKey(value) {
+    vaultKey = value
+  },
+}
+
+describe('submit-vault-password', () => {
+  beforeEach(() => {
+    vaultKey = undefined
+  })
+
+  describe('expected behavior', () => {
+    it('should create a vault when one is not configured', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const vault = createVault(storage)
+
+      // ACT
+      const result = await submitVaultPassword(vault, {
+        confirmPassword: 'password-one',
+        password: 'password-one',
+      })
+
+      // ASSERT
+      expect(result).toBe('configured')
+      expect(vaultKey).toBeDefined()
+      expect(vault.isUnlocked()).toBe(true)
+    })
+
+    it('should create a vault without a confirm password when one is not configured', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const vault = createVault(storage)
+
+      // ACT
+      const result = await submitVaultPassword(vault, { password: 'password-one' })
+
+      // ASSERT
+      expect(result).toBe('configured')
+      expect(vaultKey).toBeDefined()
+      expect(vault.isUnlocked()).toBe(true)
+    })
+
+    it('should unlock a configured vault', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const vault1 = createVault(storage)
+      await vault1.create({ password: 'password-one' })
+      vault1.lock()
+      const vault2 = createVault(storage)
+
+      // ACT
+      const result = await submitVaultPassword(vault2, { password: 'password-one' })
+
+      // ASSERT
+      expect(result).toBe('unlocked')
+      expect(vault2.isUnlocked()).toBe(true)
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should reject mismatched setup passwords', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const vault = createVault(storage)
+
+      // ACT & ASSERT
+      await expect(
+        submitVaultPassword(vault, {
+          confirmPassword: 'password-two',
+          password: 'password-one',
+        }),
+      ).rejects.toThrow('Passwords do not match')
+    })
+
+    it('should reject short setup passwords', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const vault = createVault(storage)
+
+      // ACT & ASSERT
+      await expect(
+        submitVaultPassword(vault, {
+          confirmPassword: 'short',
+          password: 'short',
+        }),
+      ).rejects.toThrow('Password must be at least 8 characters')
+    })
+
+    it('should reject long setup passwords', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const password = 'a'.repeat(VAULT_PASSWORD_MAX_LENGTH + 1)
+      const vault = createVault(storage)
+
+      // ACT & ASSERT
+      await expect(
+        submitVaultPassword(vault, {
+          confirmPassword: password,
+          password,
+        }),
+      ).rejects.toThrow(`Password must be at most ${VAULT_PASSWORD_MAX_LENGTH} characters`)
+    })
+
+    it('should reject the wrong unlock password', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const vault = createVault(storage)
+      await vault.create({ password: 'password-one' })
+      vault.lock()
+
+      // ACT & ASSERT
+      await expect(submitVaultPassword(vault, { password: 'wrong-password' })).rejects.toThrow('Unable to unlock vault')
+    })
+  })
+})

--- a/packages/vault-react/tsconfig.json
+++ b/packages/vault-react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "extends": "@workspace/config-typescript/react-library.json",
+  "include": ["src", "test"]
+}

--- a/packages/vault-react/vitest.config.ts
+++ b/packages/vault-react/vitest.config.ts
@@ -1,0 +1,4 @@
+import { sharedConfig } from '@workspace/config-vitest'
+import { defineProject, mergeConfig } from 'vitest/config'
+
+export default mergeConfig(sharedConfig, defineProject({}))


### PR DESCRIPTION
Introduce @workspace/vault-react with a provider-managed unlock dialog and password submission flow.

Mount the provider in the shell and add a dev scratch-pad card for exercising lock and unlock states.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault package added with unlock/lock UI, dialog, provider and hooks; provider now wraps relevant UI and is integrated into the app.
  * Dev panel gains a Vault tab/card showing Configured/Unlocked state with Request Unlock and Lock actions and toast feedback.

* **Tests**
  * Unit tests for vault password submission covering setup, unlock, and validation/error cases.

* **Chores**
  * English and Spanish localization added for vault dialog.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/samui-build/samui-wallet/pull/1045)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->