### PR TITLE
feat: add settings wallet protection controls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -451,6 +451,7 @@
       "dependencies": {
         "@hookform/resolvers": "catalog:",
         "@solana/kit": "catalog:",
+        "@workspace/context-react": "workspace:*",
         "@workspace/db": "workspace:*",
         "@workspace/db-react": "workspace:*",
         "@workspace/feature-explorer": "workspace:*",
@@ -459,6 +460,7 @@
         "@workspace/solana-client": "workspace:*",
         "@workspace/solana-client-react": "workspace:*",
         "@workspace/ui": "workspace:*",
+        "@workspace/vault": "workspace:*",
         "@workspace/vault-react": "workspace:*",
         "react-hook-form": "catalog:",
         "react-router": "catalog:",

--- a/packages/db/src/wallet/wallet-sanitizer.ts
+++ b/packages/db/src/wallet/wallet-sanitizer.ts
@@ -12,9 +12,5 @@ export function walletSanitizer(internal: WalletInternal): Wallet {
 }
 
 function parseWalletProtectionMode(value: string): WalletProtectionMode {
-  try {
-    return walletProtectionSchema.parse(JSON.parse(value)).mode
-  } catch {
-    return 'password'
-  }
+  return walletProtectionSchema.parse(JSON.parse(value)).mode
 }

--- a/packages/feature-settings/package.json
+++ b/packages/feature-settings/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@hookform/resolvers": "catalog:",
     "@solana/kit": "catalog:",
+    "@workspace/context-react": "workspace:*",
     "@workspace/db": "workspace:*",
     "@workspace/db-react": "workspace:*",
     "@workspace/feature-explorer": "workspace:*",
@@ -10,6 +11,7 @@
     "@workspace/solana-client": "workspace:*",
     "@workspace/solana-client-react": "workspace:*",
     "@workspace/ui": "workspace:*",
+    "@workspace/vault": "workspace:*",
     "@workspace/vault-react": "workspace:*",
     "react-hook-form": "catalog:",
     "react-router": "catalog:",

--- a/packages/feature-settings/src/settings-feature-wallet-details.tsx
+++ b/packages/feature-settings/src/settings-feature-wallet-details.tsx
@@ -1,30 +1,68 @@
+import { useAppContext } from '@workspace/context-react/use-app-context'
 import type { Account } from '@workspace/db/account/account'
+import type { Wallet } from '@workspace/db/wallet/wallet'
 import { useAccountActive } from '@workspace/db-react/use-account-active'
 import { useAccountDelete } from '@workspace/db-react/use-account-delete'
 import { useAccountUpdateOrder } from '@workspace/db-react/use-account-update-order'
 import { useAccountsForWalletLive } from '@workspace/db-react/use-accounts-for-wallet-live'
 import { useNetworkActive } from '@workspace/db-react/use-network-active'
 import { useWalletFindUnique } from '@workspace/db-react/use-wallet-find-unique'
+import { useWalletReprotect } from '@workspace/db-react/use-wallet-reprotect'
 import { useTranslation } from '@workspace/i18n'
 import { solToLamports } from '@workspace/solana-client/sol-to-lamports'
 import { useRequestAirdrop } from '@workspace/solana-client-react/use-request-airdrop'
+import { Alert, AlertDescription } from '@workspace/ui/components/alert'
 import { Button } from '@workspace/ui/components/button'
+import { Checkbox } from '@workspace/ui/components/checkbox'
+import { Input } from '@workspace/ui/components/input'
+import { Label } from '@workspace/ui/components/label'
+import { ToggleGroup, ToggleGroupItem } from '@workspace/ui/components/toggle-group'
 import { UiCard } from '@workspace/ui/components/ui-card'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiNotFound } from '@workspace/ui/components/ui-not-found'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { VAULT_PIN_MAX_LENGTH, VAULT_PIN_MIN_LENGTH } from '@workspace/vault/encrypted-value-schema'
