### PR TITLE
feat: add background vault runtime for signing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -153,6 +153,7 @@
         "@webext-core/proxy-service": "2.0.0",
         "@webext-core/storage": "1.2.0",
         "@workspace/context": "workspace:*",
+        "@workspace/core": "workspace:*",
         "@workspace/db": "workspace:*",
         "@workspace/keypair": "workspace:*",
         "@workspace/ui": "workspace:*",

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -9,6 +9,7 @@
     "@webext-core/proxy-service": "2.0.0",
     "@webext-core/storage": "1.2.0",
     "@workspace/context": "workspace:*",
+    "@workspace/core": "workspace:*",
     "@workspace/db": "workspace:*",
     "@workspace/keypair": "workspace:*",
     "@workspace/ui": "workspace:*",

--- a/packages/background/src/services.ts
+++ b/packages/background/src/services.ts
@@ -1,9 +1,15 @@
+import { createAppContext } from '@workspace/context/create-app-context'
+
 import { registerDbService } from './services/db.ts'
 import { registerRequestService } from './services/request.ts'
 import { registerSignService } from './services/sign.ts'
+import { registerVaultRuntimeService } from './services/vault.ts'
 
 export function services() {
-  registerDbService()
+  const ctx = createAppContext()
+
+  registerVaultRuntimeService(ctx)
+  registerDbService(ctx)
   registerRequestService()
-  registerSignService()
+  registerSignService(ctx)
 }

--- a/packages/background/src/services/db.ts
+++ b/packages/background/src/services/db.ts
@@ -10,7 +10,6 @@ import type { StandardConnectOutput } from '@wallet-standard/core'
 import type { ProxyService, ProxyServiceKey } from '@webext-core/proxy-service'
 import { createProxyService, registerService } from '@webext-core/proxy-service'
 import type { AppContext } from '@workspace/context/app-context'
-import { createAppContext } from '@workspace/context/create-app-context'
 import type { Account } from '@workspace/db/account/account'
 import { accountCreate } from '@workspace/db/account/account-create'
 import { accountFindUnique } from '@workspace/db/account/account-find-unique'
@@ -101,8 +100,7 @@ export function getDbService(): ProxyService<DbService> {
   return (dbService ?? createProxyService(dbServiceKey)) as ProxyService<DbService>
 }
 
