### PR TITLE
feat: add per-wallet protection primitives

### DIFF
--- a/cspell.config.mts
+++ b/cspell.config.mts
@@ -62,6 +62,7 @@ const config: CSpellSettings = {
     'netinfo',
     'nvmrc',
     'nums',
+    'reprotect',
     'rtishchev',
     'samui',
     'seti',

--- a/packages/db-react/src/options-wallet.tsx
+++ b/packages/db-react/src/options-wallet.tsx
@@ -6,6 +6,7 @@ import { walletDelete } from '@workspace/db/wallet/wallet-delete'
 import { walletFindMany } from '@workspace/db/wallet/wallet-find-many'
 import type { WalletFindManyInput } from '@workspace/db/wallet/wallet-find-many-input'
 import { walletReadMnemonic } from '@workspace/db/wallet/wallet-read-mnemonic'
+import { type WalletReprotectInput, walletReprotect } from '@workspace/db/wallet/wallet-reprotect'
 import { walletUpdate } from '@workspace/db/wallet/wallet-update'
 import type { WalletUpdateInput } from '@workspace/db/wallet/wallet-update-input'
 import { walletUpdateOrder } from '@workspace/db/wallet/wallet-update-order'
@@ -16,6 +17,7 @@ import { queryClient } from './query-client.tsx'
 export type WalletCreateMutateOptions = MutateOptions<string, Error, { input: WalletCreateInput }>
 export type WalletDeleteMutateOptions = MutateOptions<void, Error, { id: string }>
 export type WalletReadMnemonicMutateOptions = MutateOptions<string, Error, { id: string }>
+export type WalletReprotectMutateOptions = MutateOptions<void, Error, WalletReprotectInput>
 export type WalletUpdateMutateOptions = MutateOptions<number, Error, { id: string; input: WalletUpdateInput }>
 export type WalletUpdateOrderMutateOptions = MutateOptions<void, Error, { input: WalletUpdateOrderInput }>
 
@@ -45,6 +47,14 @@ export const optionsWallet = {
   readMnemonic: (ctx: DbContext, props: WalletReadMnemonicMutateOptions = {}) =>
     mutationOptions({
       mutationFn: ({ id }: { id: string }) => walletReadMnemonic(ctx, id),
+      ...props,
+    }),
+  reprotect: (ctx: DbContext, props: WalletReprotectMutateOptions = {}) =>
+    mutationOptions({
+      mutationFn: (input: WalletReprotectInput) => walletReprotect(ctx, input),
+      onSuccess: () => {
+        queryClient.invalidateQueries(optionsWallet.findMany(ctx, {}))
+      },
       ...props,
     }),
   update: (ctx: DbContext, props: WalletUpdateMutateOptions = {}) =>

--- a/packages/db-react/src/use-wallet-reprotect.tsx
+++ b/packages/db-react/src/use-wallet-reprotect.tsx
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query'
+import { useAppContext } from '@workspace/context-react/use-app-context'
+import type { WalletReprotectMutateOptions } from './options-wallet.tsx'
+import { optionsWallet } from './options-wallet.tsx'
+
+export function useWalletReprotect(props: WalletReprotectMutateOptions = {}) {
+  const ctx = useAppContext()
+  return useMutation(optionsWallet.reprotect(ctx, props))
+}

--- a/packages/db/src/wallet/wallet-create-schema.ts
+++ b/packages/db/src/wallet/wallet-create-schema.ts
@@ -1,10 +1,31 @@
+import { VAULT_PIN_MAX_LENGTH, VAULT_PIN_MIN_LENGTH } from '@workspace/vault/encrypted-value-schema'
+import { z } from 'zod'
 import { walletInternalSchema } from './wallet-internal-schema.ts'
 
-export const walletCreateSchema = walletInternalSchema.omit({
-  accounts: true,
-  createdAt: true,
-  id: true,
-  order: true,
-  secret: true,
-  updatedAt: true,
-})
+const pinDigitsRegex = /^\d+$/
+
+export const walletCreateSchema = walletInternalSchema
+  .omit({
+    accounts: true,
+    createdAt: true,
+    id: true,
+    order: true,
+    secret: true,
+    updatedAt: true,
+  })
+  .extend({
+    protection: z
+      .discriminatedUnion('mode', [
+        z.object({ mode: z.literal('password') }),
+        z.object({
+          mode: z.literal('pin'),
+          pin: z
+            .string()
+            .regex(pinDigitsRegex, 'PIN must contain only digits')
+            .min(VAULT_PIN_MIN_LENGTH, `PIN must be at least ${VAULT_PIN_MIN_LENGTH} digits`)
+            .max(VAULT_PIN_MAX_LENGTH, `PIN must be at most ${VAULT_PIN_MAX_LENGTH} digits`),
+        }),
+        z.object({ mode: z.literal('unsecured') }),
+      ])
+      .optional(),
+  })

--- a/packages/db/src/wallet/wallet-create.ts
+++ b/packages/db/src/wallet/wallet-create.ts
@@ -1,6 +1,12 @@
 import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import { encryptWithVaultKey } from '@workspace/vault/encrypted-value'
-import { createPasswordWalletProtection } from '@workspace/vault/wallet-protection'
+import {
+  createPasswordWalletProtection,
+  createPinWalletProtection,
+  createUnsecuredWalletProtection,
+  unlockPinWalletProtection,
+  unlockUnsecuredWalletProtection,
+} from '@workspace/vault/wallet-protection'
 import type { DbContext } from '../db-context.ts'
 import { randomId } from '../random-id.ts'
 import { walletCreateDetermineOrder } from './wallet-create-determine-order.ts'
@@ -10,7 +16,10 @@ import { walletCreateSchema } from './wallet-create-schema.ts'
 export async function walletCreate(ctx: DbContext, input: WalletCreateInput): Promise<string> {
   const now = new Date()
   const parsedInput = walletCreateSchema.parse(input)
-  const key = ctx.vault.requireDefaultKey()
+  const { key, protection } = await createWalletProtection({
+    protection: parsedInput.protection,
+    requireDefaultKey: () => ctx.vault.requireDefaultKey(),
+  })
   const mnemonic = await encryptWithVaultKey({ key, value: parsedInput.mnemonic })
 
   return ctx.db.transaction('rw', ctx.db.wallets, ctx.db.settings, ctx.db.accounts, async () => {
@@ -27,10 +36,30 @@ export async function walletCreate(ctx: DbContext, input: WalletCreateInput): Pr
         mnemonic,
         name: parsedInput.name,
         order,
-        secret: createPasswordWalletProtection(),
+        secret: protection,
         updatedAt: now,
       }),
       `Error creating wallet`,
     )
   })