+import { useVaultUnlockDialog } from '@workspace/vault-react/vault-unlock-provider'
+import type { SyntheticEvent } from 'react'
+import { useId, useState } from 'react'
 import { Link, useLocation, useParams } from 'react-router'
 import { SettingsUiAccountList } from './ui/settings-ui-account-list.tsx'
 import { SettingsUiWalletItem } from './ui/settings-ui-wallet-item.tsx'
 
+type WalletProtectionInput = { mode: 'password' } | { mode: 'pin'; pin: string } | { mode: 'unsecured' }
+
+type ProtectionDraft = {
+  pin: string
+  pinConfirm: string
+  selectedMode: Wallet['protectionMode']
+  sourceMode: Wallet['protectionMode']
+  unsecuredConfirmed: boolean
+  walletId: string
+}
+
+type ProtectionModeLabels = Record<Wallet['protectionMode'], string>
+
+type WalletProtectionValidationMessages = {
+  pinLength: string
+  pinMismatch: string
+  unsecuredConfirm: string
+}
+
 export function SettingsFeatureWalletDetails() {
   const { t } = useTranslation('settings')
+  const context = useAppContext()
+  const pinConfirmId = useId()
+  const pinId = useId()
+  const protectionId = useId()
+  const unsecuredConfirmId = useId()
+  const { requestUnlock } = useVaultUnlockDialog()
   const { pathname: from } = useLocation()
   const { walletId } = useParams<{ walletId: string }>()
   if (!walletId) {
     throw new Error('Parameter walletId is required')
   }
+  const resolvedWalletId = walletId
 
   const deleteMutation = useAccountDelete({
     onError: (error) => toastError(error.message),
@@ -35,10 +73,36 @@ export function SettingsFeatureWalletDetails() {
     onSuccess: () => toastSuccess('Account order updated'),
   })
   const activeAccount = useAccountActive()
-  const wallet = useWalletFindUnique({ id: walletId })
-  const accounts = useAccountsForWalletLive({ walletId })
+  const wallet = useWalletFindUnique({ id: resolvedWalletId })
+  const accounts = useAccountsForWalletLive({ walletId: resolvedWalletId })
   const activeNetwork = useNetworkActive()
   const requestAirdropMutation = useRequestAirdrop(activeNetwork)
+  const currentProtectionMode = wallet?.protectionMode ?? 'password'
+  const protectionModeLabels: ProtectionModeLabels = {
+    password: t(($) => $.walletProtectionPassword),
+    pin: t(($) => $.walletProtectionPin),
+    unsecured: t(($) => $.walletProtectionUnsecured),
+  }
+  const validationMessages: WalletProtectionValidationMessages = {
+    pinLength: t(($) => $.walletProtectionPinLengthError, {
+      max: VAULT_PIN_MAX_LENGTH,
+      min: VAULT_PIN_MIN_LENGTH,
+    }),
+    pinMismatch: t(($) => $.walletProtectionPinMismatchError),
+    unsecuredConfirm: t(($) => $.walletProtectionUnsecuredConfirmError),
+  }
+  const [protectionDraft, setProtectionDraft] = useState<ProtectionDraft>(() =>
+    createProtectionDraft(resolvedWalletId, currentProtectionMode),
+  )
+  const draft =
+    protectionDraft.sourceMode === currentProtectionMode && protectionDraft.walletId === resolvedWalletId
+      ? protectionDraft
+      : createProtectionDraft(resolvedWalletId, currentProtectionMode)
+  const { pin, pinConfirm, selectedMode: selectedProtectionMode, unsecuredConfirmed } = draft
+  const reprotectMutation = useWalletReprotect({
+    onError: (caught) => toastError(caught.message),
+    onSuccess: () => toastSuccess(t(($) => $.actionSave)),
+  })
 
   if (!wallet) {
     return <UiNotFound />
@@ -47,6 +111,68 @@ export function SettingsFeatureWalletDetails() {
   function handleMove(item: Account, adjustment: number) {
     return updateOrderMutation.mutateAsync({ input: { id: item.id, order: item.order + adjustment } })
   }
+
+  function handleProtectionModeChange(value: string) {
+    if (!value) {
+      return
+    }
+    setProtectionDraft({
+      ...draft,
+      pin: '',
+      pinConfirm: '',
+      selectedMode: parseWalletProtectionModeValue(value),
+      unsecuredConfirmed: false,
+    })
+  }
+
+  async function handleProtectionSubmit(event: SyntheticEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!wallet) {
+      return
+    }
+
+    let protection: WalletProtectionInput
+    try {
+      protection = getWalletProtectionInput({
+        pin,
+        pinConfirm,
+        protectionMode: selectedProtectionMode,
+        unsecuredConfirmed,
+        validationMessages,
+      })
+    } catch (caught) {
+      toastError(caught instanceof Error ? caught.message : `${caught}`)
+      return
+    }
+
+    const unlocked = await requestUnlock({
+      mode: currentProtectionMode,
+      reason: 'walletProtection',
+      walletId: wallet.id,
+    })
+    if (!unlocked) {
+      return
+    }
+
+    const result = await reprotectMutation
+      .mutateAsync({ protection, walletId: wallet.id })
+      .then(() => true)
+      .catch(() => false)
+    if (!result) {
+      return
+    }
+
+    if (protection.mode === 'pin') {
+      await context.vault.unlockWallet({ credential: protection.pin, walletId: wallet.id }).catch((caught) => {
+        toastError(caught instanceof Error ? caught.message : `${caught}`)
+      })
+    }
+
+    setProtectionDraft(createProtectionDraft(wallet.id, protection.mode))
+  }
+
+  const hasProtectionChange = selectedProtectionMode !== currentProtectionMode
+  const isProtectionBusy = reprotectMutation.isPending
 
   return (
     <UiCard
@@ -72,17 +198,160 @@ export function SettingsFeatureWalletDetails() {
         </div>
       }
     >
-      <SettingsUiAccountList
-        activeId={activeAccount.id}
-        deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })}
-        items={accounts}
-        networkType={activeNetwork.type}
-        onMoveDown={(item: Account) => handleMove(item, 1)}
-        onMoveUp={(item: Account) => handleMove(item, -1)}
-        requestAirdrop={async (item) => {
-          await requestAirdropMutation.mutateAsync({ address: item.publicKey, amount: solToLamports('1') })
-        }}
-      />
+      <div className="space-y-6">
+        <form className="space-y-4 border-b pb-6" onSubmit={handleProtectionSubmit}>
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <div className="font-medium">{t(($) => $.walletProtectionTitle)}</div>
+            <div className="text-muted-foreground text-sm">
+              {t(($) => $.walletProtectionCurrentLabel)}:{' '}
+              {getProtectionModeLabel(currentProtectionMode, protectionModeLabels)}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={protectionId}>{t(($) => $.walletProtectionTitle)}</Label>
+            <ToggleGroup
+              className="grid w-full grid-cols-1 sm:grid-cols-3"
+              id={protectionId}
+              onValueChange={handleProtectionModeChange}
+              type="single"
+              value={selectedProtectionMode}
+              variant="outline"
+            >
+              <ToggleGroupItem
+                className="h-auto min-h-9 whitespace-normal px-3 py-2 text-center leading-snug"
+                value="password"
+              >
+                {t(($) => $.walletProtectionPassword)}
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                className="h-auto min-h-9 whitespace-normal px-3 py-2 text-center leading-snug"
+                value="pin"
+              >
+                {t(($) => $.walletProtectionPin)}
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                className="h-auto min-h-9 whitespace-normal px-3 py-2 text-center leading-snug"
+                value="unsecured"
+              >
+                {t(($) => $.walletProtectionUnsecured)}
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+          {selectedProtectionMode === 'pin' ? (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor={pinId}>{t(($) => $.walletProtectionPinLabel)}</Label>
+                <Input
+                  autoComplete="off"
+                  id={pinId}
+                  inputMode="numeric"
+                  maxLength={VAULT_PIN_MAX_LENGTH}
+                  minLength={VAULT_PIN_MIN_LENGTH}
+                  onChange={(event) => setProtectionDraft({ ...draft, pin: event.target.value })}
+                  pattern="[0-9]*"
+                  type="password"
+                  value={pin}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor={pinConfirmId}>{t(($) => $.walletProtectionPinConfirmLabel)}</Label>
+                <Input
+                  autoComplete="off"
+                  id={pinConfirmId}
+                  inputMode="numeric"
+                  maxLength={VAULT_PIN_MAX_LENGTH}
+                  minLength={VAULT_PIN_MIN_LENGTH}
+                  onChange={(event) => setProtectionDraft({ ...draft, pinConfirm: event.target.value })}
+                  pattern="[0-9]*"
+                  type="password"
+                  value={pinConfirm}
+                />
+              </div>
+            </div>
+          ) : null}
+          {selectedProtectionMode === 'unsecured' ? (
+            <div className="space-y-3">
+              <Alert variant="warning">
+                <AlertDescription>{t(($) => $.walletProtectionUnsecuredWarning)}</AlertDescription>
+              </Alert>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  checked={unsecuredConfirmed}
+                  id={unsecuredConfirmId}
+                  onCheckedChange={(checked) => setProtectionDraft({ ...draft, unsecuredConfirmed: checked === true })}
+                />
+                <Label htmlFor={unsecuredConfirmId}>{t(($) => $.walletProtectionUnsecuredConfirm)}</Label>
+              </div>
+            </div>
+          ) : null}
+          <Button disabled={isProtectionBusy || !hasProtectionChange} type="submit">
+            {t(($) => $.actionSave)}
+          </Button>
+        </form>
+
+        <SettingsUiAccountList
+          activeId={activeAccount.id}
+          deleteItem={(input) => deleteMutation.mutateAsync({ id: input.id })}
+          items={accounts}
+          networkType={activeNetwork.type}
+          onMoveDown={(item: Account) => handleMove(item, 1)}
+          onMoveUp={(item: Account) => handleMove(item, -1)}
+          requestAirdrop={async (item) => {
+            await requestAirdropMutation.mutateAsync({ address: item.publicKey, amount: solToLamports('1') })
+          }}
+        />
+      </div>
     </UiCard>
   )
