### PR TITLE
test: cover background wallet creation

### DIFF
--- a/packages/background/test/db-service.test.ts
+++ b/packages/background/test/db-service.test.ts
@@ -76,6 +76,10 @@ const activeAccount = {
 }
 const accountId = 'active-account-id'
 const backgroundContext = { db: mocks.db, vault: { id: 'vault' } } as unknown as AppContext
+const derivedAccount = {
+  publicKey: 'derived-public-key',
+  secretKey: 'derived-secret-key',
+}
 const keyPair = {
   privateKey: { id: 'private-key' } as unknown as CryptoKey,
   publicKey: { id: 'public-key' } as unknown as CryptoKey,
@@ -83,6 +87,7 @@ const keyPair = {
 const publicKeyBytes = new Uint8Array([5, 6])
 const secretKey = JSON.stringify([1, 2, 3, 4])
 const secretKeyBytes = new Uint8Array([1, 2, 3, 4])
+const walletId = 'wallet-id'
 
 describe('db-service', () => {
   beforeEach(() => {
@@ -93,11 +98,35 @@ describe('db-service', () => {
     mocks.address.mockReturnValue(activeAccount.publicKey)
     mocks.addressEncode.mockReturnValue(publicKeyBytes)
     mocks.createKeyPairFromBytes.mockResolvedValue(keyPair)
+    mocks.deriveFromMnemonicAtIndex.mockResolvedValue(derivedAccount)
+    mocks.ellipsify.mockReturnValue('derived-public...')
     mocks.getAddressEncoder.mockReturnValue({ encode: mocks.addressEncode })
     mocks.settingFindUnique.mockResolvedValue({ value: accountId })
+    mocks.walletCreate.mockResolvedValue(walletId)
   })
 
   describe('expected behavior', () => {
+    it('should create a wallet and account with the shared background context', async () => {
+      // ARRANGE
+      expect.assertions(4)
+      const service = registerDbService(backgroundContext)
+      const input = { derivationPath: "m/44'/501'/0'/0'", mnemonic: 'test mnemonic', name: 'Test Wallet' }
+
+      // ACT
+      const result = await service.wallet.createWithAccount(input)
+
+      // ASSERT
+      expect(mocks.accountCreate).toHaveBeenCalledWith(backgroundContext, {
+        ...derivedAccount,
+        name: 'derived-public...',
+        type: 'Derived',
+        walletId,
+      })
+      expect(mocks.deriveFromMnemonicAtIndex).toHaveBeenCalledWith({ mnemonic: input.mnemonic })
+      expect(mocks.walletCreate).toHaveBeenCalledWith(backgroundContext, input)
+      expect(result).toBe(walletId)
+    })
+
     it('should create the active account key pair from the active secret key', async () => {
       // ARRANGE
       expect.assertions(4)


### PR DESCRIPTION
Add regression coverage for wallet.createWithAccount() to assert walletCreate() and accountCreate() receive the shared background context.

Mock the derived-account helpers needed by the background DB service test.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/samui-build/samui-wallet/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with additional mock data and test cases to verify wallet creation functionality and account derivation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/samui-build/samui-wallet/pull/1075)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->