+}
+
+async function createWalletProtection(input: {
+  protection: WalletCreateInput['protection']
+  requireDefaultKey: () => CryptoKey
+}): Promise<{ key: CryptoKey; protection: string }> {
+  switch (input.protection?.mode) {
+    case 'password':
+      return { key: input.requireDefaultKey(), protection: createPasswordWalletProtection() }
+    case 'pin': {
+      const protection = await createPinWalletProtection({ pin: input.protection.pin })
+      return { key: await unlockPinWalletProtection({ pin: input.protection.pin, protection }), protection }
+    }
+    case 'unsecured': {
+      const protection = createUnsecuredWalletProtection()
+      return { key: await unlockUnsecuredWalletProtection({ protection }), protection }
+    }
+    default:
+      return { key: input.requireDefaultKey(), protection: createPasswordWalletProtection() }
+  }
 }

--- a/packages/db/src/wallet/wallet-find-many.ts
+++ b/packages/db/src/wallet/wallet-find-many.ts
@@ -5,6 +5,7 @@ import type { Wallet } from './wallet.ts'
 import type { WalletFindManyInput } from './wallet-find-many-input.ts'
 
 import { walletFindManySchema } from './wallet-find-many-schema.ts'
+import { walletSanitizer } from './wallet-sanitizer.ts'
 
 export async function walletFindMany(ctx: DbContext, input: WalletFindManyInput = {}): Promise<Wallet[]> {
   const parsedInput = walletFindManySchema.parse(input)
@@ -19,6 +20,7 @@ export async function walletFindMany(ctx: DbContext, input: WalletFindManyInput 
 
             return matchId && matchName
           })
+          .raw()
           .toArray(),
         `Error finding wallets`,
       ),