+}
+
+function createProtectionDraft(walletId: string, mode: Wallet['protectionMode']): ProtectionDraft {
+  return {
+    pin: '',
+    pinConfirm: '',
+    selectedMode: mode,
+    sourceMode: mode,
+    unsecuredConfirmed: false,
+    walletId,
+  }
+}
+
+function getProtectionModeLabel(mode: Wallet['protectionMode'], labels: ProtectionModeLabels): string {
+  return labels[mode]
+}
+
+function getWalletProtectionInput(input: {
+  pin: string
+  pinConfirm: string
+  protectionMode: Wallet['protectionMode']
+  unsecuredConfirmed: boolean
+  validationMessages: WalletProtectionValidationMessages
+}): WalletProtectionInput {
+  switch (input.protectionMode) {
+    case 'password':
+      return { mode: 'password' }
+    case 'pin':
+      if (!new RegExp(`^\\d{${VAULT_PIN_MIN_LENGTH},${VAULT_PIN_MAX_LENGTH}}$`).test(input.pin)) {
+        throw new Error(input.validationMessages.pinLength)
+      }
+      if (input.pin !== input.pinConfirm) {
+        throw new Error(input.validationMessages.pinMismatch)
+      }
+      return { mode: 'pin', pin: input.pin }
+    case 'unsecured':
+      if (!input.unsecuredConfirmed) {
+        throw new Error(input.validationMessages.unsecuredConfirm)
+      }
+      return { mode: 'unsecured' }
+  }
+}
+
+function parseWalletProtectionModeValue(value: string): Wallet['protectionMode'] {
+  switch (value) {
+    case 'pin':
+    case 'unsecured':
+      return value
+    default:
+      return 'password'
+  }
 }

