### PR TITLE
feat: unlock settings sensitive actions

### DIFF
--- a/packages/feature-settings/src/settings-feature-wallet-add-account.tsx
+++ b/packages/feature-settings/src/settings-feature-wallet-add-account.tsx
@@ -15,12 +15,15 @@ import { UiPrompt } from '@workspace/ui/components/ui-prompt'
 import { ellipsify } from '@workspace/ui/lib/ellipsify'
 import { toastError } from '@workspace/ui/lib/toast-error'
 import { toastSuccess } from '@workspace/ui/lib/toast-success'
+import { useVaultUnlockDialog } from '@workspace/vault-react/vault-unlock-provider'
+import { useRef } from 'react'
 import { Link, useParams } from 'react-router'
 import { AccountUiIcon } from './ui/account-ui-icon.tsx'
 import { SettingsUiWalletItem } from './ui/settings-ui-wallet-item.tsx'
 
 export function SettingsFeatureWalletAddAccount() {
   const { t } = useTranslation('settings')
+  const { requestUnlock } = useVaultUnlockDialog()
   const { walletId } = useParams<{ walletId: string }>()
   if (!walletId) {
     throw new Error('Parameter walletId is required')
@@ -30,27 +33,47 @@ export function SettingsFeatureWalletAddAccount() {
   const deriveAccount = useWalletDeriveAndCreateAccount()
   const createAccountMutation = useAccountCreate()
   const accounts = useAccountsForWalletLive({ walletId })
+  const accountsRef = useRef(accounts)
+  accountsRef.current = accounts
 
   async function createAccountDerived(wallet: Wallet) {
+    const unlocked = await requestUnlock({
+      mode: wallet.protectionMode,
+      reason: 'generic',
+      walletId: wallet.id,
+    })
+    if (!unlocked) {
+      return
+    }
+
     try {
-      await deriveAccount.mutateAsync({ index: accounts?.length ?? 0, item: wallet })
+      await deriveAccount.mutateAsync({ index: accountsRef.current?.length ?? 0, item: wallet })
       toastSuccess(`Account derived for ${wallet.name}`)
     } catch (e) {
       toastError(`${e}`)
     }
   }
 
-  async function createAccountImported(walletId: string, input: string) {
+  async function createAccountImported(wallet: Wallet, input: string) {
     if (!input.trim().length) {
       return
     }
     try {
       const { publicKey, secretKey } = await importKeyPairToPublicKeySecretKey(input, true)
       assertIsAddress(publicKey)
-      await createAccountMutation.mutateAsync({
-        input: { name: ellipsify(publicKey), publicKey, secretKey, type: 'Imported', walletId },
+      const unlocked = await requestUnlock({
+        mode: wallet.protectionMode,
+        reason: 'generic',
+        walletId: wallet.id,
       })
-      toastSuccess(`Account imported for ${wallet?.name}`)
+      if (!unlocked) {
+        return
+      }
+
+      await createAccountMutation.mutateAsync({
+        input: { name: ellipsify(publicKey), publicKey, secretKey, type: 'Imported', walletId: wallet.id },
+      })
+      toastSuccess(`Account imported for ${wallet.name}`)
     } catch (e) {
       toastError(`${e}`)
     }
@@ -122,7 +145,7 @@ export function SettingsFeatureWalletAddAccount() {
           </ItemContent>
           <ItemActions>
             <UiPrompt
-              action={(value) => createAccountImported(wallet.id, value)}
+              action={(value) => createAccountImported(wallet, value)}
               actionLabel={t(($) => $.actionImport)}
               description={t(($) => $.walletAddAccountImportDescription)}
               label={t(($) => $.walletAddAccountImportLabel)}

--- a/packages/feature-settings/src/ui/settings-ui-bottom-sheet-export-account-secret-key.tsx
+++ b/packages/feature-settings/src/ui/settings-ui-bottom-sheet-export-account-secret-key.tsx
@@ -1,11 +1,14 @@
 import type { Account } from '@workspace/db/account/account'
 import { useAccountReadSecretKey } from '@workspace/db-react/use-account-read-secret-key'
+import { useWalletFindUnique } from '@workspace/db-react/use-wallet-find-unique'
 import { useTranslation } from '@workspace/i18n'
 import { Button } from '@workspace/ui/components/button'
 import { UiBottomSheet } from '@workspace/ui/components/ui-bottom-sheet'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
-import { useState } from 'react'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { useVaultUnlockDialog } from '@workspace/vault-react/vault-unlock-provider'
+import { useRef, useState } from 'react'
 import { SettingsUiExportConfirm } from './settings-ui-export-confirm.tsx'
 import { SettingsUiMnemonicBlur } from './settings-ui-mnemonic-blur.tsx'
 
@@ -19,20 +22,65 @@ export function SettingsUiBottomSheetExportAccountSecretKey({
   setOpen: (value: boolean) => void
 }) {
   const { t } = useTranslation('settings')
+  const { requestUnlock } = useVaultUnlockDialog()
+  const sessionRef = useRef(0)
   const [revealed, setRevealed] = useState(false)
+  const [secretKey, setSecretKey] = useState<string>()
+  const wallet = useWalletFindUnique({ id: account.walletId })
   const readSecretKeyMutation = useAccountReadSecretKey()
+
+  function handleOpenChange(value: boolean) {
+    if (!value) {
+      sessionRef.current += 1
+      readSecretKeyMutation.reset()
+      setRevealed(false)
+      setSecretKey(undefined)
+    }
+    setOpen(value)
+  }
+
+  async function handleShowSecretKey() {
+    const session = sessionRef.current
+    if (!wallet) {
+      toastError('Wallet not found')
+      return
+    }
+
+    const unlocked = await requestUnlock({
+      mode: wallet.protectionMode,
+      reason: 'exportAccountSecretKey',
+      walletId: wallet.id,
+    })
+    if (!unlocked) {
+      return
+    }
+    if (session !== sessionRef.current) {
+      return
+    }
+
+    try {
+      const result = await readSecretKeyMutation.mutateAsync({ id: account.id })
+      if (session === sessionRef.current) {
+        setSecretKey(result)
+      }
+    } catch (caught) {
+      if (session === sessionRef.current) {
+        toastError(caught instanceof Error ? caught.message : `${caught}`)
+      }
+    }
+  }
 
   return (
     <UiBottomSheet
       description={t(($) => $.exportSecretKeyCopyConfirmDescription)}
-      onOpenChange={(value) => setOpen(value)}
+      onOpenChange={handleOpenChange}
       open={open}
       title={t(($) => $.exportSecretKeyCopyConfirmTitle)}
     >
       <div className="px-4 pb-4">
-        {readSecretKeyMutation?.data?.length ? (
+        {secretKey?.length ? (
           <div className="space-y-2 text-center">
-            <SettingsUiMnemonicBlur revealed={revealed} value={readSecretKeyMutation.data} />
+            <SettingsUiMnemonicBlur revealed={revealed} value={secretKey} />
             <div className="space-x-2">
               <Button onClick={() => setRevealed((val) => !val)} variant="secondary">
                 <UiIcon icon="watch" />
@@ -40,16 +88,13 @@ export function SettingsUiBottomSheetExportAccountSecretKey({
               </Button>
               <UiTextCopyButton
                 label={t(($) => $.exportSecretKeyCopy)}
-                text={readSecretKeyMutation.data}
+                text={secretKey}
                 toast={t(($) => $.exportSecretKeyCopyCopied)}
               />
             </div>
           </div>
         ) : (
-          <SettingsUiExportConfirm
-            confirm={() => readSecretKeyMutation.mutateAsync({ id: account.id })}
-            label={t(($) => $.exportSecretKeyShow)}
-          />
+          <SettingsUiExportConfirm confirm={handleShowSecretKey} label={t(($) => $.exportSecretKeyShow)} />
         )}
       </div>
     </UiBottomSheet>

--- a/packages/feature-settings/src/ui/settings-ui-bottom-sheet-export-wallet-mnemonic.tsx
+++ b/packages/feature-settings/src/ui/settings-ui-bottom-sheet-export-wallet-mnemonic.tsx
@@ -5,7 +5,9 @@ import { Button } from '@workspace/ui/components/button'
 import { UiBottomSheet } from '@workspace/ui/components/ui-bottom-sheet'
 import { UiIcon } from '@workspace/ui/components/ui-icon'
 import { UiTextCopyButton } from '@workspace/ui/components/ui-text-copy-button'
-import { useState } from 'react'
+import { toastError } from '@workspace/ui/lib/toast-error'
+import { useVaultUnlockDialog } from '@workspace/vault-react/vault-unlock-provider'
+import { useRef, useState } from 'react'
 import { SettingsUiExportConfirm } from './settings-ui-export-confirm.tsx'
 import { SettingsUiMnemonicBlur } from './settings-ui-mnemonic-blur.tsx'
 
@@ -19,20 +21,59 @@ export function SettingsUiBottomSheetExportWalletMnemonic({
   setOpen: (value: boolean) => void
 }) {
   const { t } = useTranslation('settings')
+  const { requestUnlock } = useVaultUnlockDialog()
+  const sessionRef = useRef(0)
+  const [mnemonic, setMnemonic] = useState<string>()
   const [revealed, setRevealed] = useState(false)
   const readMnemonicMutation = useWalletReadMnemonic()
+
+  function handleOpenChange(value: boolean) {
+    if (!value) {
+      sessionRef.current += 1
+      readMnemonicMutation.reset()
+      setMnemonic(undefined)
+      setRevealed(false)
+    }
+    setOpen(value)
+  }
+
+  async function handleShowMnemonic() {
+    const session = sessionRef.current
+    const unlocked = await requestUnlock({
+      mode: wallet.protectionMode,
+      reason: 'exportWalletMnemonic',
+      walletId: wallet.id,
+    })
+    if (!unlocked) {
+      return
+    }
+    if (session !== sessionRef.current) {
+      return
+    }
+
+    try {
+      const result = await readMnemonicMutation.mutateAsync({ id: wallet.id })
+      if (session === sessionRef.current) {
+        setMnemonic(result)
+      }
+    } catch (caught) {
+      if (session === sessionRef.current) {
+        toastError(caught instanceof Error ? caught.message : `${caught}`)
+      }
+    }
+  }
 
   return (
     <UiBottomSheet
       description={t(($) => $.exportMnemonicCopyConfirmDescription)}
-      onOpenChange={(value) => setOpen(value)}
+      onOpenChange={handleOpenChange}
       open={open}
       title={t(($) => $.exportMnemonicCopyConfirmTitle)}
     >
       <div className="px-4 pb-4">
-        {readMnemonicMutation.data?.length ? (
+        {mnemonic?.length ? (
           <div className="space-y-2 text-center">
-            <SettingsUiMnemonicBlur revealed={revealed} value={readMnemonicMutation.data} />
+            <SettingsUiMnemonicBlur revealed={revealed} value={mnemonic} />
             <div className="space-x-2">
               <Button onClick={() => setRevealed((val) => !val)} variant="secondary">
                 <UiIcon icon="watch" />
@@ -40,16 +81,13 @@ export function SettingsUiBottomSheetExportWalletMnemonic({
               </Button>
               <UiTextCopyButton
                 label={t(($) => $.exportMnemonicCopy)}
-                text={readMnemonicMutation.data}
+                text={mnemonic}
                 toast={t(($) => $.exportMnemonicCopyCopied)}
               />
             </div>
           </div>
         ) : (
-          <SettingsUiExportConfirm
-            confirm={() => readMnemonicMutation.mutateAsync({ id: wallet.id })}
-            label={t(($) => $.exportMnemonicShow)}
-          />
+          <SettingsUiExportConfirm confirm={handleShowMnemonic} label={t(($) => $.exportMnemonicShow)} />
         )}
       </div>
     </UiBottomSheet>


### PR DESCRIPTION
Require the shared vault unlock dialog before settings reads wallet mnemonics, reads account secret keys, or derives new accounts.

Reset export sheet mutation data and reveal state when the sheets close so previously read secrets are not shown on reopen.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1072" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Wallet account creation (derived/imported) now requires vault unlock confirmation.
  * Exporting account secret keys requires vault unlock.
  * Exporting wallet mnemonics requires vault unlock.

* **Bug Fixes**
  * Export dialogs clear sensitive state on close and ignore stale results across open/close cycles.
  * Errors during export now surface as visible error messages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/samui-build/samui-wallet/pull/1072)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->