### PR TITLE
fix: bundle vanity worker in extension

### DIFF
--- a/packages/config-typescript/react-library.json
+++ b/packages/config-typescript/react-library.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["bun", "node", "react", "react-dom"]
+    "types": ["bun", "node", "react", "react-dom", "vite/client"]
   },
   "display": "React Library",
   "extends": "./base.json"

--- a/packages/feature-settings/src/settings-feature-account-generate-vanity.tsx
+++ b/packages/feature-settings/src/settings-feature-account-generate-vanity.tsx
@@ -17,6 +17,7 @@ import {
   type VanityWalletFormFields,
 } from './ui/settings-ui-wallet-form-generate-vanity.tsx'
 import { SettingsUiWalletItem } from './ui/settings-ui-wallet-item.tsx'
+import VanityWorker from './workers/vanity-worker.ts?worker'
 import type { VanityWorkerMessage } from './workers/vanity-worker-message.ts'
 
 type VanityGeneratorState =
@@ -76,7 +77,7 @@ function useVanityGenerator() {
 
     dispatch({ type: 'start' })
     workerRef.current?.terminate()
-    const worker = new Worker(new URL('./workers/vanity-worker.ts', import.meta.url), { type: 'module' })
+    const worker = new VanityWorker()
     workerRef.current = worker
 
     worker.onmessage = (event: MessageEvent<VanityWorkerMessage>) => {


### PR DESCRIPTION
Use Vite's explicit worker import for the vanity account generator so WXT emits the worker asset in extension builds.

Add Vite client types to the feature-settings package config so the worker import is typed without per-file references.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Web Worker initialization for the vanity generation feature.

* **Chores**
  * Updated TypeScript configuration to include Vite client type definitions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/samui-build/samui-wallet/pull/1049)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->