--- a/packages/feature-settings/src/ui/settings-ui-wallet-list-item.tsx
+++ b/packages/feature-settings/src/ui/settings-ui-wallet-list-item.tsx
@@ -1,4 +1,8 @@
+import type { Wallet } from '@workspace/db/wallet/wallet'
+import { useTranslation } from '@workspace/i18n'
+import { Badge } from '@workspace/ui/components/badge'
 import { Item, ItemActions, ItemContent, ItemTitle } from '@workspace/ui/components/item'
+import { cn } from '@workspace/ui/lib/utils'
 import { Link } from 'react-router'
 import { SettingsUiWalletItem } from './settings-ui-wallet-item.tsx'
 import { SettingsUiWalletMenu, type SettingsUiWalletMenuProps } from './settings-ui-wallet-menu.tsx'
@@ -8,6 +12,14 @@ export function SettingsUiWalletListItem({
   wallet,
   ...props
 }: SettingsUiWalletMenuProps & { activeId: null | string }) {
+  const { t } = useTranslation('settings')
+  const protectionMode = wallet.protectionMode
+  const protectionLabel = getProtectionModeLabel(protectionMode, {
+    password: t(($) => $.walletProtectionPassword),
+    pin: t(($) => $.walletProtectionPin),
+    unsecured: t(($) => $.walletProtectionUnsecured),
+  })
+
   return (
     <Item key={wallet.id} role="listitem" variant={activeId === wallet.id ? 'muted' : 'outline'}>
       <ItemContent className="min-w-0">
@@ -17,9 +29,45 @@ export function SettingsUiWalletListItem({
           </Link>
         </ItemTitle>
       </ItemContent>
-      <ItemActions>
+      <ItemActions className="ml-auto shrink-0">
+        <Badge
+          className={cn('max-w-[140px] truncate md:max-w-none', getProtectionBadgeClassName(protectionMode))}
+          title={protectionLabel}
+          variant={getProtectionBadgeVariant(protectionMode)}
+        >
+          {protectionLabel}
+        </Badge>
         <SettingsUiWalletMenu {...props} wallet={wallet} />
       </ItemActions>
     </Item>
   )
+}
+
+function getProtectionBadgeClassName(mode: Wallet['protectionMode']): string | undefined {
+  switch (mode) {
+    case 'password':
+      return undefined
+    case 'pin':
+      return 'border-transparent bg-yellow-500 text-black'
+    case 'unsecured':
+      return undefined
+  }
+}
+
+function getProtectionBadgeVariant(mode: Wallet['protectionMode']): 'destructive' | 'outline' | 'success' {
+  switch (mode) {
+    case 'password':
+      return 'success'
+    case 'pin':
+      return 'outline'
+    case 'unsecured':
+      return 'destructive'
+  }
+}
+
+function getProtectionModeLabel(
+  mode: Wallet['protectionMode'],
+  labels: Record<Wallet['protectionMode'], string>,
+): string {
+  return labels[mode]
 }

--- a/packages/i18n/locales/en/settings.json
+++ b/packages/i18n/locales/en/settings.json
@@ -110,5 +110,17 @@
   "walletPageAddTitle": "Create wallet",
   "walletPageEditTitle": "Edit wallet",
   "walletPageGenerateTitle": "Generate wallet",
-  "walletPageImportTitle": "Import wallet"
+  "walletPageImportTitle": "Import wallet",
+  "walletProtectionCurrentLabel": "Current",
+  "walletProtectionPassword": "Password",
+  "walletProtectionPin": "PIN",
+  "walletProtectionPinConfirmLabel": "Confirm PIN",
+  "walletProtectionPinLabel": "PIN",
+  "walletProtectionPinLengthError": "PIN must be {{min, number}}-{{max, number}} digits",
+  "walletProtectionPinMismatchError": "PINs do not match",
+  "walletProtectionTitle": "Wallet protection",
+  "walletProtectionUnsecured": "Unsecured",
+  "walletProtectionUnsecuredConfirm": "I understand this wallet is not protected by a password or PIN.",
+  "walletProtectionUnsecuredConfirmError": "Confirm this wallet is not protected",
+  "walletProtectionUnsecuredWarning": "Anyone with access to this browser profile may be able to use this wallet."
 }

--- a/packages/i18n/locales/es/settings.json
+++ b/packages/i18n/locales/es/settings.json
@@ -110,5 +110,17 @@
   "walletPageAddTitle": "Crear billetera",
   "walletPageEditTitle": "Editar billetera",
   "walletPageGenerateTitle": "Generar billetera",
-  "walletPageImportTitle": "Importar billetera"
+  "walletPageImportTitle": "Importar billetera",
+  "walletProtectionCurrentLabel": "Actual",
+  "walletProtectionPassword": "Contraseña",
+  "walletProtectionPin": "PIN",
+  "walletProtectionPinConfirmLabel": "Confirmar PIN",
+  "walletProtectionPinLabel": "PIN",
+  "walletProtectionPinLengthError": "El PIN debe tener entre {{min, number}} y {{max, number}} dígitos",
+  "walletProtectionPinMismatchError": "Los PIN no coinciden",
+  "walletProtectionTitle": "Protección de billetera",
+  "walletProtectionUnsecured": "Sin protección",
+  "walletProtectionUnsecuredConfirm": "Entiendo que esta billetera no está protegida por contraseña ni PIN.",
+  "walletProtectionUnsecuredConfirmError": "Confirma que esta billetera no está protegida",
+  "walletProtectionUnsecuredWarning": "Cualquier persona con acceso a este perfil del navegador podría usar esta billetera."
 }

