### PR TITLE
feat: add onboarding wallet protection controls

### DIFF
--- a/apps/web/e2e/flows/onboarding.ts
+++ b/apps/web/e2e/flows/onboarding.ts
@@ -3,17 +3,33 @@ import { expect } from '@playwright/test'
 import { testWalletMenuLabel, testWalletSeedPhrase } from '../fixtures/wallet.ts'
 import { setupVaultPassword } from './vault.ts'
 
-export async function importExistingWallet(page: Page) {
-  await page.goto('')
-  await page.getByRole('link', { name: 'I already have a wallet' }).click()
-
+async function fillImportMnemonic(page: Page) {
   for (const [index, word] of testWalletSeedPhrase.entries()) {
     const name = (index + 1).toString()
     await page.getByRole('textbox', { exact: true, name }).click()
     await page.getByRole('textbox', { exact: true, name }).fill(word)
   }
+}
+
+export async function importExistingWallet(page: Page) {
+  await page.goto('')
+  await page.getByRole('link', { name: 'I already have a wallet' }).click()
+  await fillImportMnemonic(page)
 
   await page.getByRole('button', { name: 'Import wallet' }).click()
   await setupVaultPassword(page)
+  await expect(page.getByTestId('wallet-menu-trigger')).toContainText(testWalletMenuLabel)
+}
+
+export async function importExistingWalletUnsecured(page: Page) {
+  await page.goto('')
+  await page.getByRole('link', { name: 'I already have a wallet' }).click()
+  await fillImportMnemonic(page)
+
+  await page.getByText('Advanced protection').click()
+  await page.getByRole('radio', { name: 'Unsecured' }).click()
+  await page.getByLabel('I understand this wallet is not protected by a password or PIN.').click()
+  await page.getByRole('button', { name: 'Import wallet' }).click()
+  await expect(page.getByRole('heading', { name: 'Create app password' })).toBeHidden()
   await expect(page.getByTestId('wallet-menu-trigger')).toContainText(testWalletMenuLabel)
 }

--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -1,9 +1,13 @@
 import { expect, test } from '@playwright/test'
-import { importExistingWallet } from './flows/onboarding.ts'
+import { importExistingWallet, importExistingWalletUnsecured } from './flows/onboarding.ts'
 
 test('onboarding - import existing wallet', async ({ page }) => {
   await importExistingWallet(page)
   const copyPublicKeyButton = page.getByRole('button', { name: 'Copy public key' })
   await expect(copyPublicKeyButton).toBeVisible()
   await copyPublicKeyButton.click()
+})
+
+test('onboarding - import existing wallet as unsecured', async ({ page }) => {
+  await importExistingWalletUnsecured(page)
 })

--- a/bun.lock
+++ b/bun.lock
@@ -372,6 +372,7 @@
         "@workspace/i18n": "workspace:*",
         "@workspace/keypair": "workspace:*",
         "@workspace/ui": "workspace:*",
+        "@workspace/vault": "workspace:*",
         "@workspace/vault-react": "workspace:*",
         "@wxt-dev/browser": "catalog:",
         "react-hook-form": "catalog:",

--- a/packages/db-react/src/use-wallet-generate-with-account.tsx
+++ b/packages/db-react/src/use-wallet-generate-with-account.tsx
@@ -1,4 +1,5 @@
 import { mutationOptions, useMutation } from '@tanstack/react-query'
+import { useAppContext } from '@workspace/context-react/use-app-context'
 import type { WalletCreateInput } from '@workspace/db/wallet/wallet-create-input'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
 import { useAccountCreate } from './use-account-create.tsx'
@@ -9,10 +10,12 @@ export function walletGenerateWithAccountMutationOptions({
   createAccountMutation,
   createWalletMutation,
   deriveAccountMutation,
+  unlockWallet,
 }: {
   createAccountMutation: ReturnType<typeof useAccountCreate>
   createWalletMutation: ReturnType<typeof useWalletCreate>
   deriveAccountMutation: ReturnType<typeof useAccountDeriveFromMnemonic>
+  unlockWallet: (input: { credential: string; walletId: string }) => Promise<void>
 }) {
   return mutationOptions({
     mutationFn: async (input: WalletCreateInput) => {
@@ -23,6 +26,11 @@ export function walletGenerateWithAccountMutationOptions({
       })
       // If so, we create the wallet
       const walletId = await createWalletMutation.mutateAsync({ input })
+
+      if (input.protection?.mode === 'pin') {
+        await unlockWallet({ credential: input.protection.pin, walletId })
+      }
+
       // After creating the wallet we can create the account
       await createAccountMutation.mutateAsync({
         input: {
@@ -38,6 +46,7 @@ export function walletGenerateWithAccountMutationOptions({
 }
 
 export function useWalletGenerateWithAccount() {
+  const context = useAppContext()
   const createAccountMutation = useAccountCreate()
   const createWalletMutation = useWalletCreate()
   const deriveAccountMutation = useAccountDeriveFromMnemonic()
@@ -47,6 +56,7 @@ export function useWalletGenerateWithAccount() {
       createAccountMutation,
       createWalletMutation,
       deriveAccountMutation,
+      unlockWallet: (input) => context.vault.unlockWallet(input),
     }),
   )
 }

--- a/packages/feature-onboarding/package.json
+++ b/packages/feature-onboarding/package.json
@@ -6,6 +6,7 @@
     "@workspace/i18n": "workspace:*",
     "@workspace/keypair": "workspace:*",
     "@workspace/ui": "workspace:*",
+    "@workspace/vault": "workspace:*",
     "@workspace/vault-react": "workspace:*",
     "@wxt-dev/browser": "catalog:",
     "react-hook-form": "catalog:",

--- a/packages/feature-onboarding/src/data-access/use-create-new-wallet.tsx
+++ b/packages/feature-onboarding/src/data-access/use-create-new-wallet.tsx
@@ -3,17 +3,25 @@ import { useWalletGenerateWithAccount } from '@workspace/db-react/use-wallet-gen
 import { derivationPaths } from '@workspace/keypair/derivation-paths'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { VAULT_PIN_MAX_LENGTH, VAULT_PIN_MIN_LENGTH } from '@workspace/vault/encrypted-value-schema'
 import { useVaultUnlockDialog } from '@workspace/vault-react/vault-unlock-provider'
+
+export type CreateNewWalletProtection = { mode: 'password' } | { mode: 'pin'; pin: string } | { mode: 'unsecured' }
+
+export type CreateNewWalletProtectionMode = CreateNewWalletProtection['mode']
 
 export function useCreateNewWallet() {
   const mutation = useWalletGenerateWithAccount()
   const name = useWalletDetermineName()
   const { requestUnlock } = useVaultUnlockDialog()
 
-  return async (mnemonic: string): Promise<boolean> => {
-    const unlocked = await requestUnlock({ mode: 'password', reason: 'createWallet' })
-    if (!unlocked) {
-      return false
+  return async (mnemonic: string, input?: CreateNewWalletProtection): Promise<boolean> => {
+    const protection = input ?? { mode: 'password' }
+    if (protection.mode === 'password') {
+      const unlocked = await requestUnlock({ mode: 'password', reason: 'createWallet' })
+      if (!unlocked) {
+        return false
+      }
     }
 
     return mutation
@@ -21,6 +29,7 @@ export function useCreateNewWallet() {
         derivationPath: derivationPaths.default,
         mnemonic,
         name,
+        protection,
       })
       .then(() => {
         toastSuccess('Wallet created!')
@@ -30,5 +39,40 @@ export function useCreateNewWallet() {
         toastError(`${error}`)
         return false
       })
+  }
+}
+
+export function getCreateNewWalletProtection(input: {
+  pin: string
+  pinConfirm: string
+  protectionMode: CreateNewWalletProtectionMode
+  unsecuredConfirmed: boolean
+}): CreateNewWalletProtection {
+  switch (input.protectionMode) {
+    case 'password':
+      return { mode: 'password' }
+    case 'pin':
+      if (!new RegExp(`^\\d{${VAULT_PIN_MIN_LENGTH},${VAULT_PIN_MAX_LENGTH}}$`).test(input.pin)) {
+        throw new Error(`PIN must be ${VAULT_PIN_MIN_LENGTH}-${VAULT_PIN_MAX_LENGTH} digits`)
+      }
+      if (input.pin !== input.pinConfirm) {
+        throw new Error('PINs do not match')
+      }
+      return { mode: 'pin', pin: input.pin }
+    case 'unsecured':
+      if (!input.unsecuredConfirmed) {
+        throw new Error('Confirm this wallet is not protected')
+      }
+      return { mode: 'unsecured' }
+  }
+}
+
+export function parseCreateNewWalletProtectionMode(value: string): CreateNewWalletProtectionMode {
+  switch (value) {
+    case 'pin':
+    case 'unsecured':
+      return value
+    default:
+      return 'password'
   }
 }

--- a/packages/feature-onboarding/src/onboarding-feature-generate.tsx
+++ b/packages/feature-onboarding/src/onboarding-feature-generate.tsx
@@ -14,10 +14,16 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 import { z } from 'zod'
-import { useCreateNewWallet } from './data-access/use-create-new-wallet.tsx'
+import {
+  type CreateNewWalletProtectionMode,
+  getCreateNewWalletProtection,
+  parseCreateNewWalletProtectionMode,
+  useCreateNewWallet,
+} from './data-access/use-create-new-wallet.tsx'
 import { OnboardingUiMnemonicSave } from './ui/onboarding-ui-mnemonic-save.tsx'
 import { OnboardingUiMnemonicSelectStrength } from './ui/onboarding-ui-mnemonic-select-strength.tsx'
 import { OnboardingUiMnemonicShow } from './ui/onboarding-ui-mnemonic-show.tsx'
+import { OnboardingUiWalletProtection } from './ui/onboarding-ui-wallet-protection.tsx'
 
 const onboardingGenerateSchema = z.object({
   mnemonic: z.string(),
@@ -30,7 +36,11 @@ export function OnboardingFeatureGenerate({ redirectTo }: { redirectTo: string }
   const { t } = useTranslation('onboarding')
   const create = useCreateNewWallet()
   const navigate = useNavigate()
+  const [pin, setPin] = useState('')
+  const [pinConfirm, setPinConfirm] = useState('')
+  const [protectionMode, setProtectionMode] = useState<CreateNewWalletProtectionMode>('password')
   const [revealed, setRevealed] = useState<boolean>(false)
+  const [unsecuredConfirmed, setUnsecuredConfirmed] = useState(false)
 
   const form = useForm<OnboardingGenerateForm>({
     defaultValues: {
@@ -46,13 +56,31 @@ export function OnboardingFeatureGenerate({ redirectTo }: { redirectTo: string }
 
   async function submit(input: OnboardingGenerateForm) {
     try {
-      const created = await create(input.mnemonic)
+      const created = await create(
+        input.mnemonic,
+        getCreateNewWalletProtection({
+          pin,
+          pinConfirm,
+          protectionMode,
+          unsecuredConfirmed,
+        }),
+      )
       if (created) {
         await navigate(redirectTo)
       }
     } catch (error) {
       toastError(`${error}`)
     }
+  }
+
+  function handleProtectionModeChange(value: string) {
+    if (!value) {
+      return
+    }
+    setPin('')
+    setPinConfirm('')
+    setProtectionMode(parseCreateNewWalletProtectionMode(value))
+    setUnsecuredConfirmed(false)
   }
 
   return (
@@ -97,6 +125,16 @@ export function OnboardingFeatureGenerate({ redirectTo }: { redirectTo: string }
               </Button>
             </div>
             <OnboardingUiMnemonicShow mnemonic={mnemonic} revealed={revealed} />
+            <OnboardingUiWalletProtection
+              onPinChange={setPin}
+              onPinConfirmChange={setPinConfirm}
+              onProtectionModeChange={handleProtectionModeChange}
+              onUnsecuredConfirmedChange={setUnsecuredConfirmed}
+              pin={pin}
+              pinConfirm={pinConfirm}
+              protectionMode={protectionMode}
+              unsecuredConfirmed={unsecuredConfirmed}
+            />
           </div>
         </UiCard>
       </form>

--- a/packages/feature-onboarding/src/onboarding-feature-import.tsx
+++ b/packages/feature-onboarding/src/onboarding-feature-import.tsx
@@ -7,14 +7,20 @@ import { UiBackButton } from '@workspace/ui/components/ui-back-button'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { UiTextPasteButton } from '@workspace/ui/components/ui-text-paste-button'
 import { toastError } from '@workspace/ui/lib/toast-error'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 import { z } from 'zod'
-import { useCreateNewWallet } from './data-access/use-create-new-wallet.tsx'
+import {
+  type CreateNewWalletProtectionMode,
+  getCreateNewWalletProtection,
+  parseCreateNewWalletProtectionMode,
+  useCreateNewWallet,
+} from './data-access/use-create-new-wallet.tsx'
 import { OnboardingUiMnemonicWordInput } from './onboarding-ui-mnemonic-word-input.tsx'
 import { OnboardingUiMnemonicSave } from './ui/onboarding-ui-mnemonic-save.tsx'
 import { OnboardingUiMnemonicSelectStrength } from './ui/onboarding-ui-mnemonic-select-strength.tsx'
+import { OnboardingUiWalletProtection } from './ui/onboarding-ui-wallet-protection.tsx'
 
 const onboardingImportSchema = z.object({
   strength: z.union([z.literal(128), z.literal(256)]),
@@ -27,6 +33,10 @@ export function OnboardingFeatureImport({ redirectTo }: { redirectTo: string }) 
   const { t } = useTranslation('onboarding')
   const create = useCreateNewWallet()
   const navigate = useNavigate()
+  const [pin, setPin] = useState('')
+  const [pinConfirm, setPinConfirm] = useState('')
+  const [protectionMode, setProtectionMode] = useState<CreateNewWalletProtectionMode>('password')
+  const [unsecuredConfirmed, setUnsecuredConfirmed] = useState(false)
 
   const form = useForm<OnboardingImportForm>({
     defaultValues: {
@@ -78,6 +88,16 @@ export function OnboardingFeatureImport({ redirectTo }: { redirectTo: string }) 
     }
   }
 
+  function handleProtectionModeChange(value: string) {
+    if (!value) {
+      return
+    }
+    setPin('')
+    setPinConfirm('')
+    setProtectionMode(parseCreateNewWalletProtectionMode(value))
+    setUnsecuredConfirmed(false)
+  }
+
   const isFormComplete = useMemo(() => {
     return words.slice(0, wordCount).every((word) => word.trim().length > 1)
   }, [words, wordCount])
@@ -90,7 +110,15 @@ export function OnboardingFeatureImport({ redirectTo }: { redirectTo: string }) 
 
     try {
       const mnemonic = validateMnemonic({ mnemonic: words.slice(0, wordCount).join(' ') })
-      const created = await create(mnemonic)
+      const created = await create(
+        mnemonic,
+        getCreateNewWalletProtection({
+          pin,
+          pinConfirm,
+          protectionMode,
+          unsecuredConfirmed,
+        }),
+      )
       if (created) {
         await navigate(redirectTo)
       }
@@ -152,6 +180,17 @@ export function OnboardingFeatureImport({ redirectTo }: { redirectTo: string }) 
             {form.formState.errors.words ? (
               <p className="mt-4 text-center text-red-500 text-sm">{form.formState.errors.words.message}</p>
             ) : null}
+
+            <OnboardingUiWalletProtection
+              onPinChange={setPin}
+              onPinConfirmChange={setPinConfirm}
+              onProtectionModeChange={handleProtectionModeChange}
+              onUnsecuredConfirmedChange={setUnsecuredConfirmed}
+              pin={pin}
+              pinConfirm={pinConfirm}
+              protectionMode={protectionMode}
+              unsecuredConfirmed={unsecuredConfirmed}
+            />
           </div>
         </UiCard>
       </form>

--- a/packages/feature-onboarding/src/ui/onboarding-ui-wallet-protection.tsx
+++ b/packages/feature-onboarding/src/ui/onboarding-ui-wallet-protection.tsx
@@ -1,0 +1,115 @@
+import { useTranslation } from '@workspace/i18n'
+import { Alert, AlertDescription } from '@workspace/ui/components/alert'
+import { Checkbox } from '@workspace/ui/components/checkbox'
+import { Input } from '@workspace/ui/components/input'
+import { Label } from '@workspace/ui/components/label'
+import { ToggleGroup, ToggleGroupItem } from '@workspace/ui/components/toggle-group'
+import { VAULT_PIN_MAX_LENGTH, VAULT_PIN_MIN_LENGTH } from '@workspace/vault/encrypted-value-schema'
+import { useId } from 'react'
+import type { CreateNewWalletProtectionMode } from '../data-access/use-create-new-wallet.tsx'
+
+export function OnboardingUiWalletProtection({
+  onPinChange,
+  onPinConfirmChange,
+  onProtectionModeChange,
+  onUnsecuredConfirmedChange,
+  pin,
+  pinConfirm,
+  protectionMode,
+  unsecuredConfirmed,
+}: {
+  onPinChange: (value: string) => void
+  onPinConfirmChange: (value: string) => void
+  onProtectionModeChange: (value: string) => void
+  onUnsecuredConfirmedChange: (checked: boolean) => void
+  pin: string
+  pinConfirm: string
+  protectionMode: CreateNewWalletProtectionMode
+  unsecuredConfirmed: boolean
+}) {
+  const { t } = useTranslation('onboarding')
+  const pinConfirmId = useId()
+  const pinId = useId()
+  const protectionId = useId()
+  const unsecuredConfirmId = useId()
+
+  return (
+    <details className="space-y-4">
+      <summary className="cursor-pointer text-muted-foreground text-sm">{t(($) => $.walletProtectionTitle)}</summary>
+      <div className="space-y-4 pt-2">
+        <ToggleGroup
+          aria-label={t(($) => $.walletProtectionTitle)}
+          className="grid w-full grid-cols-1 sm:grid-cols-3"
+          id={protectionId}
+          onValueChange={onProtectionModeChange}
+          type="single"
+          value={protectionMode}
+          variant="outline"
+        >
+          <ToggleGroupItem
+            className="h-auto min-h-9 whitespace-normal px-3 py-2 text-center leading-snug"
+            value="password"
+          >
+            {t(($) => $.walletProtectionPassword)}
+          </ToggleGroupItem>
+          <ToggleGroupItem className="h-auto min-h-9 whitespace-normal px-3 py-2 text-center leading-snug" value="pin">
+            {t(($) => $.walletProtectionPin)}
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            className="h-auto min-h-9 whitespace-normal px-3 py-2 text-center leading-snug"
+            value="unsecured"
+          >
+            {t(($) => $.walletProtectionUnsecured)}
+          </ToggleGroupItem>
+        </ToggleGroup>
+        {protectionMode === 'pin' ? (
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor={pinId}>{t(($) => $.walletProtectionPinLabel)}</Label>
+              <Input
+                autoComplete="off"
+                id={pinId}
+                inputMode="numeric"
+                maxLength={VAULT_PIN_MAX_LENGTH}
+                minLength={VAULT_PIN_MIN_LENGTH}
+                onChange={(event) => onPinChange(event.target.value)}
+                pattern="[0-9]*"
+                type="password"
+                value={pin}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={pinConfirmId}>{t(($) => $.walletProtectionPinConfirmLabel)}</Label>
+              <Input
+                autoComplete="off"
+                id={pinConfirmId}
+                inputMode="numeric"
+                maxLength={VAULT_PIN_MAX_LENGTH}
+                minLength={VAULT_PIN_MIN_LENGTH}
+                onChange={(event) => onPinConfirmChange(event.target.value)}
+                pattern="[0-9]*"
+                type="password"
+                value={pinConfirm}
+              />
+            </div>
+          </div>
+        ) : null}
+        {protectionMode === 'unsecured' ? (
+          <div className="space-y-3">
+            <Alert variant="warning">
+              <AlertDescription>{t(($) => $.walletProtectionUnsecuredWarning)}</AlertDescription>
+            </Alert>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                checked={unsecuredConfirmed}
+                id={unsecuredConfirmId}
+                onCheckedChange={(checked) => onUnsecuredConfirmedChange(checked === true)}
+              />
+              <Label htmlFor={unsecuredConfirmId}>{t(($) => $.walletProtectionUnsecuredConfirm)}</Label>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </details>
+  )
+}

--- a/packages/i18n/locales/en/onboarding.json
+++ b/packages/i18n/locales/en/onboarding.json
@@ -17,5 +17,13 @@
   "onboardingPageDescription": "You can now start using 🏝️ Samui Wallet!",
   "onboardingPageTitle": "You're all set!",
   "uiMnemonicUnexpectedLength": "Unexpected mnemonic length",
-  "uiMnemonicWords": "{{words, number}} words"
+  "uiMnemonicWords": "{{words, number}} words",
+  "walletProtectionPassword": "Password",
+  "walletProtectionPin": "PIN",
+  "walletProtectionPinConfirmLabel": "Confirm PIN",
+  "walletProtectionPinLabel": "PIN",
+  "walletProtectionTitle": "Advanced protection",
+  "walletProtectionUnsecured": "Unsecured",
+  "walletProtectionUnsecuredConfirm": "I understand this wallet is not protected by a password or PIN.",
+  "walletProtectionUnsecuredWarning": "Anyone with access to this browser profile may be able to use this wallet."
 }

--- a/packages/i18n/locales/es/onboarding.json
+++ b/packages/i18n/locales/es/onboarding.json
@@ -17,5 +17,13 @@
   "onboardingPageDescription": "¡Ya puedes empezar a usar 🏝 Samui Wallet!",
   "onboardingPageTitle": "¡Todo listo!",
   "uiMnemonicUnexpectedLength": "Longitud mnemónica inesperada",
-  "uiMnemonicWords": "{{words, number}} palabras"
+  "uiMnemonicWords": "{{words, number}} palabras",
+  "walletProtectionPassword": "Contraseña",
+  "walletProtectionPin": "PIN",
+  "walletProtectionPinConfirmLabel": "Confirmar PIN",
+  "walletProtectionPinLabel": "PIN",
+  "walletProtectionTitle": "Protección avanzada",
+  "walletProtectionUnsecured": "Sin protección",
+  "walletProtectionUnsecuredConfirm": "Entiendo que esta billetera no está protegida por contraseña ni PIN.",
+  "walletProtectionUnsecuredWarning": "Cualquier persona con acceso a este perfil de navegador podría usar esta billetera."
 }

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -86,6 +86,14 @@ interface Resources {
     onboardingPageTitle: "You're all set!"
     uiMnemonicUnexpectedLength: 'Unexpected mnemonic length'
     uiMnemonicWords: '{{words, number}} words'
+    walletProtectionPassword: 'Password'
+    walletProtectionPin: 'PIN'
+    walletProtectionPinConfirmLabel: 'Confirm PIN'
+    walletProtectionPinLabel: 'PIN'
+    walletProtectionTitle: 'Advanced protection'
+    walletProtectionUnsecured: 'Unsecured'
+    walletProtectionUnsecuredConfirm: 'I understand this wallet is not protected by a password or PIN.'
+    walletProtectionUnsecuredWarning: 'Anyone with access to this browser profile may be able to use this wallet.'
   }
   portfolio: {
     actionBurn: 'Burn'


### PR DESCRIPTION
Add advanced onboarding controls for password, PIN, and unsecured wallet protection during generate and import flows.

Unlock newly created PIN wallets before deriving the first account, reuse vault PIN policy bounds in onboarding validation, and cover unsecured import in e2e.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable wallet protection during create/import: password, PIN (with validation/confirmation), or unsecured (requires explicit confirmation). New UI for choosing protection.
* **Tests**
  * Added end-to-end test for importing an existing wallet as unsecured.
* **Behavior**
  * Import/create flows now respect selected protection mode and handle PIN/password/unsecured appropriately.
* **Localization**
  * Added onboarding translations for advanced wallet protection UI.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/samui-build/samui-wallet/pull/1050)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->