@@ -26,8 +28,9 @@ export async function walletFindMany(ctx: DbContext, input: WalletFindManyInput 
     ])
     return [
       ...dataWallets.map((wallet) => {
+        const sanitizedWallet = walletSanitizer(wallet)
         return {
-          ...wallet,
+          ...sanitizedWallet,
           accounts: dataAccounts.filter((account) => account.walletId === wallet.id),
         }
       }),

--- a/packages/db/src/wallet/wallet-find-unique.ts
+++ b/packages/db/src/wallet/wallet-find-unique.ts
@@ -2,10 +2,14 @@ import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 
 import type { DbContext } from '../db-context.ts'
 import type { Wallet } from './wallet.ts'
+import { walletSanitizer } from './wallet-sanitizer.ts'
 
 export async function walletFindUnique(ctx: DbContext, id: string): Promise<Wallet | null> {
   return ctx.db.transaction('r', ctx.db.wallets, async () => {
-    const data = await tryCatchOrThrow(ctx.db.wallets.get(id), `Error finding wallet with id ${id}`)
-    return data ?? null
+    const data = await tryCatchOrThrow(
+      ctx.db.wallets.where('id').equals(id).raw().first(),
+      `Error finding wallet with id ${id}`,
+    )
+    return data ? walletSanitizer(data) : null
   })
 }

--- a/packages/db/src/wallet/wallet-reprotect.ts
+++ b/packages/db/src/wallet/wallet-reprotect.ts
@@ -1,0 +1,74 @@
+import { decryptWithVaultKey, encryptWithVaultKey } from '@workspace/vault/encrypted-value'
+import {
+  createPasswordWalletProtection,
+  createPinWalletProtection,
+  createUnsecuredWalletProtection,
+  unlockPinWalletProtection,
+  unlockUnsecuredWalletProtection,
+} from '@workspace/vault/wallet-protection'
+import { Dexie } from 'dexie'
+import type { DbContext } from '../db-context.ts'
+
+export interface WalletReprotectInput {
+  protection: { mode: 'password' } | { mode: 'pin'; pin: string } | { mode: 'unsecured' }
+  walletId: string
+}
+
+export async function walletReprotect(ctx: DbContext, input: WalletReprotectInput): Promise<void> {
+  const { db, vault } = ctx
+
+  await db.transaction('rw', db.accounts, db.wallets, async () => {
+    const wallet = await db.wallets.where('id').equals(input.walletId).raw().first()
+    if (!wallet) {
+      throw new Error(`Wallet with id ${input.walletId} not found`)
+    }
+
+    const accounts = await db.accounts.where('walletId').equals(input.walletId).raw().toArray()
+    const currentKey = await Dexie.waitFor(vault.requireWalletKey({ walletId: input.walletId }))
+    const mnemonic = await Dexie.waitFor(decryptWithVaultKey({ encrypted: wallet.mnemonic, key: currentKey }))
+    const accountSecrets = await Dexie.waitFor(
+      Promise.all(
+        accounts.map(async (account) => ({
+          id: account.id,
+          secretKey: account.secretKey
+            ? await decryptWithVaultKey({ encrypted: account.secretKey, key: currentKey })
+            : undefined,
+        })),
+      ),
+    )
+    const target = await Dexie.waitFor(createTargetProtection({ protection: input.protection, vault }))
+
+    await db.wallets.update(input.walletId, {
+      mnemonic: await Dexie.waitFor(encryptWithVaultKey({ key: target.key, value: mnemonic })),
+      secret: target.protection,
+    })
+
+    for (const account of accountSecrets) {
+      if (!account.secretKey) {
+        continue
+      }
+      await db.accounts.update(account.id, {
+        secretKey: await Dexie.waitFor(encryptWithVaultKey({ key: target.key, value: account.secretKey })),
+      })
+    }
+  })
+  vault.clearWalletKey({ walletId: input.walletId })
+}
+
+async function createTargetProtection(input: {
+  protection: WalletReprotectInput['protection']
+  vault: DbContext['vault']
+}): Promise<{ key: CryptoKey; protection: string }> {
+  switch (input.protection.mode) {
+    case 'password':
+      return { key: input.vault.requireDefaultKey(), protection: createPasswordWalletProtection() }
+    case 'pin': {
+      const protection = await createPinWalletProtection({ pin: input.protection.pin })
+      return { key: await unlockPinWalletProtection({ pin: input.protection.pin, protection }), protection }
+    }
+    case 'unsecured': {
+      const protection = createUnsecuredWalletProtection()
+      return { key: await unlockUnsecuredWalletProtection({ protection }), protection }
+    }
+  }
+}

--- a/packages/db/src/wallet/wallet-sanitizer.ts
+++ b/packages/db/src/wallet/wallet-sanitizer.ts
@@ -1,7 +1,20 @@
+import type { WalletProtectionMode } from '@workspace/vault/encrypted-value-schema'
+import { walletProtectionSchema } from '@workspace/vault/wallet-protection-schema'
 import type { Wallet } from './wallet.ts'
 import type { WalletInternal } from './wallet-internal.ts'
-import { walletSchema } from './wallet-schema.ts'
+import { walletBaseSchema, walletSchema } from './wallet-schema.ts'
 
 export function walletSanitizer(internal: WalletInternal): Wallet {
-  return walletSchema.parse(internal)
+  return walletSchema.parse({
+    ...walletBaseSchema.parse(internal),
+    protectionMode: parseWalletProtectionMode(internal.secret),
+  })
+}
+
+function parseWalletProtectionMode(value: string): WalletProtectionMode {
+  try {
+    return walletProtectionSchema.parse(JSON.parse(value)).mode
+  } catch {
+    return 'password'
+  }
 }

--- a/packages/db/src/wallet/wallet-schema.ts
+++ b/packages/db/src/wallet/wallet-schema.ts
@@ -1,6 +1,11 @@
+import { walletProtectionModeSchema } from '@workspace/vault/encrypted-value-schema'
 import { walletInternalSchema } from './wallet-internal-schema.ts'
 
-export const walletSchema = walletInternalSchema.omit({
+export const walletBaseSchema = walletInternalSchema.omit({
   mnemonic: true,
   secret: true,
+})
+
+export const walletSchema = walletBaseSchema.extend({
+  protectionMode: walletProtectionModeSchema,
 })

--- a/packages/db/src/wallet/wallet-update-order.ts
+++ b/packages/db/src/wallet/wallet-update-order.ts
@@ -1,6 +1,6 @@
 import { tryCatchOrThrow } from '@workspace/core/try-catch-or-throw'
 import type { DbContext } from '../db-context.ts'
-import type { Wallet } from './wallet.ts'
+import type { WalletInternal } from './wallet-internal.ts'
 import type { WalletUpdateOrderInput } from './wallet-update-order-input.ts'
 import { walletUpdateOrderSchema } from './wallet-update-order-schema.ts'
 
@@ -32,7 +32,7 @@ export async function walletUpdateOrder(ctx: DbContext, input: WalletUpdateOrder
       ctx.db.wallets
         .where('order')
         .between(lower, upper, true, true)
-        .modify((wallet: Wallet) => {
+        .modify((wallet: WalletInternal) => {
           wallet.order = increment ? wallet.order + 1 : wallet.order - 1
         }),
       `Error updating wallet order (${increment ? 'increment' : 'decrement'})`,

--- a/packages/db/test/account-read-secret-key.test.ts
+++ b/packages/db/test/account-read-secret-key.test.ts
@@ -35,6 +35,38 @@ describe('account-read-secret-key', () => {
       // ASSERT
       expect(result).toBe(accountInput.secretKey)
     })
+
+    it('should read an unsecured wallet account while the vault is locked', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletId = await walletCreate(ctx, testWalletCreateInput({ protection: { mode: 'unsecured' } }))
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const id = await accountCreate(ctx, accountInput)
+      ctx.vault.lock()
+
+      // ACT
+      const result = await accountReadSecretKey(ctx, id)
+
+      // ASSERT
+      expect(result).toBe(accountInput.secretKey)
+    })
+
+    it('should read a PIN wallet account after unlocking the wallet', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletId = await walletCreate(ctx, testWalletCreateInput({ protection: { mode: 'pin', pin: '1234' } }))
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const id = await accountCreate(ctx, accountInput)
+      ctx.vault.lock()
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+
+      // ACT
+      const result = await accountReadSecretKey(ctx, id)
+
+      // ASSERT
+      expect(result).toBe(accountInput.secretKey)
+    })
   })
 
   describe('unexpected behavior', () => {
@@ -65,6 +97,18 @@ describe('account-read-secret-key', () => {
 
       // ACT & ASSERT
       await expect(accountReadSecretKey(ctx, id)).rejects.toThrow('Vault is locked')
+    })
+
+    it('should throw an error if a PIN wallet account is locked', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletId = await walletCreate(ctx, testWalletCreateInput({ protection: { mode: 'pin', pin: '1234' } }))
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+      const id = await accountCreate(ctx, testAccountCreateInput({ walletId }))
+      ctx.vault.lock()
+
+      // ACT & ASSERT
+      await expect(accountReadSecretKey(ctx, id)).rejects.toThrow('Wallet is locked')
     })
 
     it('should throw an error if the account is of type Watched', async () => {

--- a/packages/db/test/wallet-create.test.ts
+++ b/packages/db/test/wallet-create.test.ts
@@ -48,6 +48,43 @@ describe('wallet-create', () => {
       expect(item?.description).toBe(input.description)
       expect(item?.name).toBe(input.name)
     })
+
+    it('should create a PIN-protected wallet without requiring the default vault key', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      ctx.vault.lock()
+      const input = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'pin', pin: '1234' } })
+
+      // ACT
+      const result = await walletCreate(ctx, input)
+
+      // ASSERT
+      const raw = await ctx.db.wallets.where('id').equals(result).raw().first()
+      const protection = JSON.parse(raw?.secret ?? '{}')
+      expect(protection.mode).toBe('pin')
+      expect(protection.version).toBe(1)
+      expect(raw?.mnemonic).not.toContain(input.mnemonic)
+      expect(raw?.secret).not.toContain(input.mnemonic)
+    })
+
+    it('should create an unsecured wallet without requiring the default vault key', async () => {
+      // ARRANGE
+      expect.assertions(5)
+      ctx.vault.lock()
+      const input = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'unsecured' } })
+
+      // ACT
+      const result = await walletCreate(ctx, input)
+
+      // ASSERT
+      const raw = await ctx.db.wallets.where('id').equals(result).raw().first()
+      const protection = JSON.parse(raw?.secret ?? '{}')
+      expect(protection.keyMaterial).toBeTypeOf('string')
+      expect(protection.mode).toBe('unsecured')
+      expect(protection.version).toBe(1)
+      expect(raw?.mnemonic).not.toContain(input.mnemonic)
+      expect(raw?.secret).not.toContain(input.mnemonic)
+    })
   })
 
   describe('unexpected behavior', () => {
@@ -125,6 +162,24 @@ describe('wallet-create', () => {
       `)
     })
 
+    it('should throw an error when creating a PIN wallet with a non-digit PIN', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput({ protection: { mode: 'pin', pin: 'abcd' } })
+
+      // ACT & ASSERT
+      await expect(walletCreate(ctx, input)).rejects.toThrow('PIN must contain only digits')
+    })
+
+    it('should throw an error when creating a PIN wallet with a too short PIN', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput({ protection: { mode: 'pin', pin: '123' } })
+
+      // ACT & ASSERT
+      await expect(walletCreate(ctx, input)).rejects.toThrow('PIN must be at least 4 digits')
+    })
+
     it('should throw an error when creating a wallet fails', async () => {
       // ARRANGE
       expect.assertions(1)
@@ -135,6 +190,16 @@ describe('wallet-create', () => {
 
       // ACT & ASSERT
       await expect(walletCreate(ctx, input)).rejects.toThrow('Error creating wallet')
+    })
+
+    it('should throw when creating a password wallet while the vault is locked', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      ctx.vault.lock()
+      const input = testWalletCreateInput()
+
+      // ACT & ASSERT
+      await expect(walletCreate(ctx, input)).rejects.toThrow('Vault is locked')
     })
   })
 })

--- a/packages/db/test/wallet-determine-name.test.ts
+++ b/packages/db/test/wallet-determine-name.test.ts
@@ -11,6 +11,7 @@ function createWallet(input: Pick<Wallet, 'name' | 'order'>): Wallet {
     id: input.name,
     name: input.name,
     order: input.order,
+    protectionMode: 'password',
     updatedAt: now,
   }
 }

--- a/packages/db/test/wallet-find-many.test.ts
+++ b/packages/db/test/wallet-find-many.test.ts
@@ -1,9 +1,9 @@
 import type { PromiseExtended } from 'dexie'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { accountCreate } from '../src/account/account-create.ts'
-import type { Wallet } from '../src/wallet/wallet.ts'
 import { walletCreate } from '../src/wallet/wallet-create.ts'
 import { walletFindMany } from '../src/wallet/wallet-find-many.ts'
+import type { WalletInternal } from '../src/wallet/wallet-internal.ts'
 import {
   createDbContextTest,
   createPasswordTestVault,
@@ -48,12 +48,13 @@ describe('wallet-find-many', () => {
           accountsOrders: i.accounts.map((a) => a.order),
           id: i.id,
           order: i.order,
+          protectionMode: i.protectionMode,
         })),
       ).toEqual(
         expect.arrayContaining([
-          { accountsLength: 2, accountsOrders: [0, 1], id: wallet1Id, order: 0 },
-          { accountsLength: 1, accountsOrders: [0], id: wallet2Id, order: 1 },
-          { accountsLength: 3, accountsOrders: [0, 1, 2], id: wallet3Id, order: 2 },
+          { accountsLength: 2, accountsOrders: [0, 1], id: wallet1Id, order: 0, protectionMode: 'password' },
+          { accountsLength: 1, accountsOrders: [0], id: wallet2Id, order: 1, protectionMode: 'password' },
+          { accountsLength: 3, accountsOrders: [0, 1, 2], id: wallet3Id, order: 2, protectionMode: 'password' },
         ]),
       )
     })
@@ -129,7 +130,9 @@ describe('wallet-find-many', () => {
       vi.spyOn(ctx.db.wallets, 'orderBy').mockImplementation(() => ({
         filter: () => ({
           // @ts-expect-error - Mocking Dexie's chained methods confuses Vitest's type inference.
-          toArray: () => Promise.reject(new Error('Test error')) as PromiseExtended<Wallet[]>,
+          raw: () => ({
+            toArray: () => Promise.reject(new Error('Test error')) as PromiseExtended<WalletInternal[]>,
+          }),
         }),
       }))
 

--- a/packages/db/test/wallet-find-unique.test.ts
+++ b/packages/db/test/wallet-find-unique.test.ts
@@ -1,8 +1,8 @@
 import type { PromiseExtended } from 'dexie'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Wallet } from '../src/wallet/wallet.ts'
 import { walletCreate } from '../src/wallet/wallet-create.ts'
 import { walletFindUnique } from '../src/wallet/wallet-find-unique.ts'
+import type { WalletInternal } from '../src/wallet/wallet-internal.ts'
 import { createDbContextTest, createPasswordTestVault, testWalletCreateInput } from './test-helpers.ts'
 
 const ctx = createDbContextTest()
@@ -16,7 +16,7 @@ describe('wallet-find-unique', () => {
   describe('expected behavior', () => {
     it('should find a unique wallet', async () => {
       // ARRANGE
-      expect.assertions(3)
+      expect.assertions(4)
       const input = testWalletCreateInput()
       const id = await walletCreate(ctx, input)
 
@@ -26,6 +26,7 @@ describe('wallet-find-unique', () => {
       // ASSERT
       expect(item).toBeDefined()
       expect(item?.name).toBe(input.name)
+      expect(item?.protectionMode).toBe('password')
       // @ts-expect-error mnemonic does not exist on the type. Here we ensure it's sanitized.
       expect(item?.mnemonic).toBe(undefined)
     })
@@ -44,8 +45,15 @@ describe('wallet-find-unique', () => {
       // ARRANGE
       expect.assertions(1)
       const id = 'test-id'
-      vi.spyOn(ctx.db.wallets, 'get').mockImplementationOnce(
-        () => Promise.reject(new Error('Test error')) as PromiseExtended<Wallet | undefined>,
+      vi.spyOn(ctx.db.wallets, 'where').mockImplementationOnce(
+        () =>
+          ({
+            equals: () => ({
+              raw: () => ({
+                first: () => Promise.reject(new Error('Test error')) as PromiseExtended<WalletInternal | undefined>,
+              }),
+            }),
+          }) as never,
       )
 
       // ACT & ASSERT

--- a/packages/db/test/wallet-read-mnemonic.test.ts
+++ b/packages/db/test/wallet-read-mnemonic.test.ts
@@ -26,6 +26,35 @@ describe('wallet-read-mnemonic', () => {
       // ASSERT
       expect(result).toBe(input.mnemonic)
     })
+
+    it('should read an unsecured wallet while the vault is locked', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'unsecured' } })
+      const id = await walletCreate(ctx, input)
+      ctx.vault.lock()
+
+      // ACT
+      const result = await walletReadMnemonic(ctx, id)
+
+      // ASSERT
+      expect(result).toBe(input.mnemonic)
+    })
+
+    it('should read a PIN wallet after unlocking the wallet', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const input = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'pin', pin: '1234' } })
+      const id = await walletCreate(ctx, input)
+      ctx.vault.lock()
+      await ctx.vault.unlockWallet({ credential: '1234', walletId: id })
+
+      // ACT
+      const result = await walletReadMnemonic(ctx, id)
+
+      // ASSERT
+      expect(result).toBe(input.mnemonic)
+    })
   })
 
   describe('unexpected behavior', () => {
@@ -55,6 +84,16 @@ describe('wallet-read-mnemonic', () => {
 
       // ACT & ASSERT
       await expect(walletReadMnemonic(ctx, id)).rejects.toThrow('Vault is locked')
+    })
+
+    it('should throw an error if a PIN wallet is locked', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const id = await walletCreate(ctx, testWalletCreateInput({ protection: { mode: 'pin', pin: '1234' } }))
+      ctx.vault.lock()
+
+      // ACT & ASSERT
+      await expect(walletReadMnemonic(ctx, id)).rejects.toThrow('Wallet is locked')
     })
 
     it('should throw an error when reading the mnemonic fails', async () => {

--- a/packages/db/test/wallet-reprotect.test.ts
+++ b/packages/db/test/wallet-reprotect.test.ts
@@ -1,0 +1,185 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { accountCreate } from '../src/account/account-create.ts'
+import { accountReadSecretKey } from '../src/account/account-read-secret-key.ts'
+import { walletCreate } from '../src/wallet/wallet-create.ts'
+import { walletReadMnemonic } from '../src/wallet/wallet-read-mnemonic.ts'
+import { walletReprotect } from '../src/wallet/wallet-reprotect.ts'
+import {
+  createDbContextTest,
+  createPasswordTestVault,
+  testAccountCreateInput,
+  testWalletCreateInput,
+} from './test-helpers.ts'
+
+const ctx = createDbContextTest()
+
+describe('wallet-reprotect', () => {
+  beforeEach(async () => {
+    await ctx.db.accounts.clear()
+    await ctx.db.wallets.clear()
+    await createPasswordTestVault(ctx)
+  })
+
+  describe('expected behavior', () => {
+    it('should reprotect a password wallet to unsecured', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const walletInput = testWalletCreateInput({ mnemonic: 'test mnemonic' })
+      const walletId = await walletCreate(ctx, walletInput)
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const accountId = await accountCreate(ctx, accountInput)
+
+      // ACT
+      await walletReprotect(ctx, { protection: { mode: 'unsecured' }, walletId })
+      ctx.vault.lock()
+      const result1 = await walletReadMnemonic(ctx, walletId)
+      const result2 = await accountReadSecretKey(ctx, accountId)
+
+      // ASSERT
+      expect(result1).toBe(walletInput.mnemonic)
+      expect(result2).toBe(accountInput.secretKey)
+    })
+
+    it('should reprotect a password wallet to PIN', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const walletInput = testWalletCreateInput({ mnemonic: 'test mnemonic' })
+      const walletId = await walletCreate(ctx, walletInput)
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const accountId = await accountCreate(ctx, accountInput)
+
+      // ACT
+      await walletReprotect(ctx, { protection: { mode: 'pin', pin: '1234' }, walletId })
+      ctx.vault.lock()
+
+      // ASSERT
+      await expect(walletReadMnemonic(ctx, walletId)).rejects.toThrow('Wallet is locked')
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+      expect(await walletReadMnemonic(ctx, walletId)).toBe(walletInput.mnemonic)
+      expect(await accountReadSecretKey(ctx, accountId)).toBe(accountInput.secretKey)
+    })
+
+    it('should reprotect an unlocked PIN wallet to password', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const walletInput = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'pin', pin: '1234' } })
+      const walletId = await walletCreate(ctx, walletInput)
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const accountId = await accountCreate(ctx, accountInput)
+
+      // ACT
+      await walletReprotect(ctx, { protection: { mode: 'password' }, walletId })
+
+      // ASSERT
+      expect(await walletReadMnemonic(ctx, walletId)).toBe(walletInput.mnemonic)
+      expect(await accountReadSecretKey(ctx, accountId)).toBe(accountInput.secretKey)
+    })
+
+    it('should clear the cached PIN key after a PIN wallet changes to unsecured', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const walletInput = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'pin', pin: '1234' } })
+      const walletId = await walletCreate(ctx, walletInput)
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const accountId = await accountCreate(ctx, accountInput)
+
+      // ACT
+      await walletReprotect(ctx, { protection: { mode: 'unsecured' }, walletId })
+      const result1 = await walletReadMnemonic(ctx, walletId)
+      const result2 = await accountReadSecretKey(ctx, accountId)
+
+      // ASSERT
+      expect(result1).toBe(walletInput.mnemonic)
+      expect(result2).toBe(accountInput.secretKey)
+    })
+
+    it('should require unlock after an unlocked PIN wallet changes to a new PIN', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const walletInput = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'pin', pin: '1234' } })
+      const walletId = await walletCreate(ctx, walletInput)
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const accountId = await accountCreate(ctx, accountInput)
+
+      // ACT
+      await walletReprotect(ctx, { protection: { mode: 'pin', pin: '5678' }, walletId })
+
+      // ASSERT
+      await expect(walletReadMnemonic(ctx, walletId)).rejects.toThrow('Wallet is locked')
+      await expect(ctx.vault.unlockWallet({ credential: '1234', walletId })).rejects.toThrow('Unable to unlock wallet')
+      await ctx.vault.unlockWallet({ credential: '5678', walletId })
+      expect(await walletReadMnemonic(ctx, walletId)).toBe(walletInput.mnemonic)
+      expect(await accountReadSecretKey(ctx, accountId)).toBe(accountInput.secretKey)
+    })
+
+    it('should require unlock after an unsecured wallet changes to PIN', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const walletInput = testWalletCreateInput({ mnemonic: 'test mnemonic', protection: { mode: 'unsecured' } })
+      const walletId = await walletCreate(ctx, walletInput)
+      const accountInput = testAccountCreateInput({ secretKey: 'test-secret-key', walletId })
+      const accountId = await accountCreate(ctx, accountInput)
+
+      // ACT
+      await walletReprotect(ctx, { protection: { mode: 'pin', pin: '1234' }, walletId })
+
+      // ASSERT
+      await expect(walletReadMnemonic(ctx, walletId)).rejects.toThrow('Wallet is locked')
+      await ctx.vault.unlockWallet({ credential: '1234', walletId })
+      expect(await walletReadMnemonic(ctx, walletId)).toBe(walletInput.mnemonic)
+      expect(await accountReadSecretKey(ctx, accountId)).toBe(accountInput.secretKey)
+    })
+
+    it('should keep other password wallets protected when one wallet becomes unsecured', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const walletId1 = await walletCreate(ctx, testWalletCreateInput({ mnemonic: 'test mnemonic 1' }))
+      const walletId2 = await walletCreate(ctx, testWalletCreateInput({ mnemonic: 'test mnemonic 2' }))
+
+      // ACT
+      await walletReprotect(ctx, { protection: { mode: 'unsecured' }, walletId: walletId1 })
+      ctx.vault.lock()
+      const result = await walletReadMnemonic(ctx, walletId1)
+
+      // ASSERT
+      expect(result).toBe('test mnemonic 1')
+      await expect(walletReadMnemonic(ctx, walletId2)).rejects.toThrow('Vault is locked')
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should throw an error when the current wallet key cannot be resolved', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletId = await walletCreate(ctx, testWalletCreateInput({ protection: { mode: 'pin', pin: '1234' } }))
+
+      // ACT & ASSERT
+      await expect(walletReprotect(ctx, { protection: { mode: 'unsecured' }, walletId })).rejects.toThrow(
+        'Wallet is locked',
+      )
+    })
+
+    it('should throw an error when the target PIN is invalid', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const walletId = await walletCreate(ctx, testWalletCreateInput())
+
+      // ACT & ASSERT
+      await expect(walletReprotect(ctx, { protection: { mode: 'pin', pin: '123' }, walletId })).rejects.toThrow(
+        'PIN must be at least 4 digits',
+      )
+    })
+  })
+})

--- a/packages/db/test/wallet-sanitizer.test.ts
+++ b/packages/db/test/wallet-sanitizer.test.ts
@@ -1,3 +1,4 @@
+import { createPasswordWalletProtection, createPinWalletProtection } from '@workspace/vault/wallet-protection'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WalletInternal } from '../src/wallet/wallet-internal.ts'
 import { walletSanitizer } from '../src/wallet/wallet-sanitizer.ts'
@@ -6,7 +7,7 @@ describe('wallet-sanitizer', () => {
   describe('expected behavior', () => {
     it('should remove the mnemonic and secret from a wallet', () => {
       // ARRANGE
-      expect.assertions(3)
+      expect.assertions(4)
       const now = new Date()
       const input = {
         accounts: [],
@@ -16,7 +17,7 @@ describe('wallet-sanitizer', () => {
         mnemonic: 'mnemonic',
         name: 'Wallet',
         order: 0,
-        secret: 'secret',
+        secret: createPasswordWalletProtection(),
         updatedAt: now,
       } satisfies WalletInternal
 
@@ -25,8 +26,55 @@ describe('wallet-sanitizer', () => {
 
       // ASSERT
       expect(result.name).toBe(input.name)
+      expect(result.protectionMode).toBe('password')
       expect(result).not.toHaveProperty('mnemonic')
       expect(result).not.toHaveProperty('secret')
+    })
+
+    it('should expose the wallet protection mode', () => {
+      // ARRANGE
+      expect.assertions(1)
+      const now = new Date()
+      const input = {
+        accounts: [],
+        createdAt: now,
+        derivationPath: 'd',
+        id: 'wallet-id',
+        mnemonic: 'mnemonic',
+        name: 'Wallet',
+        order: 0,
+        secret: JSON.stringify({ keyMaterial: 'key-material', mode: 'unsecured', version: 1 }),
+        updatedAt: now,
+      } satisfies WalletInternal
+
+      // ACT
+      const result = walletSanitizer(input)
+
+      // ASSERT
+      expect(result.protectionMode).toBe('unsecured')
+    })
+
+    it('should expose the PIN wallet protection mode', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      const now = new Date()
+      const input = {
+        accounts: [],
+        createdAt: now,
+        derivationPath: 'd',
+        id: 'wallet-id',
+        mnemonic: 'mnemonic',
+        name: 'Wallet',
+        order: 0,
+        secret: await createPinWalletProtection({ pin: '1234' }),
+        updatedAt: now,
+      } satisfies WalletInternal
+
+      // ACT
+      const result = walletSanitizer(input)
+
+      // ASSERT
+      expect(result.protectionMode).toBe('pin')
     })
   })
 

--- a/packages/vault/src/vault.ts
+++ b/packages/vault/src/vault.ts
@@ -15,6 +15,7 @@ export interface VaultStorage {
 
 export interface Vault {
   changePassword(input: { newPassword: string; oldPassword: string }): Promise<void>
+  clearWalletKey(input: { walletId: string }): void
   create(input: { password: string }): Promise<void>
   isConfigured(): Promise<boolean>
   isUnlocked(): boolean
@@ -57,6 +58,9 @@ export function createVault(store: VaultStorage): Vault {
       } catch (error) {
         throw new Error('Unable to change vault password', { cause: error })
       }
+    },
+    clearWalletKey({ walletId }) {
+      walletKeys.delete(walletId)
     },
     async create({ password }) {
       if (await isConfigured()) {

--- a/packages/vault/test/wallet-protection.test.ts
+++ b/packages/vault/test/wallet-protection.test.ts
@@ -126,6 +126,30 @@ describe('wallet-protection', () => {
       expect(result).toBeDefined()
       await expect(vault.requireWalletKey({ walletId })).rejects.toThrow('Wallet is locked')
     })
+
+    it('should clear the cached wallet key for one wallet', async () => {
+      // ARRANGE
+      expect.assertions(5)
+      const vault = createVault(storage)
+      const protection1 = await createPinWalletProtection({ pin: '1234' })
+      const protection2 = await createPinWalletProtection({ pin: '5678' })
+      const walletId1 = createWallet(protection1)
+      const walletId2 = createWallet(protection2)
+      await vault.unlockWallet({ credential: '1234', walletId: walletId1 })
+      await vault.unlockWallet({ credential: '5678', walletId: walletId2 })
+
+      // ACT
+      const result1 = await vault.requireWalletKey({ walletId: walletId1 })
+      const result2 = await vault.requireWalletKey({ walletId: walletId2 })
+      vault.clearWalletKey({ walletId: walletId1 })
+
+      // ASSERT
+      expect(result1).toBeDefined()
+      expect(result2).toBeDefined()
+      await expect(vault.requireWalletKey({ walletId: walletId1 })).rejects.toThrow('Wallet is locked')
+      await expect(vault.requireWalletKey({ walletId: walletId2 })).resolves.toBe(result2)
+      await expect(vault.unlockWallet({ credential: '1234', walletId: walletId1 })).resolves.toBeUndefined()
+    })
   })
 
   describe('unexpected behavior', () => {


### PR DESCRIPTION
Allow wallet creation to select password, PIN, or unsecured protection while preserving password as the default.

Expose derived wallet protection modes on sanitized wallet reads, add wallet reprotection for mnemonics and account secret keys, and provide a db-react mutation hook.

Add focused DB tests for protected wallet creation, locked reads, sanitized protection modes, and wallet reprotection.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet reprotection: change a wallet’s protection between password, PIN, and unsecured; stored protection and encryption update accordingly.
  * Vault: clear cached per-wallet keys so wallets can be locked independently.

* **Behavior Changes**
  * Wallet creation/listing now expose protection mode; PIN protection enforces numeric length and min/max constraints.
  * Mnemonic/secret access respects protection mode and vault lock state.

* **Tests**
  * Expanded coverage for reprotect flows, PIN/unsecured behaviors, and vault lock/unlock scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->