-export function registerDbService(): DbService {
-  const ctx = createAppContext()
+export function registerDbService(ctx: AppContext): DbService {
   dbService = createDbService(ctx)
   registerService(dbServiceKey, dbService)
   return dbService

--- a/packages/background/src/services/sign.ts
+++ b/packages/background/src/services/sign.ts
@@ -22,11 +22,24 @@ import type {
 import { createSignInMessage } from '@solana/wallet-standard-util'
 import type { ProxyService, ProxyServiceKey } from '@webext-core/proxy-service'
 import { createProxyService, registerService } from '@webext-core/proxy-service'
+import type { AppContext } from '@workspace/context/app-context'
+import type { Account } from '@workspace/db/account/account'
 
 import { decodeTransportBytes } from '../transport-bytes.ts'
 import { getDbService } from './db.ts'
 
 const rpc = createSolanaRpc('https://api.devnet.solana.com')
+
+async function withUnlockedActiveWallet<T>(ctx: AppContext, operation: (active: Account) => Promise<T>): Promise<T> {
+  const active = await getDbService().account.active()
+
+  try {
+    await ctx.vault.requireWalletKey({ walletId: active.walletId })
+    return await operation(active)
+  } finally {
+    ctx.vault.lock()
+  }
+}
 
 // TODO: None of this code is safe for production use.
 // Private keys should not be handled in this way.
@@ -36,87 +49,94 @@ const rpc = createSolanaRpc('https://api.devnet.solana.com')
 // Nothing about this code should be trusted.
 // This is acceptable for a POC
 // This will be improved post-hackathon.
-function createSignService() {
+function createSignService(ctx: AppContext) {
   return {
     signAndSendTransaction: async (
       inputs: SolanaSignAndSendTransactionInput[],
     ): Promise<SolanaSignAndSendTransactionOutput[]> => {
-      const results: SolanaSignAndSendTransactionOutput[] = []
-      const key = await getDbService().account.keyPair()
+      return await withUnlockedActiveWallet(ctx, async () => {
+        const results: SolanaSignAndSendTransactionOutput[] = []
+        const key = await getDbService().account.keyPair()
 
-      for (const input of inputs) {
-        const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
-        const transaction = await signTransaction([key], decoded)
-        assertIsSendableTransaction(transaction)
-        const sendTransaction = sendTransactionWithoutConfirmingFactory({ rpc })
-        await sendTransaction(transaction, { commitment: 'confirmed' })
+        for (const input of inputs) {
+          const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
+          const transaction = await signTransaction([key], decoded)
+          assertIsSendableTransaction(transaction)
+          const sendTransaction = sendTransactionWithoutConfirmingFactory({ rpc })
+          await sendTransaction(transaction, { commitment: 'confirmed' })
 
-        results.push({
-          signature: new Uint8Array(getBase58Encoder().encode(getSignatureFromTransaction(transaction))),
-        })
-      }
+          results.push({
+            signature: new Uint8Array(getBase58Encoder().encode(getSignatureFromTransaction(transaction))),
+          })
+        }
 
-      return results
+        return results
+      })
     },
     signIn: async (inputs: SolanaSignInInput[]): Promise<SolanaSignInOutput[]> => {
-      const results: SolanaSignInOutput[] = []
-      const active = await getDbService().account.active()
-      const accounts = await getDbService().account.walletAccounts()
+      return await withUnlockedActiveWallet(ctx, async (active) => {
+        const results: SolanaSignInOutput[] = []
+        const accounts = await getDbService().account.walletAccounts()
 
-      if (accounts.accounts[0] === undefined) {
-        throw new Error('No wallet account found')
-      }
+        if (accounts.accounts[0] === undefined) {
+          throw new Error('No wallet account found')
+        }
 
-      const { privateKey } = await getDbService().account.keyPair()
+        const { privateKey } = await getDbService().account.keyPair()
 
-      for (const input of inputs) {
-        const signedMessage = createSignInMessage({
-          ...input,
-          address: input.address || active.publicKey,
-          domain: input.domain || globalThis.self?.location?.hostname || 'localhost',
-        })
-        const signature = await signBytes(privateKey, signedMessage)
+        for (const input of inputs) {
+          const signedMessage = createSignInMessage({
+            ...input,
+            address: input.address || active.publicKey,
+            domain: input.domain || globalThis.self?.location?.hostname || 'localhost',
+          })
+          const signature = await signBytes(privateKey, signedMessage)
 
-        results.push({
-          account: accounts.accounts[0],
-          signature,
-          signatureType: 'ed25519',
-          signedMessage,
-        })
-      }
+          results.push({
+            account: accounts.accounts[0],
+            signature,
+            signatureType: 'ed25519',
+            signedMessage,
+          })
+        }
 
-      return results
+        return results
+      })
     },
     signMessage: async (inputs: SolanaSignMessageInput[]): Promise<SolanaSignMessageOutput[]> => {
-      const results: SolanaSignMessageOutput[] = []
-      const { privateKey } = await getDbService().account.keyPair()
+      return await withUnlockedActiveWallet(ctx, async () => {
+        const results: SolanaSignMessageOutput[] = []
+        const { privateKey } = await getDbService().account.keyPair()
 
-      for (const input of inputs) {
-        const signedMessage = decodeTransportBytes(input.message)
-        const signature = await signBytes(privateKey, signedMessage)
+        for (const input of inputs) {
+          const signedMessage = decodeTransportBytes(input.message)
+          const signature = await signBytes(privateKey, signedMessage)
 
-        results.push({
-          signature,
-          signatureType: 'ed25519',
-          signedMessage,
-        })
-      }
+          results.push({
+            signature,
+            signatureType: 'ed25519',
+            signedMessage,
+          })
+        }
 
-      return results
+        return results
+      })
     },
     signTransaction: async (inputs: SolanaSignTransactionInput[]): Promise<SolanaSignTransactionOutput[]> => {
-      const results: SolanaSignTransactionOutput[] = []
-      const key = await getDbService().account.keyPair()
+      return await withUnlockedActiveWallet(ctx, async () => {
+        const results: SolanaSignTransactionOutput[] = []
+        const key = await getDbService().account.keyPair()
 
-      for (const input of inputs) {
-        const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
-        const signed = await signTransaction([key], decoded)
-        results.push({
-          signedTransaction: new Uint8Array(getTransactionEncoder().encode(signed)),
-        })
-      }
+        for (const input of inputs) {
+          const decoded = getTransactionDecoder().decode(decodeTransportBytes(input.transaction))
+          const signed = await signTransaction([key], decoded)
+          results.push({
+            signedTransaction: new Uint8Array(getTransactionEncoder().encode(signed)),
+          })
+        }
 
-      return results
+        return results
+      })
     },
   }
 }
@@ -130,8 +150,8 @@ export function getSignService(): ProxyService<SignService> {
   return (signService ?? createProxyService(signServiceKey)) as ProxyService<SignService>
 }
 
-export function registerSignService(): SignService {
-  signService = createSignService()
+export function registerSignService(ctx: AppContext): SignService {
+  signService = createSignService(ctx)
   registerService(signServiceKey, signService)
   return signService
 }

--- a/packages/background/src/services/vault.ts
+++ b/packages/background/src/services/vault.ts
@@ -1,0 +1,83 @@
+import type { ProxyService, ProxyServiceKey } from '@webext-core/proxy-service'
+import { createProxyService, registerService } from '@webext-core/proxy-service'
+import type { AppContext } from '@workspace/context/app-context'
+import { tryCatch } from '@workspace/core/try-catch'
+import type { Account } from '@workspace/db/account/account'
+import { accountFindUnique } from '@workspace/db/account/account-find-unique'
+import { settingFindUnique } from '@workspace/db/setting/setting-find-unique'
+import type { Wallet, WalletProtectionMode } from '@workspace/db/wallet/wallet'
+import { walletFindUnique } from '@workspace/db/wallet/wallet-find-unique'
+
+function createVaultRuntimeService(ctx: AppContext) {
+  return {
+    activeWalletProtectionMode: async (): Promise<WalletProtectionMode> => {
+      const wallet = await findActiveWallet(ctx)
+      return wallet?.protectionMode ?? 'password'
+    },
+    isActiveWalletUnlocked: async (): Promise<boolean> => {
+      const account = await findActiveAccount(ctx)
+      if (!account) {
+        return ctx.vault.isUnlocked()
+      }
+
+      const wallet = await walletFindUnique(ctx, account.walletId)
+      if (wallet?.protectionMode === 'unsecured') {
+        return true
+      }
+
+      const { error } = await tryCatch(ctx.vault.requireWalletKey({ walletId: account.walletId }))
+      return !error
+    },
+    isConfigured: async (): Promise<boolean> => await ctx.vault.isConfigured(),
+    lock: (): void => ctx.vault.lock(),
+    unlock: async (input: { password: string }): Promise<void> => await ctx.vault.unlock(input),
+    unlockActiveWallet: async (input: { credential: string }): Promise<void> => {
+      const account = await findActiveAccount(ctx)
+      if (!account) {
+        await ctx.vault.unlock({ password: input.credential })
+        return
+      }
+
+      const wallet = await walletFindUnique(ctx, account.walletId)
+      if (!wallet || wallet.protectionMode === 'password') {
+        await ctx.vault.unlock({ password: input.credential })
+        return
+      }
+
+      await ctx.vault.unlockWallet({ credential: input.credential, walletId: account.walletId })
+    },
+  }
+}
+
+type VaultRuntimeService = ReturnType<typeof createVaultRuntimeService>
+
+const vaultRuntimeServiceKey = 'VaultRuntimeService' as ProxyServiceKey<VaultRuntimeService>
+let vaultRuntimeService: VaultRuntimeService | undefined
+
+async function findActiveAccount(ctx: AppContext): Promise<Account | null> {
+  const accountId = (await settingFindUnique(ctx, 'activeAccountId'))?.value
+  if (!accountId) {
+    return null
+  }
+
+  return await accountFindUnique(ctx, accountId)
+}
+
+async function findActiveWallet(ctx: AppContext): Promise<Wallet | null> {
+  const account = await findActiveAccount(ctx)
+  if (!account) {
+    return null
+  }
+
+  return await walletFindUnique(ctx, account.walletId)
+}
+
+export function getVaultRuntimeService(): ProxyService<VaultRuntimeService> {
+  return (vaultRuntimeService ?? createProxyService(vaultRuntimeServiceKey)) as ProxyService<VaultRuntimeService>
+}
+
+export function registerVaultRuntimeService(ctx: AppContext): VaultRuntimeService {
+  vaultRuntimeService = createVaultRuntimeService(ctx)
+  registerService(vaultRuntimeServiceKey, vaultRuntimeService)
+  return vaultRuntimeService
+}

--- a/packages/background/test/db-service.test.ts
+++ b/packages/background/test/db-service.test.ts
@@ -1,3 +1,4 @@
+import type { AppContext } from '@workspace/context/app-context'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { registerDbService } from '../src/services/db.ts'
@@ -7,10 +8,10 @@ const mocks = vi.hoisted(() => ({
   accountFindUnique: vi.fn(),
   accountReadSecretKey: vi.fn(),
   address: vi.fn(),
-  appContext: { db: { id: 'db' } },
-  createAppContext: vi.fn(),
+  addressEncode: vi.fn(),
   createKeyPairFromBytes: vi.fn(),
   createProxyService: vi.fn(),
+  db: { id: 'db' },
   deriveFromMnemonicAtIndex: vi.fn(),
   ellipsify: vi.fn(),
   getAddressEncoder: vi.fn(),
@@ -53,10 +54,6 @@ vi.mock('@workspace/db/account/account-read-secret-key', () => ({
   accountReadSecretKey: mocks.accountReadSecretKey,
 }))
 
-vi.mock('@workspace/context/create-app-context', () => ({
-  createAppContext: mocks.createAppContext,
-}))
-
 vi.mock('@workspace/db/setting/setting-find-unique', () => ({
   settingFindUnique: mocks.settingFindUnique,
 }))
@@ -73,11 +70,17 @@ vi.mock('@workspace/ui/lib/ellipsify', () => ({
   ellipsify: mocks.ellipsify,
 }))
 
+const activeAccount = {
+  publicKey: 'active-public-key',
+  walletId: 'wallet-id',
+}
 const accountId = 'active-account-id'
+const backgroundContext = { db: mocks.db, vault: { id: 'vault' } } as unknown as AppContext
 const keyPair = {
   privateKey: { id: 'private-key' } as unknown as CryptoKey,
   publicKey: { id: 'public-key' } as unknown as CryptoKey,
 }
+const publicKeyBytes = new Uint8Array([5, 6])
 const secretKey = JSON.stringify([1, 2, 3, 4])
 const secretKeyBytes = new Uint8Array([1, 2, 3, 4])
 
@@ -85,9 +88,12 @@ describe('db-service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
+    mocks.accountFindUnique.mockResolvedValue(activeAccount)
     mocks.accountReadSecretKey.mockResolvedValue(secretKey)
-    mocks.createAppContext.mockReturnValue(mocks.appContext)
+    mocks.address.mockReturnValue(activeAccount.publicKey)
+    mocks.addressEncode.mockReturnValue(publicKeyBytes)
     mocks.createKeyPairFromBytes.mockResolvedValue(keyPair)
+    mocks.getAddressEncoder.mockReturnValue({ encode: mocks.addressEncode })
     mocks.settingFindUnique.mockResolvedValue({ value: accountId })
   })
 
@@ -95,16 +101,32 @@ describe('db-service', () => {
     it('should create the active account key pair from the active secret key', async () => {
       // ARRANGE
       expect.assertions(4)
-      const service = registerDbService()
+      const service = registerDbService(backgroundContext)
 
       // ACT
       const result = await service.account.keyPair()
 
       // ASSERT
-      expect(mocks.accountReadSecretKey).toHaveBeenCalledWith(mocks.appContext, accountId)
+      expect(mocks.accountReadSecretKey).toHaveBeenCalledWith(backgroundContext, accountId)
       expect(mocks.createKeyPairFromBytes).toHaveBeenCalledWith(secretKeyBytes)
-      expect(mocks.settingFindUnique).toHaveBeenCalledWith(mocks.appContext, 'activeAccountId')
+      expect(mocks.settingFindUnique).toHaveBeenCalledWith(backgroundContext, 'activeAccountId')
       expect(result).toBe(keyPair)
+    })
+
+    it('should return public account metadata without reading secret data', async () => {
+      // ARRANGE
+      expect.assertions(5)
+      const service = registerDbService(backgroundContext)
+
+      // ACT
+      const result = await service.account.walletAccounts()
+
+      // ASSERT
+      expect(mocks.accountReadSecretKey).not.toHaveBeenCalled()
+      expect(mocks.addressEncode).toHaveBeenCalledWith(activeAccount.publicKey)
+      expect(result.accounts[0]).not.toHaveProperty('secretKey')
+      expect(result.accounts[0]?.address).toBe(activeAccount.publicKey)
+      expect(result.accounts[0]?.publicKey).toBe(publicKeyBytes)
     })
   })
 
@@ -123,7 +145,7 @@ describe('db-service', () => {
       // ARRANGE
       expect.assertions(2)
       mocks.accountReadSecretKey.mockResolvedValue(undefined)
-      const service = registerDbService()
+      const service = registerDbService(backgroundContext)
 
       // ACT & ASSERT
       await expect(service.account.keyPair()).rejects.toThrow('Active account secretKey not found')

--- a/packages/background/test/sign-service.test.ts
+++ b/packages/background/test/sign-service.test.ts
@@ -5,7 +5,7 @@ import type {
   SolanaSignTransactionInput,
 } from '@solana/wallet-standard-features'
 import type { StandardConnectOutput } from '@wallet-standard/core'
-
+import type { AppContext } from '@workspace/context/app-context'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { registerSignService } from '../src/services/sign.ts'
@@ -31,6 +31,8 @@ const mocks = vi.hoisted(() => ({
   signTransaction: vi.fn(),
   transactionDecode: vi.fn(),
   transactionEncode: vi.fn(),
+  vaultLock: vi.fn(),
+  vaultRequireWalletKey: vi.fn(),
 }))
 
 vi.mock('@solana/kit', () => ({
@@ -58,7 +60,13 @@ vi.mock('../src/services/db.ts', () => ({
   getDbService: mocks.getDbService,
 }))
 
-const activeAccount = { publicKey: 'active-public-key' }
+const activeAccount = { publicKey: 'active-public-key', walletId: 'active-wallet-id' }
+const backgroundContext = {
+  vault: {
+    lock: mocks.vaultLock,
+    requireWalletKey: mocks.vaultRequireWalletKey,
+  },
+} as unknown as AppContext
 const decodedTransaction = { id: 'decoded-transaction' }
 const encodedTransactionBytes = new Uint8Array([14, 15])
 const privateKey = { id: 'private-key' } as unknown as CryptoKey
@@ -103,31 +111,35 @@ describe('sign-service', () => {
     mocks.signTransaction.mockResolvedValue(signedTransaction)
     mocks.transactionDecode.mockReturnValue(decodedTransaction)
     mocks.transactionEncode.mockReturnValue(encodedTransactionBytes)
+    mocks.vaultRequireWalletKey.mockResolvedValue({ id: 'wallet-key' })
   })
 
   describe('expected behavior', () => {
     it('should sign and send a transaction with the active secret key', async () => {
       // ARRANGE
-      expect.assertions(6)
-      const service = registerSignService()
+      expect.assertions(9)
+      const service = registerSignService(backgroundContext)
       const input = { transaction: transactionBytes } as SolanaSignAndSendTransactionInput
 
       // ACT
       const result = await service.signAndSendTransaction([input])
 
       // ASSERT
+      expect(mocks.accountActive).toHaveBeenCalledTimes(1)
       expect(mocks.accountKeyPair).toHaveBeenCalledTimes(1)
       expect(mocks.assertIsSendableTransaction).toHaveBeenCalledWith(signedTransaction)
       expect(mocks.base58Encode).toHaveBeenCalledWith(signatureValue)
       expect(mocks.sendTransaction).toHaveBeenCalledWith(signedTransaction, { commitment: 'confirmed' })
       expect(mocks.signTransaction).toHaveBeenCalledWith([keyPair], decodedTransaction)
+      expect(mocks.vaultLock).toHaveBeenCalledTimes(1)
+      expect(mocks.vaultRequireWalletKey).toHaveBeenCalledWith({ walletId: activeAccount.walletId })
       expect(result).toEqual([{ signature: signatureBytes }])
     })
 
     it('should sign in with the active secret key', async () => {
       // ARRANGE
-      expect.assertions(5)
-      const service = registerSignService()
+      expect.assertions(7)
+      const service = registerSignService(backgroundContext)
       const input = {} as SolanaSignInInput
 
       // ACT
@@ -141,6 +153,8 @@ describe('sign-service', () => {
         domain: 'localhost',
       })
       expect(mocks.signBytes).toHaveBeenCalledWith(privateKey, signedMessage)
+      expect(mocks.vaultLock).toHaveBeenCalledTimes(1)
+      expect(mocks.vaultRequireWalletKey).toHaveBeenCalledWith({ walletId: activeAccount.walletId })
       expect(result).toEqual([
         {
           account: walletAccount,
@@ -153,57 +167,77 @@ describe('sign-service', () => {
 
     it('should sign a message with the active secret key', async () => {
       // ARRANGE
-      expect.assertions(3)
-      const service = registerSignService()
+      expect.assertions(6)
+      const service = registerSignService(backgroundContext)
       const input = { message: transactionBytes } as SolanaSignMessageInput
 
       // ACT
       const result = await service.signMessage([input])
 
       // ASSERT
+      expect(mocks.accountActive).toHaveBeenCalledTimes(1)
       expect(mocks.accountKeyPair).toHaveBeenCalledTimes(1)
       expect(mocks.signBytes).toHaveBeenCalledWith(privateKey, transactionBytes)
+      expect(mocks.vaultLock).toHaveBeenCalledTimes(1)
+      expect(mocks.vaultRequireWalletKey).toHaveBeenCalledWith({ walletId: activeAccount.walletId })
       expect(result).toEqual([{ signature, signatureType: 'ed25519', signedMessage: transactionBytes }])
     })
 
     it('should sign a transaction with the active secret key', async () => {
       // ARRANGE
-      expect.assertions(4)
-      const service = registerSignService()
+      expect.assertions(7)
+      const service = registerSignService(backgroundContext)
       const input = { transaction: transactionBytes } as SolanaSignTransactionInput
 
       // ACT
       const result = await service.signTransaction([input])
 
       // ASSERT
+      expect(mocks.accountActive).toHaveBeenCalledTimes(1)
       expect(mocks.accountKeyPair).toHaveBeenCalledTimes(1)
       expect(mocks.signTransaction).toHaveBeenCalledWith([keyPair], decodedTransaction)
       expect(mocks.transactionEncode).toHaveBeenCalledWith(signedTransaction)
+      expect(mocks.vaultLock).toHaveBeenCalledTimes(1)
+      expect(mocks.vaultRequireWalletKey).toHaveBeenCalledWith({ walletId: activeAccount.walletId })
       expect(result).toEqual([{ signedTransaction: encodedTransactionBytes }])
     })
   })
 
   describe('unexpected behavior', () => {
-    let consoleLogSpy: ReturnType<typeof vi.spyOn>
-
     beforeEach(() => {
-      consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      vi.spyOn(console, 'log').mockImplementation(() => {})
     })
 
     afterEach(() => {
-      consoleLogSpy.mockRestore()
+      vi.restoreAllMocks()
     })
 
     it('should throw an error when the active account key pair is not available', async () => {
       // ARRANGE
-      expect.assertions(2)
+      expect.assertions(4)
       mocks.accountKeyPair.mockRejectedValue(new Error('Active account secretKey not found'))
-      const service = registerSignService()
+      const service = registerSignService(backgroundContext)
       const input = { message: transactionBytes } as SolanaSignMessageInput
 
       // ACT & ASSERT
       await expect(service.signMessage([input])).rejects.toThrow('Active account secretKey not found')
       expect(mocks.signBytes).not.toHaveBeenCalled()
+      expect(mocks.vaultLock).toHaveBeenCalledTimes(1)
+      expect(mocks.vaultRequireWalletKey).toHaveBeenCalledWith({ walletId: activeAccount.walletId })
+    })
+
+    it('should throw an error when the active wallet key is locked', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      mocks.vaultRequireWalletKey.mockRejectedValue(new Error('Vault is locked'))
+      const service = registerSignService(backgroundContext)
+      const input = { message: transactionBytes } as SolanaSignMessageInput
+
+      // ACT & ASSERT
+      await expect(service.signMessage([input])).rejects.toThrow('Vault is locked')
+      expect(mocks.accountKeyPair).not.toHaveBeenCalled()
+      expect(mocks.signBytes).not.toHaveBeenCalled()
+      expect(mocks.vaultLock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/background/test/vault-service.test.ts
+++ b/packages/background/test/vault-service.test.ts
@@ -1,0 +1,204 @@
+import type { AppContext } from '@workspace/context/app-context'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getVaultRuntimeService, registerVaultRuntimeService } from '../src/services/vault.ts'
+
+const mocks = vi.hoisted(() => {
+  const appContext = {
+    db: {},
+    vault: {
+      isConfigured: vi.fn(),
+      isUnlocked: vi.fn(),
+      lock: vi.fn(),
+      requireWalletKey: vi.fn(),
+      unlock: vi.fn(),
+      unlockWallet: vi.fn(),
+    },
+  }
+
+  return {
+    accountFindUnique: vi.fn(),
+    appContext,
+    createProxyService: vi.fn(),
+    registerService: vi.fn(),
+    settingFindUnique: vi.fn(),
+    walletFindUnique: vi.fn(),
+  }
+})
+
+vi.mock('@webext-core/proxy-service', () => ({
+  createProxyService: mocks.createProxyService,
+  registerService: mocks.registerService,
+}))
+
+vi.mock('@workspace/db/account/account-find-unique', () => ({
+  accountFindUnique: mocks.accountFindUnique,
+}))
+
+vi.mock('@workspace/db/setting/setting-find-unique', () => ({
+  settingFindUnique: mocks.settingFindUnique,
+}))
+
+vi.mock('@workspace/db/wallet/wallet-find-unique', () => ({
+  walletFindUnique: mocks.walletFindUnique,
+}))
+
+const account = {
+  id: 'account-id',
+  publicKey: 'public-key',
+  walletId: 'wallet-id',
+}
+const credential = '1234'
+const appContext = mocks.appContext as unknown as AppContext
+const wallet = {
+  id: account.walletId,
+  protectionMode: 'pin',
+}
+
+describe('vault-service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.accountFindUnique.mockResolvedValue(account)
+    mocks.appContext.vault.isConfigured.mockResolvedValue(true)
+    mocks.appContext.vault.isUnlocked.mockReturnValue(false)
+    mocks.appContext.vault.requireWalletKey.mockResolvedValue({ id: 'wallet-key' })
+    mocks.appContext.vault.unlock.mockResolvedValue(undefined)
+    mocks.appContext.vault.unlockWallet.mockResolvedValue(undefined)
+    mocks.settingFindUnique.mockResolvedValue({ value: account.id })
+    mocks.walletFindUnique.mockResolvedValue(wallet)
+  })
+
+  describe('expected behavior', () => {
+    it('should return a proxy service when the local service is not registered', () => {
+      // ARRANGE
+      expect.assertions(2)
+      const proxyService = { id: 'proxy-service' }
+      mocks.createProxyService.mockReturnValue(proxyService)
+
+      // ACT
+      const result = getVaultRuntimeService()
+
+      // ASSERT
+      expect(mocks.createProxyService).toHaveBeenCalledTimes(1)
+      expect(result).toBe(proxyService)
+    })
+
+    it('should register the vault runtime service', () => {
+      // ARRANGE
+      expect.assertions(2)
+
+      // ACT
+      const result = registerVaultRuntimeService(appContext)
+
+      // ASSERT
+      expect(mocks.registerService).toHaveBeenCalledTimes(1)
+      expect(result).toBeDefined()
+    })
+
+    it('should return the active wallet protection mode', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const service = registerVaultRuntimeService(appContext)
+
+      // ACT
+      const result = await service.activeWalletProtectionMode()
+
+      // ASSERT
+      expect(mocks.accountFindUnique).toHaveBeenCalledWith(mocks.appContext, account.id)
+      expect(mocks.walletFindUnique).toHaveBeenCalledWith(mocks.appContext, account.walletId)
+      expect(result).toBe('pin')
+    })
+
+    it('should fall back to password when there is no active wallet', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      mocks.settingFindUnique.mockResolvedValue(undefined)
+      const service = registerVaultRuntimeService(appContext)
+
+      // ACT
+      const result = await service.activeWalletProtectionMode()
+
+      // ASSERT
+      expect(result).toBe('password')
+    })
+
+    it('should report active wallet unlock status from requireWalletKey', async () => {
+      // ARRANGE
+      expect.assertions(3)
+      const service = registerVaultRuntimeService(appContext)
+
+      // ACT
+      const result = await service.isActiveWalletUnlocked()
+
+      // ASSERT
+      expect(mocks.appContext.vault.requireWalletKey).toHaveBeenCalledWith({ walletId: account.walletId })
+      expect(mocks.walletFindUnique).toHaveBeenCalledWith(mocks.appContext, account.walletId)
+      expect(result).toBe(true)
+    })
+
+    it('should report unsecured active wallet as unlocked without requiring the wallet key', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      mocks.walletFindUnique.mockResolvedValue({ ...wallet, protectionMode: 'unsecured' })
+      const service = registerVaultRuntimeService(appContext)
+
+      // ACT
+      const result = await service.isActiveWalletUnlocked()
+
+      // ASSERT
+      expect(mocks.appContext.vault.requireWalletKey).not.toHaveBeenCalled()
+      expect(result).toBe(true)
+    })
+
+    it('should unlock a PIN active wallet by wallet id', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      const service = registerVaultRuntimeService(appContext)
+
+      // ACT
+      await service.unlockActiveWallet({ credential })
+
+      // ASSERT
+      expect(mocks.appContext.vault.unlock).not.toHaveBeenCalled()
+      expect(mocks.appContext.vault.unlockWallet).toHaveBeenCalledWith({ credential, walletId: account.walletId })
+    })
+
+    it('should unlock a password active wallet through the vault password', async () => {
+      // ARRANGE
+      expect.assertions(2)
+      mocks.walletFindUnique.mockResolvedValue({ ...wallet, protectionMode: 'password' })
+      const service = registerVaultRuntimeService(appContext)
+
+      // ACT
+      await service.unlockActiveWallet({ credential })
+
+      // ASSERT
+      expect(mocks.appContext.vault.unlock).toHaveBeenCalledWith({ password: credential })
+      expect(mocks.appContext.vault.unlockWallet).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unexpected behavior', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return false when the active wallet key is locked', async () => {
+      // ARRANGE
+      expect.assertions(1)
+      mocks.appContext.vault.requireWalletKey.mockRejectedValue(new Error('Wallet is locked'))
+      const service = registerVaultRuntimeService(appContext)
+
+      // ACT
+      const result = await service.isActiveWalletUnlocked()
+
+      // ASSERT
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/packages/db/src/wallet/wallet.ts
+++ b/packages/db/src/wallet/wallet.ts
@@ -3,3 +3,4 @@ import type { z } from 'zod'
 import type { walletSchema } from './wallet-schema.ts'
 
 export type Wallet = z.infer<typeof walletSchema>
+export type WalletProtectionMode = Wallet['protectionMode']


### PR DESCRIPTION
Create a background vault runtime service and register it before the DB and sign services.

Share one AppContext across the background services and require the active wallet key before reading signing key material.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a background vault runtime service to manage wallet protection and unlock flows.

* **Improvements**
  * Signing flows now automatically unlock and re-lock wallet keys for improved security.
  * Background services refactored to use an injected application context for clearer modularity and safer dependency handling.
  * Exposed wallet protection mode typing.

* **Tests**
  * Expanded and added tests covering vault, signing, and database behaviors.

* **Chores**
  * Workspace package dependency updated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/samui-build/samui-wallet/pull/1073)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->