--- a/packages/i18n/src/resources.d.ts
+++ b/packages/i18n/src/resources.d.ts
@@ -270,6 +270,18 @@ export default interface Resources {
     walletPageEditTitle: 'Edit wallet'
     walletPageGenerateTitle: 'Generate wallet'
     walletPageImportTitle: 'Import wallet'
+    walletProtectionCurrentLabel: 'Current'
+    walletProtectionPassword: 'Password'
+    walletProtectionPin: 'PIN'
+    walletProtectionPinConfirmLabel: 'Confirm PIN'
+    walletProtectionPinLabel: 'PIN'
+    walletProtectionPinLengthError: 'PIN must be {{min, number}}-{{max, number}} digits'
+    walletProtectionPinMismatchError: 'PINs do not match'
+    walletProtectionTitle: 'Wallet protection'
+    walletProtectionUnsecured: 'Unsecured'
+    walletProtectionUnsecuredConfirm: 'I understand this wallet is not protected by a password or PIN.'
+    walletProtectionUnsecuredConfirmError: 'Confirm this wallet is not protected'
+    walletProtectionUnsecuredWarning: 'Anyone with access to this browser profile may be able to use this wallet.'
   }
   shell: {
     accountAdd: 'Add account'


### PR DESCRIPTION
Add per-wallet protection controls in settings so a wallet can be changed between password, PIN, and unsecured modes.

Stop falling back to password when stored wallet protection cannot be parsed, so unsupported modes surface the schema error directly.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wallet protection management interface in wallet settings with support for password, PIN, or unsecured modes.
  * Added visual protection status indicator on wallet list items to display current protection mode.
  * Updated localization for wallet protection settings across supported languages.

* **Bug Fixes**
  * Protection-mode validation errors are now surfaced instead of being silently defaulted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/samui-build/samui-wallet/pull/1071)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->